### PR TITLE
New IP-address API

### DIFF
--- a/Sources/WebURL/Model/IPAddress.swift
+++ b/Sources/WebURL/Model/IPAddress.swift
@@ -19,7 +19,7 @@ import Algorithms
 
 /// An object which is informed by the IPv4 parser if a validation error occurs.
 ///
-public protocol IPv4ParserCallback {
+public protocol IPv4AddressParserCallback {
   mutating func validationError(ipv4 error: IPv4Address.ValidationError)
 }
 
@@ -35,7 +35,7 @@ public protocol IPv6AddressParserCallback {
 /// This allows a single object to conform to both `IPv6AddressParserCallback` and `IPv4AddressParserCallback`, while giving IPv4 errors
 /// encountered via the v6 parser a distinct representation from those encountered via the v4 parser.
 ///
-fileprivate struct IPParserCallbackv4Tov6<Base>: IPv4ParserCallback where Base: IPv6AddressParserCallback {
+fileprivate struct IPParserCallbackv4Tov6<Base>: IPv4AddressParserCallback where Base: IPv6AddressParserCallback {
   var v6Handler: UnsafeMutablePointer<Base>
   func validationError(ipv4 error: IPv4Address.ValidationError) {
     v6Handler.pointee.validationError(ipv6: .invalidIPv4Address(error))
@@ -823,7 +823,7 @@ extension IPv4Address {
   ///
   public static func parse<Bytes, Callback>(
     utf8 input: Bytes, callback: inout Callback
-  ) -> ParseResult where Bytes: Collection, Bytes.Element == UInt8, Callback: IPv4ParserCallback {
+  ) -> ParseResult where Bytes: Collection, Bytes.Element == UInt8, Callback: IPv4AddressParserCallback {
     guard input.isEmpty == false else {
       callback.validationError(ipv4: .emptyInput)
       return .failure
@@ -969,7 +969,7 @@ extension IPv4Address {
   ///
   public static func parse_simple<Bytes, Callback>(
     utf8 input: Bytes, callback: inout Callback
-  ) -> Self? where Bytes: Collection, Bytes.Element == UInt8, Callback: IPv4ParserCallback {
+  ) -> Self? where Bytes: Collection, Bytes.Element == UInt8, Callback: IPv4AddressParserCallback {
 
     var numericAddress = UInt32(0)
     var idx = input.startIndex

--- a/Sources/WebURL/Model/ValidationError.swift
+++ b/Sources/WebURL/Model/ValidationError.swift
@@ -20,7 +20,7 @@
 /// Most validation errors are non-fatal and parsing can continue regardless. If parsing fails, the last
 /// validation error typically describes the issue which caused it to fail.
 ///
-public protocol URLParserCallback: IPv6AddressParserCallback, IPv4ParserCallback {
+public protocol URLParserCallback: IPv6AddressParserCallback, IPv4AddressParserCallback {
   mutating func validationError(_ error: ValidationError)
 }
 

--- a/Sources/WebURL/Model/ValidationError.swift
+++ b/Sources/WebURL/Model/ValidationError.swift
@@ -65,13 +65,14 @@ public struct CollectValidationErrors: URLParserCallback {
 
 public struct ValidationError: Equatable {
   private var code: UInt8
-  /* testable */ private(set) var hostParserError: AnyHostParserError? = nil
+  /* testable */ @usableFromInline private(set) var hostParserError: AnyHostParserError? = nil
 
+  @usableFromInline
   enum AnyHostParserError: Equatable, CustomStringConvertible {
     case ipv4AddressError(IPv4Address.ValidationError)
     case ipv6AddressError(IPv6Address.ValidationError)
 
-    var description: String {
+    @usableFromInline var description: String {
       switch self {
       case .ipv4AddressError(let error):
         return error.description

--- a/Sources/WebURL/ParsedHost.swift
+++ b/Sources/WebURL/ParsedHost.swift
@@ -45,7 +45,7 @@ extension ParsedHost {
         callback.validationError(.unclosedIPv6Address)
         return nil
       }
-      guard let result = IPv6Address.parse(ipv6Slice, callback: &callback) else {
+      guard let result = IPv6Address.parse(utf8: ipv6Slice, callback: &callback) else {
         return nil
       }
       self = .ipv6Address(result)

--- a/Sources/WebURL/ParsedHost.swift
+++ b/Sources/WebURL/ParsedHost.swift
@@ -83,7 +83,7 @@ extension ParsedHost {
     let asciiDomain = domain
 
     var ipv4Error = LastValidationError()
-    switch IPv4Address.parse(asciiDomain, callback: &ipv4Error) {
+    switch IPv4Address.parse(utf8: asciiDomain, callback: &ipv4Error) {
     case .success(let address):
       self = .ipv4Address(address)
       return

--- a/Sources/WebURLTestSupport/IPAddressUtils.swift
+++ b/Sources/WebURLTestSupport/IPAddressUtils.swift
@@ -144,7 +144,7 @@ extension IPv6Address.Utils {
   /// At random, a series of 16-bit pieces are set to 0, in order to prompt a compressed serialization format.
   /// There is no bias to produce more addresses in the IPv4 range.
   ///
-  public static func randomAddress() -> IPv6Address.AddressType {
+  public static func randomAddress() -> IPv6Address.UInt16Pieces {
     var rng = SystemRandomNumberGenerator()
     let injectCompression = Bool.random(using: &rng)
     return randomAddress(limitedToIPv4: false, injectCompression: injectCompression, using: &rng)
@@ -161,12 +161,12 @@ extension IPv6Address.Utils {
     limitedToIPv4: Bool,
     injectCompression: Bool,
     using rng: inout RNG
-  ) -> IPv6Address.AddressType {
+  ) -> IPv6Address.UInt16Pieces {
 
     switch limitedToIPv4 {
     case true:
       var randomBytes = (UInt64(0), UInt64.random(in: 0...UInt64(UInt32.max), using: &rng).bigEndian)
-      return withUnsafeBytes(of: &randomBytes) { $0.load(as: IPv6Address.AddressType.self) }
+      return withUnsafeBytes(of: &randomBytes) { $0.load(as: IPv6Address.UInt16Pieces.self) }
 
     case false:
       var randomBytes = (UInt64.random(in: 0 ... .max, using: &rng), UInt64.random(in: 0 ... .max, using: &rng))
@@ -181,7 +181,7 @@ extension IPv6Address.Utils {
             rawPtr[x] = 0
           }
         }
-        return rawPtr.load(as: IPv6Address.AddressType.self)
+        return rawPtr.load(as: IPv6Address.UInt16Pieces.self)
       }
     }
   }
@@ -205,7 +205,7 @@ extension IPv6Address.Utils {
   /// This may be skewed a bit - some generated addresses will already be compressed, regardless of our
   /// randomised toggle to inject compressable pieces.
   ///
-  public static func randomString() -> (IPv6Address.AddressType, String) {
+  public static func randomString() -> (IPv6Address.UInt16Pieces, String) {
     var rng = SystemRandomNumberGenerator()
     let address = randomAddress(
       limitedToIPv4: Bool.random(using: &rng),
@@ -236,7 +236,7 @@ extension IPv6Address.Utils {
   ///
   ///
   public static func randomString<RNG: RandomNumberGenerator>(
-    address: IPv6Address.AddressType,
+    address: IPv6Address.UInt16Pieces,
     allowIPv4Addresses: Bool,
     mayCompress: Bool,
     using rng: inout RNG

--- a/Tests/WebURLTests/IPv6AddressTests.swift
+++ b/Tests/WebURLTests/IPv6AddressTests.swift
@@ -17,6 +17,8 @@ import XCTest
 
 @testable import WebURL
 
+// Helpers.
+
 #if canImport(Glibc)
   import Glibc
 #elseif canImport(Darwin)
@@ -25,126 +27,198 @@ import XCTest
   #error("Unknown libc variant")
 #endif
 
-extension Array where Element == UInt16 {
-  init(fromIPv6Address addr: IPv6Address.AddressType) {
+fileprivate extension Array {
+  
+  init(fromIPv6Octets addr: IPv6Address.Octets) where Element == UInt8 {
+    self = [addr.0, addr.1, addr.2, addr.3, addr.4, addr.5, addr.6, addr.7,
+            addr.8, addr.9, addr.10, addr.11, addr.12, addr.13, addr.14, addr.15]
+  }
+  
+  init(fromIPv6Pieces addr: IPv6Address.UInt16Pieces) where Element == UInt16 {
     self = [addr.0, addr.1, addr.2, addr.3, addr.4, addr.5, addr.6, addr.7]
   }
 }
 
-extension ValidationError {
-  public var ipv6Error: IPv6Address.ValidationError? {
+fileprivate extension ValidationError {
+  var ipv6Error: IPv6Address.ValidationError? {
     guard case .some(.ipv6AddressError(let error)) = self.hostParserError else { return nil }
     return error
   }
 }
 
+fileprivate func pton_octets(_ input: String) -> [UInt8]? {
+  var result = in6_addr()
+  guard inet_pton(AF_INET6, input, &result) != 0 else { return nil }
+  return withUnsafeBytes(of: &result.__u6_addr.__u6_addr8) { ptr in
+    let u16 = ptr.bindMemory(to: UInt8.self)
+    return Array(u16)
+  }
+}
+
+fileprivate func pton_pieces(_ input: String) -> [UInt16]? {
+  var result = in6_addr()
+  guard inet_pton(AF_INET6, input, &result) != 0 else { return nil }
+  return withUnsafeBytes(of: &result.__u6_addr.__u6_addr16) { ptr in
+    let u16 = ptr.bindMemory(to: UInt16.self)
+    return Array(u16)
+  }
+}
+
+fileprivate func ntop_octets(_ input: [UInt8]) -> String? {
+  var src = in6_addr()
+  src.__u6_addr.__u6_addr8.0 = input[0]
+  src.__u6_addr.__u6_addr8.1 = input[1]
+  src.__u6_addr.__u6_addr8.2 = input[2]
+  src.__u6_addr.__u6_addr8.3 = input[3]
+  src.__u6_addr.__u6_addr8.4 = input[4]
+  src.__u6_addr.__u6_addr8.5 = input[5]
+  src.__u6_addr.__u6_addr8.6 = input[6]
+  src.__u6_addr.__u6_addr8.7 = input[7]
+  src.__u6_addr.__u6_addr8.8 = input[8]
+  src.__u6_addr.__u6_addr8.9 = input[9]
+  src.__u6_addr.__u6_addr8.10 = input[10]
+  src.__u6_addr.__u6_addr8.11 = input[11]
+  src.__u6_addr.__u6_addr8.12 = input[12]
+  src.__u6_addr.__u6_addr8.13 = input[13]
+  src.__u6_addr.__u6_addr8.14 = input[14]
+  src.__u6_addr.__u6_addr8.15 = input[15]
+  let str = String(_unsafeUninitializedCapacity: Int(INET6_ADDRSTRLEN)) {
+    return $0.withMemoryRebound(to: CChar.self) {
+      let p = inet_ntop(AF_INET6, &src, $0.baseAddress, socklen_t($0.count))
+      guard p != nil else { return 0 }
+      return strlen($0.baseAddress!)
+    }
+  }
+  return str.isEmpty ? nil : str
+}
+
+fileprivate func ntop_pieces(_ input: [UInt16]) -> String? {
+  var src = in6_addr()
+  src.__u6_addr.__u6_addr16.0 = input[0]
+  src.__u6_addr.__u6_addr16.1 = input[1]
+  src.__u6_addr.__u6_addr16.2 = input[2]
+  src.__u6_addr.__u6_addr16.3 = input[3]
+  src.__u6_addr.__u6_addr16.4 = input[4]
+  src.__u6_addr.__u6_addr16.5 = input[5]
+  src.__u6_addr.__u6_addr16.6 = input[6]
+  src.__u6_addr.__u6_addr16.7 = input[7]
+  let str = String(_unsafeUninitializedCapacity: Int(INET6_ADDRSTRLEN)) {
+    return $0.withMemoryRebound(to: CChar.self) {
+      let p = inet_ntop(AF_INET6, &src, $0.baseAddress, socklen_t($0.count))
+      guard p != nil else { return 0 }
+      return strlen($0.baseAddress!)
+    }
+  }
+  return str.isEmpty ? nil : str
+}
+
+
+// MARK: - Tests
+
+
 final class IPv6AddressTests: XCTestCase {
 
-  fileprivate func parse_pton(_ input: String) -> [UInt16]? {
-    var result = in6_addr()
-    guard inet_pton(AF_INET6, input, &result) != 0 else { return nil }
-    return withUnsafeBytes(of: &result) { ptr in
-      let u16 = ptr.bindMemory(to: UInt16.self)
-      return Array(u16)
-    }
-  }
-
-  fileprivate func serialize_ntop(_ input: [UInt16]) -> String? {
-    var src = in6_addr()
-    src.__u6_addr.__u6_addr16.0 = input[0]
-    src.__u6_addr.__u6_addr16.1 = input[1]
-    src.__u6_addr.__u6_addr16.2 = input[2]
-    src.__u6_addr.__u6_addr16.3 = input[3]
-    src.__u6_addr.__u6_addr16.4 = input[4]
-    src.__u6_addr.__u6_addr16.5 = input[5]
-    src.__u6_addr.__u6_addr16.6 = input[6]
-    src.__u6_addr.__u6_addr16.7 = input[7]
-    let str = String(_unsafeUninitializedCapacity: 40) {
-      return $0.baseAddress!.withMemoryRebound(to: CChar.self, capacity: $0.count) {
-        let p = inet_ntop(AF_INET6, &src, $0, 40)
-        guard p != nil else { return 0 }
-        return strlen($0)
-      }
-    }
-    return str.isEmpty ? nil : str
-  }
-
   func testBasic() {
-    let testData: [(String, [UInt16], String)] = [
+    let testData: [(String, String, [UInt8], [UInt16])] = [
       // Canonical
       (
-        "2001:0db8:85a3:0000:0000:8a2e:0370:7334", [8193, 3512, 34211, 0, 0, 35374, 880, 29492],
-        "2001:db8:85a3::8a2e:370:7334"
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:db8:85a3::8a2e:370:7334",
+        [0x20, 0x01, 0x0d, 0x0b8, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34],
+        [0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334]
       ),
       // Teredo
       (
-        "2001::ce49:7601:e866:efff:62c3:fffe", [8193, 0, 52809, 30209, 59494, 61439, 25283, 65534],
-        "2001:0:ce49:7601:e866:efff:62c3:fffe"
+        "2001::ce49:7601:e866:efff:62c3:fffe", "2001:0:ce49:7601:e866:efff:62c3:fffe",
+        [0x20, 0x01, 0x00, 0x00, 0xce, 0x49, 0x76, 0x01, 0xe8, 0x66, 0xef, 0xff, 0x62, 0xc3, 0xff, 0xfe],
+        [0x2001, 0x0000, 0xce49, 0x7601, 0xe866, 0xefff, 0x62c3, 0xfffe]
       ),
       // Compact
-      ("2608::3:5", [9736, 0, 0, 0, 0, 0, 3, 5], "2608::3:5"),
+      ("2608::3:5", "2608::3:5",
+       [0x26, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x05],
+       [0x2608, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0003, 0x0005]
+      ),
       // Empty
-      ("::", [0, 0, 0, 0, 0, 0, 0, 0], "::"),
+      ("::", "::",
+       [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+       [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000]
+      ),
       // IPv4
-      ("::ffff:192.168.0.1", [0, 0, 0, 0, 0, 65535, 49320, 1], "::ffff:c0a8:1"),
+      ("::ffff:192.168.0.1", "::ffff:c0a8:1",
+       [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01],
+       [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xffff, 0xc0a8, 0x0001]
+      ),
     ]
 
-    for (string, expectedRawAddress, expectedDescription) in testData {
+    for (string, expectedDescription, expectedOctets, expectedNumericPieces) in testData {
       guard let addr = IPv6Address(string) else {
         XCTFail("Failed to parse valid address: \(string)")
         continue
       }
-      XCTAssertEqual(
-        Array(fromIPv6Address: addr.rawAddress), expectedRawAddress,
-        "Raw address mismatch for: \(string)"
-      )
-      XCTAssertEqual(
-        Array(fromIPv6Address: addr.networkAddress), parse_pton(string),
-        "Net address mismatch for: \(string)"
-      )
+      // Octets.
+      XCTAssertEqual(Array(fromIPv6Octets: addr.octets), expectedOctets, "Octet mismatch: \(string)")
+      XCTAssertEqual(Array(fromIPv6Octets: addr.octets), pton_octets(string), "Octet mismatch: \(string)")
+      // Pieces.
+      XCTAssertEqual(Array(fromIPv6Pieces: addr[uint16Pieces: .numeric]), expectedNumericPieces,
+                     "Piece mismatch: \(string)")
+      XCTAssertEqual(Array(fromIPv6Pieces: addr[uint16Pieces: .binary]), pton_pieces(string),
+                     "Piece mismatch: \(string)")
+      // Serialization.
       XCTAssertEqual(addr.serialized, expectedDescription)
+      // Idempotence.
       if let reparsedAddr = IPv6Address(addr.serialized) {
-        XCTAssertEqual(
-          addr, reparsedAddr,
-          "Address failed to round-trip. Original: '\(string)'. Printed: '\(addr.serialized)'"
-        )
+        XCTAssertEqual(Array(fromIPv6Octets: addr.octets), Array(fromIPv6Octets: reparsedAddr.octets),
+                       "Not idempotent. Original: '\(string)'. Printed: '\(addr.serialized)'")
       } else {
-        XCTFail("Address failed to round-trip. Original: '\(string)'. Printed: '\(addr.serialized)'")
+        XCTFail("Not idempotent. Original: '\(string)'. Printed: '\(addr.serialized)'")
       }
     }
   }
-
+  
   func testCompression() {
-    let testData: [(String, [UInt16], String)] = [
+
+    let testData: [(String, String, [UInt8], [UInt16])] = [
       // Leading
-      ("::1234:F088", [0, 0, 0, 0, 0, 0, 4660, 61576], "::1234:f088"),
+      ("::1234:F088", "::1234:f088",
+       [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0xf0, 0x88],
+       [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x1234, 0xf088]
+      ),
+      ("0:0::0:192.168.0.2", "::c0a8:2",
+       [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0xa8, 0x00, 0x02],
+       [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xc0a8, 0x0002]
+      ),
       // Middle
-      ("1212:F0F0::3434:D0D0", [4626, 61680, 0, 0, 0, 0, 13364, 53456], "1212:f0f0::3434:d0d0"),
+      ("1212:F0F0::3434:D0D0", "1212:f0f0::3434:d0d0",
+       [0x12, 0x12, 0xf0, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x34, 0xd0, 0xd0],
+       [0x1212, 0xf0f0, 0x0000, 0x0000, 0x0000, 0x0000, 0x3434, 0xd0d0]
+      ),
       // Trailing
-      ("1234:F088::", [4660, 61576, 0, 0, 0, 0, 0, 0], "1234:f088::"),
+      ("1234:F088::", "1234:f088::",
+       [0x12, 0x34, 0xf0, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+       [0x1234, 0xf088, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000]
+      ),
     ]
 
-    for (string, expectedRawAddress, expectedDescription) in testData {
+    for (string, expectedDescription, expectedOctets, expectedNumericPieces) in testData {
       guard let addr = IPv6Address(string) else {
         XCTFail("Failed to parse valid address: \(string)")
         continue
       }
-      XCTAssertEqual(
-        Array(fromIPv6Address: addr.rawAddress), expectedRawAddress,
-        "Raw address mismatch for: \(string)"
-      )
-      XCTAssertEqual(
-        Array(fromIPv6Address: addr.networkAddress), parse_pton(string),
-        "Net address mismatch for: \(string)"
-      )
+      // Octets.
+      XCTAssertEqual(Array(fromIPv6Octets: addr.octets), expectedOctets, "Octet mismatch: \(string)")
+      XCTAssertEqual(Array(fromIPv6Octets: addr.octets), pton_octets(string), "Octet mismatch: \(string)")
+      // Pieces.
+      XCTAssertEqual(Array(fromIPv6Pieces: addr[uint16Pieces: .numeric]), expectedNumericPieces,
+                     "Piece mismatch: \(string)")
+      XCTAssertEqual(Array(fromIPv6Pieces: addr[uint16Pieces: .binary]), pton_pieces(string),
+                     "Piece mismatch: \(string)")
+      // Serialization.
       XCTAssertEqual(addr.serialized, expectedDescription)
+      // Idempotence.
       if let reparsedAddr = IPv6Address(addr.serialized) {
-        XCTAssertEqual(
-          addr, reparsedAddr,
-          "Address failed to round-trip. Original: '\(string)'. Printed: '\(addr.serialized)'"
-        )
+        XCTAssertEqual(Array(fromIPv6Octets: addr.octets), Array(fromIPv6Octets: reparsedAddr.octets),
+                       "Not idempotent. Original: '\(string)'. Printed: '\(addr.serialized)'")
       } else {
-        XCTFail("Address failed to round-trip. Original: '\(string)'. Printed: '\(addr.serialized)'")
+        XCTFail("Not idempotent. Original: '\(string)'. Printed: '\(addr.serialized)'")
       }
     }
   }
@@ -181,11 +255,13 @@ final class IPv6AddressTests: XCTestCase {
     ]
 
     for (string, expectedError) in invalidAddresses {
-      var callback = LastValidationError()
-      if let addr = IPv6Address.parse(string, callback: &callback) {
-        XCTFail("Invalid address '\(string)' was parsed as '\(addr.rawAddress)' (raw)")
-      } else {
-        XCTAssertEqual(callback.error?.ipv6Error, expectedError, "Unexpected error for invalid address '\(string)'")
+      do {
+      	let addr = try IPv6Address(reportingErrors: string)
+        XCTFail("Invalid address '\(string)' was parsed as '\(addr)")
+      } catch let error as IPv6Address.ValidationError {
+        XCTAssertEqual(error, expectedError, "Unexpected error for invalid address '\(string)'")
+      } catch {
+        XCTFail("Unexpected error type: \(error)")
       }
     }
   }
@@ -200,27 +276,24 @@ extension IPv6AddressTests {
   func testRandom_Serialization() {
     for _ in 0..<1000 {
       let expected = IPv6Address.Utils.randomAddress()
-      let address = IPv6Address(networkAddress: expected)
+      let address = IPv6Address(uint16Pieces: expected, .binary)
       if address.serialized.contains("::") {
-        XCTAssertTrue(Array(fromIPv6Address: expected).longestSubrange(equalTo: 0).length > 0)
+        XCTAssertTrue(Array(fromIPv6Pieces: expected).longestSubrange(equalTo: 0).length > 0)
       }
+      
       // Serialize with libc. It should return the same String.
-      let libcStr = withUnsafePointer(to: expected) { intsPtr in
-        intsPtr.withMemoryRebound(to: UInt16.self, capacity: 8) { addrPtr in
-          return serialize_ntop(Array(UnsafeBufferPointer(start: addrPtr, count: 8)))
-        }
-      }
-      // Exception: if the address <= UInt32.max, libc prints this as an embedded IPv4 address
+      let libcStr = ntop_pieces(Array(fromIPv6Pieces: expected))
+      // Exception: if the address <= UInt32.max, libc may print this as an embedded IPv4 address on some platforms
       // (e.g. it prints "::198.135.80.188", we print "::c687:50bc").
       if libcStr?.contains(".") == true {
-        XCTAssertTrue(expected.0 == 0 && expected.1.bigEndian <= UInt64(UInt32.max))
-        continue
+        XCTAssertTrue(Array(fromIPv6Pieces: expected).dropLast(2).allSatisfy { $0 == 0 })
+      } else {
+        XCTAssertEqual(libcStr, address.serialized)
       }
-      XCTAssertEqual(libcStr, address.serialized)
 
       // Parse our serialized output with libc. It should return the same address.
-      let libcAddr = parse_pton(address.serialized)
-      XCTAssertEqual(libcAddr, Array(fromIPv6Address: address.networkAddress))
+      XCTAssertEqual(pton_octets(address.serialized), Array(fromIPv6Octets: address.octets))
+      XCTAssertEqual(pton_pieces(address.serialized), Array(fromIPv6Pieces: address[uint16Pieces: .binary]))
     }
   }
 
@@ -230,13 +303,14 @@ extension IPv6AddressTests {
   ///
   func testRandom_Parsing() {
     for _ in 0..<1000 {
-      let (randomAddress, randomAddressString) = IPv6Address.Utils.randomString()
+      let (randomPieces, randomAddressString) = IPv6Address.Utils.randomString()
       guard let parsedAddress = IPv6Address(randomAddressString) else {
-        XCTFail("Failed to parse address: \(randomAddressString); expected address: \(randomAddress)")
+        XCTFail("Failed to parse address: \(randomAddressString); expected pieces: \(randomPieces)")
         continue
       }
-      XCTAssertEqual(Array(fromIPv6Address: parsedAddress.networkAddress), Array(fromIPv6Address: randomAddress))
-      XCTAssertEqual(Array(fromIPv6Address: parsedAddress.networkAddress), parse_pton(randomAddressString))
+      XCTAssertEqual(Array(fromIPv6Octets: parsedAddress.octets), pton_octets(randomAddressString))
+      XCTAssertEqual(Array(fromIPv6Pieces: parsedAddress[uint16Pieces: .binary]), Array(fromIPv6Pieces: randomPieces))
+      XCTAssertEqual(Array(fromIPv6Pieces: parsedAddress[uint16Pieces: .binary]), pton_pieces(randomAddressString))
     }
   }
 }

--- a/Tests/WebURLTests/IPv6AddressTests.swift
+++ b/Tests/WebURLTests/IPv6AddressTests.swift
@@ -17,7 +17,9 @@ import XCTest
 
 @testable import WebURL
 
-// Helpers.
+
+// MARK: - Helpers.
+
 
 #if canImport(Glibc)
   import Glibc
@@ -283,9 +285,9 @@ extension IPv6AddressTests {
       
       // Serialize with libc. It should return the same String.
       let libcStr = ntop_pieces(Array(fromIPv6Pieces: expected))
-      // Exception: if the address <= UInt32.max, libc may print this as an embedded IPv4 address on some platforms
-      // (e.g. it prints "::198.135.80.188", we print "::c687:50bc").
       if libcStr?.contains(".") == true {
+        // Exception: if the address <= UInt32.max, libc may print this as an embedded IPv4 address on some platforms
+        // (e.g. it prints "::198.135.80.188", we print "::c687:50bc").
         XCTAssertTrue(Array(fromIPv6Pieces: expected).dropLast(2).allSatisfy { $0 == 0 })
       } else {
         XCTAssertEqual(libcStr, address.serialized)


### PR DESCRIPTION
A new public API which steers users towards octets and away from multi-byte integers.

For the most part IP addresses are opaque - you get them from parsing a string, or from `getaddrinfo`, and you pretty much only care about displaying them or connecting to them, not manipulating their components (although that should also be possible). These types handle parsing and formatting via LosslessStringConvertible, and manipulation (when you want to) via octets.

As for C interop, `in6_addr` is a union which allows you to get/set the value via octets 💪. `in_addr` unfortunately doesn't have a similar feature, so you need to use `.init(value: UInt32, .binary)` or `.subscript(value: UInt32, .binary)` to copy the bits without flipping byte order.