### PR TITLE
Parser cleanup (part 1)

### DIFF
--- a/Sources/WebURL/Parser/Parser+StringUtils.swift
+++ b/Sources/WebURL/Parser/Parser+StringUtils.swift
@@ -27,8 +27,10 @@
 ///
 /// https://url.spec.whatwg.org/#url-code-points
 ///
-func hasNonURLCodePoints<CodeUnits>(_ input: CodeUnits, allowPercentSign: Bool = false) -> Bool
-where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
+@inlinable @inline(never)
+internal func hasNonURLCodePoints<UTF8Bytes>(
+  utf8: UTF8Bytes, allowPercentSign: Bool = false
+) -> Bool where UTF8Bytes: Sequence, UTF8Bytes.Element == UInt8 {
 
   // Rather than using UTF8.decode to parse the actual 21-bit unicode codepoint, we can detect
   // the handful of disallowed codepoints while they're still in UTF-8 form.
@@ -36,7 +38,10 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
   // (Note: "?" indicates a "don't care"/"match both" bit)
   //
   // - ASCII values need to be checked, but don't need any fancy decoding.
-  // - (0x80 ..< 0xA0) are the patterns 0xC28? and 0xC29? when encoded, so just 1.5 bytes to match.
+  // - (0x80 ..< 0xA0) are the patterns 0xC28? and 0xC29? when encoded, which is an easy range to detect
+  //   by just ignoring the last 4 bits of the 2nd encoded codepoint.
+  // - Surrogates (0xD800 ... 0xDFFF) run the range (0xD800 ... 0xDFFF) => (0xEDA080 ... 0xEDBFBF) when encoded,
+  //   so we can match them with the bit-pattern 11101101_101?????_10??????.
   // - Non-characters have a relatively simple pattern when encoded:
   //     > A noncharacter is a code point that is in the range U+FDD0 to U+FDEF, inclusive,
   //       or U+FFFE, U+FFFF, U+(0x01 ... 0x10)FFFE, U+(0x01 ... 0x10)FFFF.
@@ -49,15 +54,10 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
   //    - 0xFFFE, 0xFFFF     => 0xEFBFB(E/F) in UTF8            (11101111_10111111_1011111?)
   //    - 0x??FFFE, 0x??FFFF => 0xF??FBFB(E/F) in UTF8 (11110???_10??1111_10111111_1011111?)
   //      (even though there are 2 "?" hex characters, we only have 5 "?" bits because the max codepoint is 10FFFF).
-  //
-  // - Surrogates (0xD800 ... 0xDFFF) are not valid in UTF8 anyway, but they're easy to check for, so why not?
-  //   Better than having them slip through, get percent-escaped or something and encoded in the resulting String.
-  //   They run the range (0xD800 ... 0xDFFF) => (0xEDA080 ... 0xEDBFBF) in UTF8,
-  //   so we can match them with the bit-pattern 11101101_101?????_10??????.
 
-  var input = input.makeIterator()
-  while let byte1 = input.next() {
-    switch (~byte1).leadingZeroBitCount {  // a.k.a leadingNonZeroBitCount.
+  var utf8 = utf8.makeIterator()
+  while let byte1 = utf8.next() {
+    switch (~byte1).leadingZeroBitCount {
     case 0:
       // ASCII.
       if byte1 == 0x25, allowPercentSign {
@@ -73,7 +73,7 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
       }
     case 2:
       // 2-byte sequence.
-      guard let byte2 = input.next() else {
+      guard let byte2 = utf8.next() else {
         return true  // Invalid UTF8.
       }
       let encodedScalar = UInt32(byte1) << 8 | UInt32(byte2)
@@ -84,7 +84,7 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
       }
     case 3:
       // 3-byte sequence.
-      guard let byte2 = input.next(), let byte3 = input.next() else {
+      guard let byte2 = utf8.next(), let byte3 = utf8.next() else {
         return true  // Invalid UTF8.
       }
       let encodedScalar = UInt32(byte1) << 16 | UInt32(byte2) << 8 | UInt32(byte3)
@@ -104,7 +104,7 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
       }
     case 4:
       // 4-byte sequence.
-      guard let byte2 = input.next(), let byte3 = input.next(), let byte4 = input.next() else {
+      guard let byte2 = utf8.next(), let byte3 = utf8.next(), let byte4 = utf8.next() else {
         return true  // Invalid UTF8.
       }
       let encodedScalar = UInt32(byte1) << 24 | UInt32(byte2) << 16 | UInt32(byte3) << 8 | UInt32(byte4)
@@ -122,8 +122,11 @@ where CodeUnits: Sequence, CodeUnits.Element == UInt8 {
 /// Returns `true` if `bytes` begins with two U+002F (/) codepoints.
 /// Otherwise, `false`.
 ///
-func hasDoubleSolidusPrefix<T>(_ bytes: T) -> Bool where T: Collection, T.Element == UInt8 {
-  var it = bytes.makeIterator()
+@inlinable
+internal func hasDoubleSolidusPrefix<UTF8Bytes>(
+  utf8: UTF8Bytes
+) -> Bool where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
+  var it = utf8.makeIterator()
   return it.next() == ASCII.forwardSlash.codePoint && it.next() == ASCII.forwardSlash.codePoint
 }
 
@@ -137,7 +140,8 @@ extension ASCII {
   ///
   /// https://url.spec.whatwg.org/#host-miscellaneous
   ///
-  var isForbiddenHostCodePoint: Bool {
+  @inlinable
+  internal var isForbiddenHostCodePoint: Bool {
     //                 FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210
     let lo: UInt64 = 0b11010100_00000000_10000000_00101001_00000000_00000000_00100110_00000001
     let hi: UInt64 = 0b00000000_00000000_00000000_00000000_01111000_00000000_00000000_00000001

--- a/Sources/WebURL/Parser/Parser+StringUtils.swift
+++ b/Sources/WebURL/Parser/Parser+StringUtils.swift
@@ -130,6 +130,16 @@ internal func hasDoubleSolidusPrefix<UTF8Bytes>(
   return it.next() == ASCII.forwardSlash.codePoint && it.next() == ASCII.forwardSlash.codePoint
 }
 
+@inlinable
+internal var idnaPrefix: StaticString { "xn--" }
+
+@inlinable
+internal func hasIDNAPrefix<UTF8Bytes>(
+  utf8: UTF8Bytes
+) -> Bool where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
+  idnaPrefix.withUTF8Buffer { utf8.starts(with: $0) }
+}
+
 extension ASCII {
 
   /// Returns `true` if this character is a forbidden host code point, otherwise `false`.

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -608,7 +608,7 @@ extension URLScanner {
     // state: "scheme", after a valid scheme has been parsed.
     switch scheme {
     case .file:
-      if !hasDoubleSolidusPrefix(input) {
+      if !hasDoubleSolidusPrefix(utf8: input) {
         callback.validationError(.fileSchemeMissingFollowingSolidus)
       }
       return scanAllFileURLComponents(input, baseURL: baseURL, &mapping, callback: &callback)
@@ -628,7 +628,7 @@ extension URLScanner {
     default:
       // state: "special relative or authority"
       var authority = input
-      if hasDoubleSolidusPrefix(input) {
+      if hasDoubleSolidusPrefix(utf8: input) {
         // state: "special authority slashes"
         authority = authority.dropFirst(2)
       } else {
@@ -1450,7 +1450,7 @@ where Input: Collection, Input.Element == UInt8, Callback: URLParserCallback {
     return
   }
 
-  if hasNonURLCodePoints(input, allowPercentSign: true) {
+  if hasNonURLCodePoints(utf8: input, allowPercentSign: true) {
     callback.validationError(.invalidURLCodePoint)
   }
 

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -336,9 +336,7 @@ extension ParsedURLString.ProcessedMapping {
         writer.writeCredentialsTerminator()
       }
 
-      writer.withHostnameWriter { hostWriter in
-        parsedHost!.write(bytes: inputString[hostname], using: &hostWriter)
-      }
+      parsedHost!.write(bytes: inputString[hostname], using: &writer)
 
       if let port = port, port != schemeKind.defaultPort {
         writer.writePort(port)
@@ -1442,6 +1440,7 @@ func findEndOfHostnamePrefix<Input, Callback>(
 /// - Note: This method considers the percent sign ("%") to be a valid URL code-point.
 /// - Note: This method is a no-op if `callback` is an instance of `IgnoreValidationErrors`.
 ///
+@inlinable
 internal func validateURLCodePointsAndPercentEncoding<Input, Callback>(_ input: Input, callback: inout Callback)
 where Input: Collection, Input.Element == UInt8, Callback: URLParserCallback {
 

--- a/Sources/WebURL/Parser/WebURL+Component.swift
+++ b/Sources/WebURL/Parser/WebURL+Component.swift
@@ -17,7 +17,7 @@ extension WebURL {
   // swift-format-ignore
   /// A value representing a component in a URL.
   ///
-  /// Each component has a unique `rawValue` suitable for bitmasks.
+  /// Each component has a unique bit set on its `rawValue`, making it suitable for use in bit-sets.
   ///
   /// - seealso: `WebURL.ComponentSet`.
   ///
@@ -47,23 +47,29 @@ extension WebURL {
 
   /// An efficient set of `WebURL.Component` values.
   ///
-  struct ComponentSet: Equatable, ExpressibleByArrayLiteral {
-    private var rawValue: UInt8
+  @usableFromInline
+  internal struct ComponentSet: Equatable, ExpressibleByArrayLiteral {
 
-    init(arrayLiteral elements: Component...) {
-      self.rawValue = elements.reduce(into: 0) { $0 |= $1.rawValue }
+    @usableFromInline
+    internal var _rawValue: UInt8
+
+    @inlinable
+    internal init(arrayLiteral elements: Component...) {
+      self._rawValue = elements.reduce(into: 0) { $0 |= $1.rawValue }
     }
 
     /// Inserts a component in to the set.
     ///
-    mutating func insert(_ newMember: Component) {
-      self.rawValue |= newMember.rawValue
+    @inlinable
+    internal mutating func insert(_ newMember: Component) {
+      _rawValue |= newMember.rawValue
     }
 
     /// Whether or not the given component is a member of this set.
     ///
-    func contains(_ member: Component) -> Bool {
-      return (self.rawValue & member.rawValue) != 0
+    @inlinable
+    internal func contains(_ member: Component) -> Bool {
+      return (_rawValue & member.rawValue) != 0
     }
   }
 }

--- a/Sources/WebURL/Util/ASCII.swift
+++ b/Sources/WebURL/Util/ASCII.swift
@@ -244,12 +244,19 @@ extension ASCII {
     }
   }
 
+  /// Whether or not this is an uppercase alpha character (A-Z).
+  ///
+  @inlinable
+  internal var isUppercaseAlpha: Bool {
+    return ASCII.ranges.uppercaseAlpha.contains(self)
+  }
+
   /// Whether or not this is an alpha character (a-z, A-Z).
   ///
   @inlinable
   internal var isAlpha: Bool {
     let uppercased = ASCII(_unchecked: codePoint & 0b11011111)
-    return ASCII.ranges.uppercaseAlpha.contains(uppercased)
+    return uppercased.isUppercaseAlpha
   }
 
   /// Whether or not this is a decimal digit (0-9).

--- a/Sources/WebURL/WebURL+Host.swift
+++ b/Sources/WebURL/WebURL+Host.swift
@@ -52,7 +52,7 @@ extension WebURL {
       return .ipv6Address(address)
     case .empty:
       return .empty
-    case .domain:
+    case .asciiDomain:
       return .domain(hostname)
     case .opaque:
       return .opaque(hostname)

--- a/Tests/WebURLTests/OtherUtilitiesTests.swift
+++ b/Tests/WebURLTests/OtherUtilitiesTests.swift
@@ -27,11 +27,11 @@ extension OtherUtilitiesTests {
     //    U+002E (.), U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+003F (?), U+0040 (@), U+005F (_),
     //    U+007E (~), and code points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and noncharacters.
 
-    XCTAssertFalse(hasNonURLCodePoints("alpha123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha123".utf8))
 
     // ASCII.
     for asciiCharacter in stringWithEveryASCIICharacter {
-      let isDisallowed = hasNonURLCodePoints("alpha\(asciiCharacter)123".utf8)
+      let isDisallowed = hasNonURLCodePoints(utf8: "alpha\(asciiCharacter)123".utf8)
       switch ASCII(asciiCharacter.utf8.first!)! {
       case ASCII.ranges.uppercaseAlpha, ASCII.ranges.lowercaseAlpha,
         ASCII.ranges.digits, .exclamationMark, .dollarSign, .ampersand, .apostrophe,
@@ -44,16 +44,16 @@ extension OtherUtilitiesTests {
       }
     }
     // Disallowed range up to U+00A0.
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0080}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0097}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{009F}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0080}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0097}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{009F}123".utf8))
     // A sample of allowed non-ASCII codepoints.
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{00A0}123".utf8))
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{00F0}123".utf8))
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{00B0D0}123".utf8))
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{01ABC0}123".utf8))
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{06DEF0}123".utf8))
-    XCTAssertFalse(hasNonURLCodePoints("alpha\u{10FFFD}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{00A0}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{00F0}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{00B0D0}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{01ABC0}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{06DEF0}123".utf8))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: "alpha\u{10FFFD}123".utf8))
 
     // Disallowed non-characters.
     func codeUnitsWithScalar(_ scalar: Unicode.Scalar) -> [UInt8] {
@@ -64,51 +64,51 @@ extension OtherUtilitiesTests {
       return codeUnits
     }
     // String doesn't like it when we write some of these.
-    XCTAssertFalse(hasNonURLCodePoints(codeUnitsWithScalar(Unicode.Scalar(0xFDCF)!)))
-    XCTAssertTrue(hasNonURLCodePoints(codeUnitsWithScalar(Unicode.Scalar(0xFDD0)!)))
-    XCTAssertTrue(hasNonURLCodePoints(codeUnitsWithScalar(Unicode.Scalar(0xFDDF)!)))
-    XCTAssertTrue(hasNonURLCodePoints(codeUnitsWithScalar(Unicode.Scalar(0xFDEF)!)))
-    XCTAssertFalse(hasNonURLCodePoints(codeUnitsWithScalar(Unicode.Scalar(0xFDF0)!)))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: codeUnitsWithScalar(Unicode.Scalar(0xFDCF)!)))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: codeUnitsWithScalar(Unicode.Scalar(0xFDD0)!)))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: codeUnitsWithScalar(Unicode.Scalar(0xFDDF)!)))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: codeUnitsWithScalar(Unicode.Scalar(0xFDEF)!)))
+    XCTAssertFalse(hasNonURLCodePoints(utf8: codeUnitsWithScalar(Unicode.Scalar(0xFDF0)!)))
 
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{01FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{01FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{02FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{02FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{03FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{03FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{04FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{04FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{05FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{05FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{06FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{06FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{07FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{07FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{08FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{08FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{09FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{09FFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0AFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0AFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0BFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0BFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0CFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0CFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0DFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0DFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0EFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0EFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0FFFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{0FFFFF}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{10FFFE}123".utf8))
-    XCTAssertTrue(hasNonURLCodePoints("alpha\u{10FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{01FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{01FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{02FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{02FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{03FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{03FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{04FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{04FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{05FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{05FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{06FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{06FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{07FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{07FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{08FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{08FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{09FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{09FFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0AFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0AFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0BFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0BFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0CFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0CFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0DFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0DFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0EFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0EFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0FFFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{0FFFFF}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{10FFFE}123".utf8))
+    XCTAssertTrue(hasNonURLCodePoints(utf8: "alpha\u{10FFFF}123".utf8))
 
     // Surrogates.
-    XCTAssertTrue(hasNonURLCodePoints([0xED, 0xA0, 0x80]))  // D800
-    XCTAssertTrue(hasNonURLCodePoints([0xED, 0xAA, 0xBC]))  // DABC
-    XCTAssertTrue(hasNonURLCodePoints([0xED, 0xBF, 0xBF]))  // DFFF
+    XCTAssertTrue(hasNonURLCodePoints(utf8: [0xED, 0xA0, 0x80]))  // D800
+    XCTAssertTrue(hasNonURLCodePoints(utf8: [0xED, 0xAA, 0xBC]))  // DABC
+    XCTAssertTrue(hasNonURLCodePoints(utf8: [0xED, 0xBF, 0xBF]))  // DFFF
   }
 
   func testForbiddenHostCodePoint() {

--- a/Tests/WebURLTests/WHATWGTests.swift
+++ b/Tests/WebURLTests/WHATWGTests.swift
@@ -57,10 +57,6 @@ extension WHATWGTests {
       370,  // domain2ascii: Hosts and percent-encoding.
       566,  // domain2ascii: IDNA ignored code points in file URLs hosts.
       567,  // domain2ascii: IDNA ignored code points in file URLs hosts.
-
-      // FIXME: This one needs another look. We should not accept any IDNA-encoded domain names, even if they are _already_ encoded.
-
-      570,  // domain2ascii: Empty host after the domain to ASCII.
     ])
 
     harness.runTests(fileContents)

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -30,12 +30,12 @@ extension WebURLTests {
       .appendingPathComponent("additional_constructor_tests.json")
     let fileContents = try JSONDecoder().decode([URLConstructorTest.FileEntry].self, from: try Data(contentsOf: url))
     assert(
-      fileContents.count == 79,
+      fileContents.count == 82,
       "Incorrect number of test cases. If you updated the test list, be sure to update the expected failure indexes"
     )
     var harness = URLConstructorTest.WebURLReportHarness()
     harness.runTests(fileContents)
-    XCTAssert(harness.entriesSeen == 79, "Unexpected number of tests executed.")
+    XCTAssert(harness.entriesSeen == 82, "Unexpected number of tests executed.")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")
 
     // Generate a report file because the XCTest ones really aren't that helpful.

--- a/Tests/WebURLTests/additional_constructor_tests.json
+++ b/Tests/WebURLTests/additional_constructor_tests.json
@@ -861,5 +861,16 @@
     "pathname": "/",
     "search": "",
     "hash": ""
+  },
+  "[HOST]: Domain is ASCII, but a component contains invalid IDNA",
+  {
+    "input": "http://a.b.c.xn--pokxncvks",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://10.0.0.xn--pokxncvks",
+    "base": "about:blank",
+    "failure": true
   }
 ]


### PR DESCRIPTION
First half of the files in `Parser/`. The main parser and path parser are next, then the public WebURL API (+ other tweaks), then that's it :)

Also fixes an issue I already knew about: the host parser wasn't rejecting already-encoded IDNA hostnames. Even though they are ASCII, they need to be decoded and validated as part of a true implementation of the standard (which we don't do yet). These are now properly rejected until we actually have IDNA support.