### PR TITLE
Fix memory binding mistakes in IP address serialisation.

### DIFF
--- a/Sources/WebURL/Util/ASCII.swift
+++ b/Sources/WebURL/Util/ASCII.swift
@@ -356,7 +356,7 @@ extension ASCII {
   ///
   /// - returns:  The index one-past-the-end of the resulting text.
   ///
-  static func insertDecimalString(for number: UInt8, into stringBuffer: UnsafeMutableBufferPointer<UInt8>) -> Int {
+  static func insertDecimalString(for number: UInt8, into stringBuffer: UnsafeMutableRawBufferPointer) -> Int {
     var idx = stringBuffer.startIndex
     guard _fastPath(stringBuffer.count >= 3) else { return idx }
 
@@ -382,7 +382,7 @@ extension ASCII {
   ///
   /// - returns:  The index one-past-the-end of the resulting text.
   ///
-  static func insertHexString<B>(for number: B, into stringBuffer: UnsafeMutableBufferPointer<UInt8>) -> Int
+  static func insertHexString<B>(for number: B, into stringBuffer: UnsafeMutableRawBufferPointer) -> Int
   where B: BinaryInteger {
     var idx = stringBuffer.startIndex
     assert(stringBuffer.count >= number.bitWidth / 4)

--- a/Sources/WebURL/Util/TuplePointers.swift
+++ b/Sources/WebURL/Util/TuplePointers.swift
@@ -1,0 +1,88 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension UnsafeRawBufferPointer {
+
+  /// Returns a typed pointer to the memory referenced by this buffer, assuming that the memory is already bound to the specified type.
+  ///
+  /// This is equivalent to calling `UnsafeRawPointer.assumingMemoryBound` on this buffer's base address, and dividing this buffer's
+  /// `count` by the `stride` of the given type. Be sure to do lots of research on the above method before even thinking about using this.
+  ///
+  fileprivate func assumingMemoryBound<T>(to: T.Type) -> UnsafeBufferPointer<T> {
+    guard let base = baseAddress else {
+      return .init(start: nil, count: 0)
+    }
+    // Question: If we 'assumingMemoryBound' the base address, can we just make a buffer with the correct 'count'
+    //           and treat all of it as typed/bound?
+    //
+    // Answer:   Yes. Unlike 'bindMemory', which calls a Builtin function [1] with the pointer address and number of
+    //           elements and communicates to the compiler the entire _region_ of memory being bound,
+    //           'assumingMemoryBound' does nothing [2] - it doesn't call any Builtins, and simply constructs
+    //           a typed pointer from an untyped one.
+    //
+    //           That's what makes it so dangerous: as it doesn't actually communicate anything to the compiler
+    //           about how the memory is being accessed, incorrect use can cause type-based anti-aliasing to miscompile.
+    //           As the name suggests, we assume the compiler already knows - i.e. that the entire region has already
+    //           been bound.
+    //
+    // [1]: https://github.com/apple/swift/blob/a0098c0174199b76473636af50699e21b688110c/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb#L692
+    // [2]: https://github.com/apple/swift/blob/a0098c0174199b76473636af50699e21b688110c/stdlib/public/core/UnsafeRawPointer.swift#L335
+    return .init(start: base.assumingMemoryBound(to: to), count: count / MemoryLayout<T>.stride)
+  }
+}
+
+extension UnsafeMutableRawBufferPointer {
+
+  /// Returns a typed pointer to the memory referenced by this buffer, assuming that the memory is already bound to the specified type.
+  ///
+  /// This is equivalent to calling `UnsafeMutableRawPointer.assumingMemoryBound` on this buffer's base address, and dividing this buffer's
+  /// `count` by the `stride` of the given type. Be sure to do lots of research on the above method before even thinking about using this.
+  ///
+  fileprivate func assumingMemoryBound<T>(to: T.Type) -> UnsafeMutableBufferPointer<T> {
+    guard let base = baseAddress else {
+      return .init(start: nil, count: 0)
+    }
+    return .init(start: base.assumingMemoryBound(to: to), count: count / MemoryLayout<T>.stride)
+  }
+}
+
+// Arity 4:
+
+func withUnsafeMutableBufferPointerToElements<T, Result>(
+  tuple: inout (T, T, T, T), _ body: (inout UnsafeMutableBufferPointer<T>) -> Result
+) -> Result {
+  return withUnsafeMutableBytes(of: &tuple) {
+    var ptr = $0.assumingMemoryBound(to: T.self)
+    return body(&ptr)
+  }
+}
+
+// Arity 8:
+
+func withUnsafeBufferPointerToElements<T, Result>(
+  tuple: (T, T, T, T, T, T, T, T), _ body: (UnsafeBufferPointer<T>) -> Result
+) -> Result {
+  return withUnsafeBytes(of: tuple) {
+    return body($0.assumingMemoryBound(to: T.self))
+  }
+}
+
+func withUnsafeMutableBufferPointerToElements<T, Result>(
+  tuple: inout (T, T, T, T, T, T, T, T), _ body: (inout UnsafeMutableBufferPointer<T>) -> Result
+) -> Result {
+  return withUnsafeMutableBytes(of: &tuple) {
+    var ptr = $0.assumingMemoryBound(to: T.self)
+    return body(&ptr)
+  }
+}

--- a/Tests/WebURLTests/ASCIITests.swift
+++ b/Tests/WebURLTests/ASCIITests.swift
@@ -31,7 +31,7 @@ final class ASCIITests: XCTestCase {
 
   func testASCIIDecimalPrinting() {
     var buf: [UInt8] = [0, 0, 0, 0]
-    buf.withUnsafeMutableBufferPointer { buffer in
+    buf.withUnsafeMutableBytes { buffer in
       for num in (UInt8.min)...(UInt8.max) {
         let bufferContentsEnd = ASCII.insertDecimalString(for: num, into: buffer)
         let asciiContents = Array(buffer[..<bufferContentsEnd])


### PR DESCRIPTION
- Serialisation now writes in to a (mutable) raw buffer, meaning we don't need to bind the tuple of `UInt64`s that are used as makeshift fixed-size arrays to `UInt8`

Additionally, added `withUnsafe(Mutable)BufferPointerToElements` functions to enable (Mutable)Collection access to a tuple. Replaces `bindMemory` in situations where we `assumingMemoryBound` would have been more appropriate, but AMB is a pretty dangerous function even by `Unsafe*` standards, so it is wrapped in a helper function which is easier to check for correctness.

- IPv6 serialisation wants a collection view over the `UInt16` pieces of the address; this is an `assumingMemoryBound` situation.
- Both parsers want a MutableCollection view over a tuple as a fixed-size scratch buffer, but there is no type funkiness going on - again, an `assumingMemoryBound` situation.

Also, renamed some of the tuple variables to be a little bit clearer about how they are used.
