### PR TITLE
Tidy up remaining utils

### DIFF
--- a/Sources/WebURL/Util/Collection+longestRange.swift
+++ b/Sources/WebURL/Util/Collection+longestRange.swift
@@ -25,7 +25,7 @@ extension Collection {
   ///                   as well as how many elements are contained within that range.
   ///
   @inlinable
-  public func longestSubrange(satisfying predicate: (Element) throws -> Bool) rethrows
+  internal func longestSubrange(satisfying predicate: (Element) throws -> Bool) rethrows
     -> (subrange: Range<Index>, length: Int)
   {
     var idx = startIndex
@@ -48,6 +48,8 @@ extension Collection {
     return longest
   }
 }
+
+// Note: This has to be 'public' for WebURLTestSupport :(
 
 extension Collection where Element: Equatable {
 

--- a/Sources/WebURL/Util/Collection+trim.swift
+++ b/Sources/WebURL/Util/Collection+trim.swift
@@ -23,7 +23,7 @@ extension BidirectionalCollection {
   ///    - predicate:  A closure which determines if the element should be omitted from the resulting slice.
   ///
   @inlinable
-  public func trim(where predicate: (Element) throws -> Bool) rethrows -> SubSequence {
+  internal func trim(where predicate: (Element) throws -> Bool) rethrows -> SubSequence {
     var sliceStart = startIndex
     var sliceEnd = endIndex
     // Consume elements from the front.

--- a/Sources/WebURL/Util/Either.swift
+++ b/Sources/WebURL/Util/Either.swift
@@ -22,30 +22,14 @@ internal enum Either<Left, Right> {
 
 extension Either {
 
-  func map<NewLeft, NewRight>(
+  @inlinable
+  internal func map<NewLeft, NewRight>(
     left transformLeft: (Left) -> NewLeft,
     right transformRight: (Right) -> NewRight
   ) -> Either<NewLeft, NewRight> {
     switch self {
-    case .left(let value):
-      return .left(transformLeft(value))
-    case .right(let value):
-      return .right(transformRight(value))
-    }
-  }
-}
-
-extension Either {
-
-  /// Extracts the value held by this container as a tuple.
-  /// Either the `.left` or `.right` element will have a value; the other component will be `Optional.none`.
-  ///
-  var extracted: (left: Left?, right: Right?) {
-    switch self {
-    case .left(let value):
-      return (value, nil)
-    case .right(let value):
-      return (nil, value)
+    case .left(let value): return .left(transformLeft(value))
+    case .right(let value): return .right(transformRight(value))
     }
   }
 }
@@ -54,20 +38,11 @@ extension Either where Left == Right {
 
   /// Returns the value held by this container.
   ///
-  func get() -> Left {
+  @inlinable
+  internal func get() -> Left {
     switch self {
-    case .left(let value):
-      return value
-    case .right(let value):
-      return value
+    case .left(let value): return value
+    case .right(let value): return value
     }
   }
-}
-
-// Standard protocols.
-
-extension Either: Equatable where Left: Equatable, Right: Equatable {
-}
-
-extension Either: Hashable where Left: Hashable, Right: Hashable {
 }


### PR DESCRIPTION
- Make Collection extensions internal (where possible)
- Remove some dead code from Either
- Improvements to documentation comments
- Make everything inlinable
- Remove some redundant header setters in MAB, in favour of having the compiler generate them from the _modify accessors

- Style unification:
-- Add explicit internal
-- Unified subheading style
-- Avoid 'return' for single-expression functions