### PR TITLE
Add specialisation/inline attributes for enormous speed increases

### DIFF
--- a/Sources/WebURL/Model/PercentEncoding+Public.swift
+++ b/Sources/WebURL/Model/PercentEncoding+Public.swift
@@ -29,12 +29,16 @@ extension StringProtocol {
   /// ```
   ///
   public var urlEncoded: String {
-    var result = ""
-    result.reserveCapacity(utf8.underestimatedCount)
-    self.utf8.lazy.percentEncoded(using: URLEncodeSet.Component.self).writeBuffered { buffer in
-      result.append(contentsOf: String(decoding: buffer, as: UTF8.self))
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
+    get {
+      var result = ""
+      result.reserveCapacity(utf8.underestimatedCount)
+      self.utf8.lazy.percentEncoded(using: URLEncodeSet.Component.self).writeBuffered { buffer in
+        result.append(contentsOf: String(decoding: buffer, as: UTF8.self))
+      }
+      return result
     }
-    return result
   }
 
   /// Returns a copy of this string that can be used as a component in a `application/x-www-form-urlencoded` string.
@@ -50,12 +54,16 @@ extension StringProtocol {
   /// ```
   ///
   public var urlFormEncoded: String {
-    var result = ""
-    result.reserveCapacity(utf8.underestimatedCount)
-    self.utf8.lazy.percentEncoded(using: URLEncodeSet.FormEncoded.self).writeBuffered { buffer in
-      result.append(contentsOf: String(decoding: buffer, as: UTF8.self))
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
+    get {
+      var result = ""
+      result.reserveCapacity(utf8.underestimatedCount)
+      self.utf8.lazy.percentEncoded(using: URLEncodeSet.FormEncoded.self).writeBuffered { buffer in
+        result.append(contentsOf: String(decoding: buffer, as: UTF8.self))
+      }
+      return result
     }
-    return result
   }
 }
 
@@ -74,7 +82,11 @@ extension StringProtocol {
   /// "%F0%9F%98%8E".urlDecoded // 😎
   /// ```
   public var urlDecoded: String {
-    String(decoding: self.utf8.lazy.percentDecoded, as: UTF8.self)
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
+    get {
+      String(decoding: self.utf8.lazy.percentDecoded, as: UTF8.self)
+    }
   }
 
   /// Returns a copy of this string that has been decoded from `application/x-www-form-urlencoded` format.
@@ -89,9 +101,15 @@ extension StringProtocol {
   /// ```
   ///
   public var urlFormDecoded: String {
-    String(decoding: self.utf8.lazy.percentDecoded(using: URLEncodeSet.FormEncoded.self), as: UTF8.self)
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
+    get {
+      String(decoding: self.utf8.lazy.percentDecoded(using: URLEncodeSet.FormEncoded.self), as: UTF8.self)
+    }
   }
 }
+
+// Note: This is sloooooow, because it doesn't get specialized.
 
 extension LazyCollectionProtocol where Elements: StringProtocol {
 

--- a/Sources/WebURL/Model/WebURL.swift
+++ b/Sources/WebURL/Model/WebURL.swift
@@ -63,10 +63,12 @@ public struct WebURL {
   /// hostnames may be IDNA-encoded, or rewritten in a canonical notation if they are IP addresses, paths may be lexically simplified, etc. This means that the
   /// serialized result may look different to the original contents. These transformations are defined in the URL specification.
   ///
+  @inlinable @inline(__always)
   public init?<S>(_ string: S) where S: StringProtocol, S.UTF8View: BidirectionalCollection {
     self.init(utf8: string.utf8)
   }
 
+  @inlinable @inline(__always)
   init?<C>(utf8 bytes: C) where C: BidirectionalCollection, C.Element == UInt8 {
     guard let url = urlFromBytes(bytes, baseURL: nil) else {
       return nil
@@ -80,10 +82,12 @@ public struct WebURL {
   /// hostnames may be IDNA-encoded, or rewritten in a canonical notation if they are IP addresses, paths may be lexically simplified, etc. This means that the
   /// serialized result may look different to the original contents. These transformations are defined in the URL specification.
   ///
+  @inlinable @inline(__always)
   public func join<S>(_ string: S) -> WebURL? where S: StringProtocol, S.UTF8View: BidirectionalCollection {
     return join(utf8: string.utf8)
   }
 
+  @inlinable @inline(__always)
   func join<C>(utf8 bytes: C) -> WebURL? where C: BidirectionalCollection, C.Element == UInt8 {
     guard let url = urlFromBytes(bytes, baseURL: self) else {
       return nil
@@ -412,6 +416,8 @@ extension WebURL {
   ///
   /// - seealso: `scheme`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setScheme<S>(to newScheme: S) throws where S: StringProtocol {
     try setScheme(utf8: newScheme.utf8)
   }
@@ -420,6 +426,8 @@ extension WebURL {
   ///
   /// - seealso: `username`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setUsername<S>(to newUsername: S?) throws where S: StringProtocol {
     try setUsername(utf8: newUsername?.utf8)
   }
@@ -428,6 +436,8 @@ extension WebURL {
   ///
   /// - seealso: `password`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setPassword<S>(to newPassword: S?) throws where S: StringProtocol {
     try setPassword(utf8: newPassword?.utf8)
   }
@@ -436,6 +446,8 @@ extension WebURL {
   ///
   /// - seealso: `hostname`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setHostname<S>(to newHostname: S?) throws
   where S: StringProtocol, S.UTF8View: BidirectionalCollection {
     try setHostname(utf8: newHostname?.utf8)
@@ -466,6 +478,8 @@ extension WebURL {
   ///
   /// - seealso: `path`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setPath<S>(to newPath: S) throws where S: StringProtocol, S.UTF8View: BidirectionalCollection {
     try setPath(utf8: newPath.utf8)
   }
@@ -474,6 +488,8 @@ extension WebURL {
   ///
   /// - seealso: `query`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setQuery<S>(to newQuery: S?) where S: StringProtocol {
     setQuery(utf8: newQuery?.utf8)
   }
@@ -482,6 +498,8 @@ extension WebURL {
   ///
   /// - seealso: `fragment`
   ///
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public mutating func setFragment<S>(to newFragment: S?) where S: StringProtocol {
     setFragment(utf8: newFragment?.utf8)
   }

--- a/Sources/WebURL/Parser.swift
+++ b/Sources/WebURL/Parser.swift
@@ -38,6 +38,7 @@
 //    the content to freshly-allocated storage. The actual construction process involves performing a dry-run
 //    to calculate the optimal result type and produce an allocation which is correctly sized to hold the result.
 
+@inlinable
 func urlFromBytes<Bytes>(_ inputString: Bytes, baseURL: WebURL?) -> WebURL?
 where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
 
@@ -47,7 +48,9 @@ where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
   } ?? _urlFromBytes_impl(inputString, baseURL: baseURL, callback: &callback)
 }
 
-private func _urlFromBytes_impl<Bytes, Callback>(
+@usableFromInline
+@_specialize(kind:partial,where Callback == IgnoreValidationErrors)
+func _urlFromBytes_impl<Bytes, Callback>(
   _ inputString: Bytes, baseURL: WebURL?, callback: inout Callback
 ) -> WebURL? where Bytes: BidirectionalCollection, Bytes.Element == UInt8, Callback: URLParserCallback {
 

--- a/Sources/WebURL/Util/StringUtils+NonURL.swift
+++ b/Sources/WebURL/Util/StringUtils+NonURL.swift
@@ -78,16 +78,3 @@ private func with32ByteStackBuffer<T>(_ perform: (UnsafeMutableBufferPointer<UIn
     }
   }
 }
-
-extension StringProtocol {
-
-  @inlinable @inline(__always)
-  func _withUTF8<T>(_ body: (UnsafeBufferPointer<UInt8>) throws -> T) rethrows -> T {
-    if var string = self as? String {
-      return try string.withUTF8(body)
-    } else {
-      var substring = self as! Substring
-      return try substring.withUTF8(body)
-    }
-  }
-}


### PR DESCRIPTION
`.urlEncoded` and `.urlDecoded` properties in particular are 98% faster thanks to `@_specialize`.

- Added `@_specialize` to generic WebURL setters which use StringProtocol
- Added inlining to WebURL initializer, only as far as `urlFromBytes`, where `withContiguousStorageIfAvailable` takes over.
- Added inlining to IP Address initializers, only as far as their `parse` functions, where `withContiguousStorageIfAvailable` takes over.