### PR TITLE
Tidy up URLStorage setters, make inlinable

### DIFF
--- a/Sources/WebURL/IPAddress.swift
+++ b/Sources/WebURL/IPAddress.swift
@@ -443,7 +443,8 @@ extension IPv6Address {
     }
   }
 
-  var serializedDirect: (buffer: (UInt64, UInt64, UInt64, UInt64, UInt64), count: UInt8) {
+  @usableFromInline
+  internal var serializedDirect: (buffer: (UInt64, UInt64, UInt64, UInt64, UInt64), count: UInt8) {
 
     // Maximum length of an IPv6 address = 39 bytes.
     // Note that this differs from libc's INET6_ADDRSTRLEN which is 46 because inet_ntop writes
@@ -972,7 +973,8 @@ extension IPv4Address {
     }
   }
 
-  var serializedDirect: (buffer: (UInt64, UInt64), count: UInt8) {
+  @usableFromInline
+  internal var serializedDirect: (buffer: (UInt64, UInt64), count: UInt8) {
 
     // The maximum length of an IPv4 address in decimal notation ("XXX.XXX.XXX.XXX") is 15 bytes.
     // We write one-too-many separators and chop it off at the end, so 16 bytes are needed.

--- a/Sources/WebURL/Parser/Parser+Host.swift
+++ b/Sources/WebURL/Parser/Parser+Host.swift
@@ -16,7 +16,8 @@
 ///
 /// - seealso: `ParsedURLString`
 ///
-enum ParsedHost: Equatable {
+@usableFromInline
+internal enum ParsedHost: Equatable {
   case domain
   case ipv4Address(IPv4Address)
   case ipv6Address(IPv6Address)
@@ -31,9 +32,10 @@ extension ParsedHost {
   /// Parses the given hostname to determine what kind of host it is, and whether or not it is valid.
   /// The created `ParsedHost` object may then be used to write a normalized/encoded version of the hostname.
   ///
-  init?<Bytes, Callback>(
-    _ hostname: Bytes, schemeKind: WebURL.SchemeKind, callback: inout Callback
-  ) where Bytes: BidirectionalCollection, Bytes.Element == UInt8, Callback: URLParserCallback {
+  @usableFromInline  // TODO: [inlinable]: Make inlinable for specialization
+  internal init?<UTF8Bytes, Callback>(
+    _ hostname: UTF8Bytes, schemeKind: WebURL.SchemeKind, callback: inout Callback
+  ) where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8, Callback: URLParserCallback {
 
     guard hostname.isEmpty == false else {
       self = .empty
@@ -125,9 +127,10 @@ extension ParsedHost {
   /// Writes a normalized hostname using the given `Writer` instance.
   /// `bytes` must be the same collection this `ParsedHost` was created for.
   ///
-  func write<Bytes, Writer>(
-    bytes: Bytes, using writer: inout Writer
-  ) where Bytes: BidirectionalCollection, Bytes.Element == UInt8, Writer: HostnameWriter {
+  @inlinable
+  internal func write<UTF8Bytes, Writer>(
+    bytes: UTF8Bytes, using writer: inout Writer
+  ) where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8, Writer: HostnameWriter {
 
     switch self {
     case .empty:

--- a/Sources/WebURL/Parser/Parser+Path.swift
+++ b/Sources/WebURL/Parser/Parser+Path.swift
@@ -782,7 +782,8 @@ where InputString: BidirectionalCollection, InputString.Element == UInt8, Callba
 
 /// A namespace for functions relating to parsing of path components.
 ///
-enum PathComponentParser<T> where T: Collection, T.Element == UInt8 {
+@usableFromInline
+internal enum PathComponentParser<T> where T: Collection, T.Element == UInt8 {
 
   /// A Windows drive letter is two code points, of which the first is an ASCII alpha and the second is either U+003A (:) or U+007C (|).
   ///
@@ -861,7 +862,8 @@ enum PathComponentParser<T> where T: Collection, T.Element == UInt8 {
 
   /// Returns `true` if the given normalized path requires a path sigil when written to a URL that does not have an authority sigil.
   ///
-  static func doesNormalizedPathRequirePathSigil(_ path: T) -> Bool {
+  @inlinable
+  internal static func doesNormalizedPathRequirePathSigil(_ path: T) -> Bool {
     var iter = path.makeIterator()
     guard iter.next() == ASCII.forwardSlash.codePoint, iter.next() == ASCII.forwardSlash.codePoint else {
       return false

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -391,9 +391,9 @@ extension ParsedURLString.ProcessedMapping {
         )
       assert(pathMetrics.requiredCapacity > 0)
       writer.writePathMetricsHint(pathMetrics)
-      writer.writeHint(.path, needsEscaping: pathMetrics.needsEscaping)
+      writer.writeHint(.path, needsEscaping: pathMetrics.needsPercentEncoding)
 
-      if pathMetrics.requiresSigil && (hasAuthority == false) {
+      if pathMetrics.requiresPathSigil && (hasAuthority == false) {
         writer.writePathSigil()
       }
       writer.writeUnsafePath(
@@ -405,7 +405,7 @@ extension ParsedURLString.ProcessedMapping {
           schemeKind: schemeKind,
           baseURL: info.componentsToCopyFromBase.contains(.path) ? baseURL! : nil,
           absolutePathsCopyWindowsDriveFromBase: info.absolutePathsCopyWindowsDriveFromBase,
-          needsEscaping: pathMetrics.needsEscaping
+          needsPercentEncoding: pathMetrics.needsPercentEncoding
         )
       }
 

--- a/Sources/WebURL/Parser/URLWriter.swift
+++ b/Sources/WebURL/Parser/URLWriter.swift
@@ -459,7 +459,8 @@ struct UnsafePresizedBufferWriter: URLWriter {
 
 /// An interface through which `ParsedHost` writes its contents.
 ///
-protocol HostnameWriter {
+@usableFromInline
+internal protocol HostnameWriter {
 
   /// Writes the bytes provided by `writerFunc`.
   /// The bytes will already be percent-encoded/IDNA-transformed and not include any separators.
@@ -490,18 +491,38 @@ extension URLWriter {
   }
 }
 
-struct HostnameLengthCounter: HostnameWriter {
-  var length: Int = 0
-  mutating func writeHostname<T>(_ writerFunc: ((T) -> Void) -> Void) where T: Collection, T.Element == UInt8 {
+@usableFromInline
+internal struct HostnameLengthCounter: HostnameWriter {
+
+  @usableFromInline
+  internal private(set) var length: Int = 0
+
+  @inlinable
+  internal init() {
+    self.length = 0
+  }
+
+  @inlinable
+  internal mutating func writeHostname<T>(_ writerFunc: ((T) -> Void) -> Void) where T: Collection, T.Element == UInt8 {
     writerFunc { piece in
       length += piece.count
     }
   }
 }
 
-struct UnsafeBufferHostnameWriter: HostnameWriter {
-  var buffer: UnsafeMutableBufferPointer<UInt8>
-  mutating func writeHostname<T>(_ writerFunc: ((T) -> Void) -> Void) where T: Collection, T.Element == UInt8 {
+@usableFromInline
+internal struct UnsafeBufferHostnameWriter: HostnameWriter {
+
+  @usableFromInline
+  internal private(set) var buffer: UnsafeMutableBufferPointer<UInt8>
+
+  @inlinable
+  internal init(buffer: UnsafeMutableBufferPointer<UInt8>) {
+    self.buffer = buffer
+  }
+
+  @inlinable
+  internal mutating func writeHostname<T>(_ writerFunc: ((T) -> Void) -> Void) where T: Collection, T.Element == UInt8 {
     writerFunc { piece in
       let n = buffer.initialize(from: piece).1
       buffer = UnsafeMutableBufferPointer(rebasing: buffer.suffix(from: n))

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -363,6 +363,16 @@ extension LazilyPercentEncodedGroups {
     }
     return didEncode
   }
+
+  /// Returns the total length of the encoded UTF-8 bytes,
+  /// and whether or not any code-units were altered by the `EncodeSet`.
+  ///
+  @inlinable @inline(__always)
+  internal var encodedLength: (count: Int, needsEncoding: Bool) {
+		var count = 0
+    let needsEncoding = write { count += $0.count }
+    return (count, needsEncoding)
+  }
 }
 
 // Eager encoding to String.

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -369,7 +369,7 @@ extension LazilyPercentEncodedGroups {
   ///
   @inlinable @inline(__always)
   internal var encodedLength: (count: Int, needsEncoding: Bool) {
-		var count = 0
+    var count = 0
     let needsEncoding = write { count += $0.count }
     return (count, needsEncoding)
   }

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -877,18 +877,16 @@ extension URLStorage {
       return removeSubrange(existingFragment, newStructure: newStructure)
     }
 
-    var bytesToWrite = 1  // for prefix.
-    let needsEncoding = newBytes.lazy.percentEncodedGroups(as: encodeSet).write { bytesToWrite += $0.count }
-    let subrangeToReplace = oldStructure.rangeForReplacingCodeUnits(of: component)
+    let (newLength, needsEncoding) = newBytes.lazy.percentEncodedGroups(as: encodeSet).encodedLength
+
+    let bytesToWrite = 1 /* prefix char */ + newLength
+    let oldRange = oldStructure.rangeForReplacingCodeUnits(of: component)
+
     var newStructure = oldStructure
     newStructure[keyPath: lengthKey] = bytesToWrite
     adjustStructure(&newStructure)
 
-    return replaceSubrange(
-      subrangeToReplace,
-      withUninitializedSpace: bytesToWrite,
-      newStructure: newStructure
-    ) { dest in
+    return replaceSubrange(oldRange, withUninitializedSpace: bytesToWrite, newStructure: newStructure) { dest in
       dest[0] = prefix.codePoint
       var bytesWritten = 1
       if needsEncoding {

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -23,9 +23,10 @@ extension URLStorage {
   /// Attempts to set the scheme component to the given UTF8-encoded string.
   /// The new value may contain a trailing colon (e.g. `http`, `http:`). Colons are only allowed as the last character of the string.
   ///
-  mutating func setScheme<Input>(
-    to newValue: Input
-  ) -> (AnyURLStorage, URLSetterError?) where Input: Collection, Input.Element == UInt8 {
+  @inlinable
+  internal mutating func setScheme<UTF8Bytes>(
+    to newValue: UTF8Bytes
+  ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
     // Check that the new value is a valid scheme.
     guard let (idx, newSchemeKind) = parseScheme(newValue),
@@ -65,7 +66,7 @@ extension URLStorage {
     withUTF8(of: .port) {
       guard let portBytes = $0 else { return }
       assert(portBytes.count > 1, "invalid URLStructure: port must either be nil or >1 character")
-      if newStructure.schemeKind.isDefaultPortString(portBytes.dropFirst()) {
+      if newStructure.schemeKind.isDefaultPort(utf8: portBytes.dropFirst()) {
         newStructure.portLength = 0
         commands.append(.remove(subrange: oldStructure.rangeForReplacingCodeUnits(of: .port)))
       }

--- a/Sources/WebURL/WebURL+QueryParameters.swift
+++ b/Sources/WebURL/WebURL+QueryParameters.swift
@@ -445,8 +445,9 @@ extension URLStorage {
     let combinedLength: Int
     let needsEscaping: Bool
     (combinedLength, needsEscaping) = keyValuePairs.reduce(into: (0, false)) { info, kvp in
-      let encodeKey = kvp.0.lazy.percentEncodedGroups(as: \.form).write { info.0 += $0.count }
-      let encodeVal = kvp.1.lazy.percentEncodedGroups(as: \.form).write { info.0 += $0.count }
+      let (keyLength, encodeKey) = kvp.0.lazy.percentEncodedGroups(as: \.form).encodedLength
+      let (valLength, encodeVal) = kvp.1.lazy.percentEncodedGroups(as: \.form).encodedLength
+      info.0 += keyLength + valLength
       info.1 = info.1 || encodeKey || encodeVal
     }
     if needsEscaping {

--- a/Tests/WebURLTests/SchemeKindTests.swift
+++ b/Tests/WebURLTests/SchemeKindTests.swift
@@ -63,21 +63,22 @@ final class SchemeKindTests: XCTestCase {
       if let defaultPort = expectedDefaultPort {
         // isDefaultPortString should only return 'true' for the literal port number as an ASCII string.
         let serialized = String(defaultPort)
-        XCTAssertTrue(schemeKind.isDefaultPortString(serialized.utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString((":" + serialized).utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString((serialized + "\n").utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString((serialized + "🦩").utf8))
+        XCTAssertTrue(schemeKind.isDefaultPort(utf8: serialized.utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: (":" + serialized).utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: (serialized + "0").utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: (serialized + "\n").utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: (serialized + "🦩").utf8))
         // Schemes with default ports are special.
         XCTAssertTrue(schemeKind.isSpecial)
       } else {
         // If there is no default port, everything should return 'false'.
-        XCTAssertFalse(schemeKind.isDefaultPortString("80".utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString(":80".utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString(":80\n".utf8))
-        XCTAssertFalse(schemeKind.isDefaultPortString("🦩".utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: "80".utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: ":80".utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: ":80\n".utf8))
+        XCTAssertFalse(schemeKind.isDefaultPort(utf8: "🦩".utf8))
       }
-      XCTAssertFalse(schemeKind.isDefaultPortString("".utf8))
-      XCTAssertFalse(schemeKind.isDefaultPortString("\n".utf8))
+      XCTAssertFalse(schemeKind.isDefaultPort(utf8: "".utf8))
+      XCTAssertFalse(schemeKind.isDefaultPort(utf8: "\n".utf8))
     }
   }
 }


### PR DESCRIPTION
Trying not to get too bogged down with stuff in Parser/ or WebURL APIs for now. Those are next.

Mostly just making things inlinable so that they can be specialized without using `@_specialize` (which, while better than not specializing at all, doesn't seem to work as well as I'd hoped).