### PR TITLE
Better documentation

### DIFF
--- a/Sources/WebURL/IPAddress.swift
+++ b/Sources/WebURL/IPAddress.swift
@@ -106,6 +106,7 @@ public struct IPv6Address {
     UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
   )
 
+  /// The octets of this address.
   public var octets: Octets
 
   /// Creates an address with the given octets.
@@ -122,9 +123,11 @@ public struct IPv6Address {
   /// - parameters:
   ///     - pieces:            The integer pieces of the address.
   ///     - octetArrangement:  How the octets in each integer of `pieces` are arranged:
-  ///                            - If `numeric`, the integers are assumed to be in "host byte order", and their octets will be rearranged if necessary.
-  ///                            - If `binary`, the integers are assumed to be in "network byte order", and their octets will be stored in the order
-  ///                              they are in.
+  ///                          <ul>
+  ///                          <li>If `numeric`, the integers are assumed to be in "host byte order", and their octets will be rearranged if necessary.</li>
+  ///                          <li>If `binary`, the integers are assumed to be in "network byte order", and their octets will be stored in the order
+  ///                              they are in.</li>
+  ///                          </ul>
   ///
   @inlinable
   public init(pieces: Pieces, _ octetArrangement: OctetArrangement) {
@@ -137,9 +140,11 @@ public struct IPv6Address {
   /// - seealso: `OctetArrangement`
   /// - parameters:
   ///     - octetArrangement:  How the octets in each integer of `pieces` are arranged:
-  ///                            - If `numeric`, the integers are assumed to be in "host byte order", and their octets will be rearranged if necessary.
-  ///                            - If `binary`, the integers are assumed to be in "network byte order", and their octets will be stored in the order
-  ///                              they are in.
+  ///                          <ul>
+  ///                          <li>If `numeric`, the integers are assumed to be in "host byte order", and their octets will be rearranged if necessary.</li>
+  ///                          <li>If `binary`, the integers are assumed to be in "network byte order", and their octets will be stored in the order
+  ///                              they are in.</li>
+  ///                          </ul>
   ///
   @inlinable
   public subscript(pieces octetArrangement: OctetArrangement) -> Pieces {
@@ -509,6 +514,7 @@ public struct IPv4Address {
 
   public typealias Octets = (UInt8, UInt8, UInt8, UInt8)
 
+  /// The octets of this address.
   public var octets: Octets
 
   /// Creates an address with the given octets.
@@ -522,9 +528,11 @@ public struct IPv4Address {
   /// - parameters:
   ///     - value:             The integer value of the address.
   ///     - octetArrangement:  How the octets of `value` are arranged:
-  ///                            - If `numeric`, the integer is assumed to be in "host byte order", and its octets will be rearranged if necessary.
-  ///                            - If `binary`, the integer is assumed to be in "network byte order", and its octets will be stored in the order
-  ///                              they are in.
+  ///                          <ul>
+  ///                          <li>If `numeric`, the integer is assumed to be in "host byte order", and its octets will be rearranged if necessary.</li>
+  ///                          <li>If `binary`, the integer is assumed to be in "network byte order", and its octets will be stored in the order
+  ///                              they are in.</li>
+  ///                          </ul>
   ///
   public init(value: UInt32, _ octetArrangement: OctetArrangement) {
     self.init()
@@ -536,9 +544,11 @@ public struct IPv4Address {
   /// - seealso: `OctetArrangement`
   /// - parameters:
   ///     - octetArrangement:  How the octets of `value` are arranged:
-  ///                            - If `numeric`, the integer is assumed to be in "host byte order", and its octets will be rearranged if necessary.
-  ///                            - If `binary`, the integer is assumed to be in "network byte order", and its octets will be stored in the order
-  ///                              they are in.
+  ///                          <ul>
+  ///                          <li>If `numeric`, the integer is assumed to be in "host byte order", and its octets will be rearranged if necessary.</li>
+  ///                          <li>If `binary`, the integer is assumed to be in "network byte order", and its octets will be stored in the order
+  ///                              they are in.</li>
+  ///                          </ul>
   ///
   public subscript(value octetArrangement: OctetArrangement) -> UInt32 {
     get {
@@ -621,7 +631,7 @@ extension IPv4Address {
   ///    the address' 3rd and 4th octets respectively.
   ///  - _a.b_, where _a_ defines the address' first octet, and _b_ is interpreted as a 24-bit integer whose bytes define the remaining octets from most to least
   ///    significant.
-  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose octets define the octets of the address in order from most to least significant.
+  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose bytes define the octets of the address in order from most to least significant.
   ///
   /// The numeric parts may be written in decimal, octal (prefixed with a `0`), or hexadecimal (prefixed with `0x`, case-insensitive).
   /// Additionally, a single trailing '.' is permitted (e.g. `a.b.c.d.`).
@@ -651,17 +661,17 @@ extension IPv4Address {
   ///    the address' 3rd and 4th octets respectively.
   ///  - _a.b_, where _a_ defines the address' first octet, and _b_ is interpreted as a 24-bit integer whose bytes define the remaining octets from most to least
   ///    significant.
-  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose octets define the octets of the address in order from most to least significant.
+  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose bytes define the octets of the address in order from most to least significant.
   ///
   /// The numeric parts may be written in decimal, octal (prefixed with a `0`), or hexadecimal (prefixed with `0x`, case-insensitive).
   /// Additionally, a single trailing '.' is permitted (e.g. `a.b.c.d.`).
   ///
   /// Examples:
   /// ```
-  /// IPv4Address("0x7f.0.0.1")!.octets == (0x7f, 0x00, 0x00, 0x01) == "127.0.0.1"
-  /// IPv4Address("10.1.0x12.")!.octets == (0x0a, 0x01, 0x00, 0x12) == "10.1.0.18"
-  /// IPv4Address("0300.0xa80032")!.octets == (0xc0, 0xa8, 0x00, 0x32) == "192.168.0.50"
-  /// IPv4Address("0x8Badf00d")!.octets == (0x8b, 0xad, 0xf0, 0x0d) == "139.173.240.13"
+  /// IPv4Address("0x7f.0.0.1".utf8)!.octets == (0x7f, 0x00, 0x00, 0x01) == "127.0.0.1"
+  /// IPv4Address("10.1.0x12.".utf8)!.octets == (0x0a, 0x01, 0x00, 0x12) == "10.1.0.18"
+  /// IPv4Address("0300.0xa80032".utf8)!.octets == (0xc0, 0xa8, 0x00, 0x32) == "192.168.0.50"
+  /// IPv4Address("0x8Badf00d".utf8)!.octets == (0x8b, 0xad, 0xf0, 0x0d) == "139.173.240.13"
   /// ```
   ///
   /// - parameters:
@@ -678,6 +688,9 @@ extension IPv4Address {
 
 extension IPv4Address {
 
+  /// A tri-state result which captures whether an IPv4 address failed to parse because it was invalid,
+  /// or whether it failed because the given string does not look like an IP address.
+  ///
   public enum ParserResult {
 
     /// The string was successfully parsed as an IPv4 address.
@@ -688,7 +701,7 @@ extension IPv4Address {
     ///
     case failure
 
-    /// The string cannot be recognized as an IPv4 address. This is not the same as being invalid - for example, the string "9999999999.com" fails
+    /// The string cannot be recognized as an IPv4 address. This is not the same as being an invalid IP address - for example, the string "9999999999.com" fails
     /// to parse because the non-numeric characters "com" mean it isn't even an IP address string, whereas the string "9999999999" _is_ a properly-formatted
     /// IP address string, but fails to parse because the value would overflow.
     ///
@@ -708,7 +721,7 @@ extension IPv4Address {
   ///    the address' 3rd and 4th octets respectively.
   ///  - _a.b_, where _a_ defines the address' first octet, and _b_ is interpreted as a 24-bit integer whose bytes define the remaining octets from most to least
   ///    significant.
-  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose octets define the octets of the address in order from most to least significant.
+  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose bytes define the octets of the address in order from most to least significant.
   ///
   /// The numeric parts may be written in decimal, octal (prefixed with a `0`), or hexadecimal (prefixed with `0x`, case-insensitive).
   /// Additionally, a single trailing '.' is permitted (e.g. `a.b.c.d.`).

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -157,23 +157,23 @@ extension LazyCollectionProtocol where Element == UInt8 {
   }
 }
 
-/// A `Collection` which lazily percent-encodes some given `Source` UTF8 code-units with a given `EncodeSet`.
-/// This collection only adds percent-encoding or substitutions; it does not decode any pre-existing percent-encoded or substituted bytes in the `Source`.
+/// A `Collection` which lazily percent-encodes its `Source` UTF8 code-units using a given `EncodeSet`.
+/// This collection only _adds_ percent-encoding or substitutions; it does not decode any pre-existing percent-encoded or substituted code-points in `Source`.
 ///
-/// Percent encoding transforms arbitrary Unicode strings to a limited set of ASCII characters which the `EncodeSet` permits.
+/// Percent encoding transforms arbitrary Unicode strings to a limited set of ASCII code-points which are permitted by the `EncodeSet`.
 /// If the `EncodeSet` performs substitutions, users should take care to decode the contents using the same `EncodeSet`.
 ///
 public typealias LazilyPercentEncodedUTF8<Source, EncodeSet> =
   FlattenSequence<LazilyPercentEncodedGroups<Source, EncodeSet>>
 where Source: Collection, Source.Element == UInt8, EncodeSet: PercentEncodeSetProtocol
 
-/// A `Collection` which lazily percent-encodes some given `Source` UTF8 code-units with a given `EncodeSet`.
-/// This collection only adds percent-encoding or substitutions; it does not decode any pre-existing percent-encoded or substituted bytes in the `Source`.
+/// A `Collection` which lazily percent-encodes its `Source` UTF8 code-units using a given `EncodeSet`.
+/// This collection only _adds_ percent-encoding or substitutions; it does not decode any pre-existing percent-encoded or substituted code-points in `Source`.
 ///
-/// The elements of this collection are `_PercentEncodedByte`s, themselves collections of 1 or 3 ASCII codepoints depending on how the source
-/// byte must be encoded. The overall, encoded UTF8 code-unit sequence is obtained by flattening this collection's elements.
+/// The elements of this collection are `_PercentEncodedByte`s, which are small clusters of either 1 or 3 ASCII code-points depending on how the source
+/// code-unit must be encoded. The overall, encoded ASCII string is obtained by flattening this 2-dimensional collection.
 ///
-/// Percent encoding transforms arbitrary Unicode strings to a limited set of ASCII characters which the `EncodeSet` permits.
+/// Percent encoding transforms arbitrary Unicode strings to a limited set of ASCII code-points which are permitted by the `EncodeSet`.
 /// If the `EncodeSet` performs substitutions, users should take care to decode the contents using the same `EncodeSet`.
 ///
 public struct LazilyPercentEncodedGroups<Source, EncodeSet>: Collection, LazyCollectionProtocol
@@ -408,7 +408,7 @@ extension LazilyPercentEncodedGroups {
 
 extension Collection where Element == UInt8 {
 
-  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them with the given `EncodeSet`.
+  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them using the given `EncodeSet`.
   ///
   /// - seealso: `StringProtocol.percentEncoded(as:)`
   ///
@@ -421,7 +421,7 @@ extension Collection where Element == UInt8 {
     } ?? String(decoding: self.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
   }
 
-  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them with the `\.component` encoding-set.
+  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them using the `\.component` encoding-set.
   ///
   /// - seealso: `StringProtocol.urlComponentEncoded`
   ///
@@ -430,7 +430,7 @@ extension Collection where Element == UInt8 {
     percentEncodedString(as: \.component)
   }
 
-  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them with the
+  /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them using the
   /// `application/x-www-form-urlencoded` (`\.form`) encoding-set.
   ///
   /// - seealso: `StringProtocol.urlFormEncoded`
@@ -443,12 +443,12 @@ extension Collection where Element == UInt8 {
 
 extension StringProtocol {
 
-  /// Returns a copy of this string, encoded with the given `EncodeSet`.
+  /// Returns a copy of this string, encoded using the given `EncodeSet`.
   ///
-  /// This function only adds percent-encoding or substitutions as required by `EncodeSet`; it does not decode any percent-encoded or substituted characters
-  /// already contained by the string.
+  /// This function only _adds_ percent-encoding or substitutions as required by `EncodeSet`; it does not decode any percent-encoded or substituted characters
+  /// already contained in the string.
   ///
-  /// Percent encoding transforms strings containing arbitrary Unicode characters to ones containing a limited set of ASCII characters permitted by
+  /// Percent-encoding transforms strings containing arbitrary Unicode characters to ones containing a limited set of ASCII code-points permitted by
   /// the `EncodeSet`. If the `EncodeSet` performs substitutions, users should take care to decode the contents using the same `EncodeSet`.
   ///
   /// ```swift
@@ -465,12 +465,13 @@ extension StringProtocol {
     utf8.percentEncodedString(as: encodeSet)
   }
 
-  /// Returns a copy of this string, encoded with the `\.component` encoding-set.
+  /// Returns a copy of this string, encoded using the `\.component` encoding-set.
   ///
   /// The `\.component` encoding-set is suitable for encoding strings so they may be embedded in a URL's `path`, `query`, `fragment`,
-  /// or in the names of opaque `host`s. It does not include substitutions.
+  /// or in the names of opaque `host`s. It does not perform substitutions.
   ///
-  /// The URL standard confirms that encoding a string with the `\.component` set gives identical results to JavaScript's `encodeURIComponent()` function.
+  /// The URL standard confirms that encoding a string using the `\.component` set gives identical results
+  /// to JavaScript's `encodeURIComponent()` function.
   ///
   /// ```swift
   /// "hello, world!".urlComponentEncoded // hello%2C%20world!
@@ -483,7 +484,7 @@ extension StringProtocol {
     utf8.urlComponentEncodedString
   }
 
-  /// Returns a copy of this string, encoded with the `application/x-www-form-urlencoded` (`\.form`) encoding-set.
+  /// Returns a copy of this string, encoded using the `application/x-www-form-urlencoded` (`\.form`) encoding-set.
   ///
   /// To create an `application/x-www-form-urlencoded` key-value pair string from a collection of keys and values, encode each key and value, and join
   /// the results using the format: `encoded-key-1=encoded-value-1&encoded-key-2=encoded-value-2...`. For example:
@@ -495,8 +496,8 @@ extension StringProtocol {
   /// print(form) // favourite+pet=%F0%9F%A6%86%2C+of+course&favourite+foods=%F0%9F%8D%8E+%26+%F0%9F%8D%A6
   /// ```
   ///
-  /// This encoding-set includes substitutions. Users should take care to also decode the resulting strings using the `application/x-www-form-urlencoded`
-  /// encoding-set.
+  /// This encoding-set performs substitutions. Users should take care to also decode the resulting strings using the `application/x-www-form-urlencoded`
+  /// decoding-set.
   ///
   @inlinable
   public var urlFormEncoded: String {
@@ -512,8 +513,9 @@ extension StringProtocol {
 
 extension LazyCollectionProtocol where Element == UInt8 {
 
-  /// Interprets this collection's elements as UTF8 code-units, and returns a collection of UTF8 code-units whose elements are formed lazily,
-  /// by decoding all percent-encoded code-unit sequences, and using `EncodeSet` to restore other code-units which may have been substituted.
+  /// Interprets this collection's elements as UTF-8 code-units, and returns a collection of bytes whose elements are computed lazily
+  /// by decoding all percent-encoded code-unit sequences and using `EncodeSet` to restore substituted code-units.
+  ///
   /// If no code-points were substituted when this collection's contents were encoded, `\.percentEncodedOnly` may be used to only remove percent-encoding.
   ///
   /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
@@ -528,12 +530,12 @@ extension LazyCollectionProtocol where Element == UInt8 {
     LazilyPercentDecodedUTF8(source: elements)
   }
 
-  /// Interprets this collection's elements as UTF8 code-units, and returns a collection of UTF8 code-units whose elements are formed lazily,
+  /// Interprets this collection's elements as UTF-8 code-units, and returns a collection of bytes whose elements are computed lazily
   /// by decoding all percent-encoded code-unit sequences.
   ///
   /// This is equivalent to calling `percentDecodedUTF8(from: \.percentEncodedOnly)`. If this collection's contents were encoded
-  /// with substitutions (e.g. `application/x-www-form-urlencoded`), use `percentDecodedUTF8(from:)` instead,
-  /// providing a `PercentDecodeSet` which is able to reverse those substitutions.
+  /// with substitutions (e.g. using form-encoding), use `percentDecodedUTF8(from:)` instead, providing a `PercentDecodeSet` which is able
+  /// to reverse those substitutions.
   ///
   /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
   ///              (e.g. extra path components which lead to sensitive data when used as a relative path, ASCII NULL bytes, or SQL injection),
@@ -546,10 +548,10 @@ extension LazyCollectionProtocol where Element == UInt8 {
   }
 }
 
-/// A `Collection` which lazily replaces all percent-encoded UTF8 code-units from a `Source` collection with their decoded code-units.
+/// A `Collection` which lazily replaces all percent-encoded UTF8 code-units from its `Source` with their decoded code-units.
 /// It does not reverse any substitutions that may be a part of how `Source` is encoded.
 ///
-/// Percent decoding transforms certain ASCII sequences to arbitrary byte values ("%AB" to the byte value 0xAB).
+/// Percent decoding transforms certain sequences of ASCII code-points to arbitrary byte values ("%AB" to the byte 0xAB).
 ///
 /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
 ///              (e.g. extra path components which lead to sensitive data when used as a relative path, ASCII NULL bytes, or SQL injection),
@@ -559,10 +561,10 @@ extension LazyCollectionProtocol where Element == UInt8 {
 public typealias LazilyPercentDecodedUTF8WithoutSubstitutions<Source> =
   LazilyPercentDecodedUTF8<Source, PercentEncodeSet._Passthrough> where Source: Collection, Source.Element == UInt8
 
-/// A `Collection` which lazily replaces all percent-encoded encoded UTF8 code-units from a `Source` collection with their decoded code-units,
+/// A `Collection` which lazily replaces all percent-encoded UTF8 code-units from its `Source` with their decoded code-units,
 /// and reverses substitutions of other code-units performed by `EncodeSet`.
 ///
-/// If the encode-set does not perform substitutions, `PercentEncodeSet._Passthrough` can be used to remove percent-encoding only.
+/// If the encode-set does not perform substitutions, `PercentEncodeSet._Passthrough` can be used to only remove percent-encoding.
 ///
 /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
 ///              (e.g. extra path components which lead to sensitive data when used as a relative path, ASCII NULL bytes, or SQL injection),
@@ -686,9 +688,10 @@ where Source: Collection, Source.Element == UInt8, EncodeSet: PercentEncodeSetPr
 
 extension Collection where Element == UInt8 {
 
-  /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences, and
-  /// using `EncodeSet` to restore other code-units which may have been substituted. If no code-points were substituted when this collection's contents were
-  /// encoded, `\.percentEncodedOnly` may be used to only remove percent-encoding.
+  /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences and
+  /// using `EncodeSet` to restore substituted code-units.
+  ///
+  /// If no code-points were substituted when this collection's contents were encoded, `\.percentEncodedOnly` may be used to only remove percent-encoding.
   ///
   /// - seealso: `StringProtocol.percentDecoded(from:)`
   /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
@@ -708,8 +711,8 @@ extension Collection where Element == UInt8 {
   /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences.
   ///
   /// This is equivalent to calling `percentDecodedString(from: \.percentEncodedOnly)`. If this collection's contents were encoded
-  /// with substitutions (e.g. `application/x-www-form-urlencoded`), use `percentDecodedString(from:)` instead,
-  /// providing a `PercentDecodeSet` which is able to reverse those substitutions.
+  /// with substitutions (e.g. form-encoding), use `percentDecodedString(from:)` instead, providing a `PercentDecodeSet` which is able to
+  /// reverse those substitutions.
   ///
   /// - seealso: `StringProtocol.percentDecoded`
   /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
@@ -722,8 +725,9 @@ extension Collection where Element == UInt8 {
     percentDecodedString(from: \.percentEncodedOnly)
   }
 
-  /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences, and
+  /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences and
   /// reversing substitutions made by the `application/x-www-form-urlencoded` encode-set.
+  ///
   /// This is equivalent to callling `percentDecodedString(from: \.form)`.
   ///
   /// - seealso: `StringProtocol.urlFormDecoded`
@@ -740,9 +744,9 @@ extension Collection where Element == UInt8 {
 
 extension StringProtocol {
 
-  /// Returns a string formed by decoding all percent-encoded code-units in this string's contents, and using `EncodeSet` to restore other code-units
-  /// which may have been substituted. If no code-points were substituted when this string was encoded, `\.percentEncodingOnly` may be used to
-  /// only remove percent-encoding.
+  /// Returns a string formed by decoding all percent-encoded code-units in this string, and using `EncodeSet` to restore substituted code-units.
+  ///
+  /// If no code-points were substituted when this string was encoded, `\.percentEncodingOnly` may be used to only remove percent-encoding.
   ///
   /// ```swift
   /// "hello,%20world!".percentDecoded(from: \.percentEncodingOnly) // "hello, world!"
@@ -763,7 +767,6 @@ extension StringProtocol {
   }
 
   /// Returns a string formed by decoding all percent-encoded code-units in the contents of this string.
-  /// Equivalent to JavaScript's `decodeURIComponent()` function.
   ///
   /// ```swift
   /// "hello%2C%20world!".percentDecoded // hello, world!
@@ -772,8 +775,10 @@ extension StringProtocol {
   /// ```
   ///
   /// This is equivalent to calling `percentDecodedString(from: \.percentEncodedOnly)`. If this collection's contents were encoded
-  /// with substitutions (e.g. `application/x-www-form-urlencoded`), use `percentDecoded(from:)` instead,
-  /// providing a `PercentDecodeSet` which is able to reverse those substitutions.
+  /// with substitutions (e.g. form-encoding), use `percentDecoded(from:)` instead, providing a `PercentDecodeSet` which is able to
+  /// reverse those substitutions.
+  ///
+  /// Equivalent to JavaScript's `decodeURIComponent()` function.
   ///
   /// - important: Users should beware that percent-encoding has frequently been used by attackers to smuggle malicious inputs
   ///              (e.g. extra path components which lead to sensitive data when used as a relative path, ASCII NULL bytes, or SQL injection),
@@ -785,8 +790,10 @@ extension StringProtocol {
     utf8.percentDecodedString
   }
 
-  /// Returns a string formed by decoding all percent-encoded code-units in this string's contents, and reversing substitutions made by
-  /// the `application/x-www-form-urlencoded` encode-set. This is equivalent to callling `percentDecoded(from: \.form)`.
+  /// Returns a string formed by decoding all percent-encoded code-units in this string and reversing substitutions made by
+  /// the `application/x-www-form-urlencoded` encode-set.
+  ///
+  /// This is equivalent to callling `percentDecoded(from: \.form)`.
   ///
   /// The following example decodes a form-encoded URL query by splitting a string in to key-value pairs at the "&" character, splitting the key from the value
   /// at the "=" character, and decoding each key and value from its encoded representation:
@@ -815,56 +822,75 @@ extension StringProtocol {
 // --------------------------------------------
 
 
+/// A namespace for percent-decode sets.
+///
+/// Decoding is thankfully much simpler than encoding; in almost all cases, simply removing percent-encoding is sufficient, as regular URL encode-sets do
+/// not substitute characters. Form-encoding is the only exception specified in the URL Standard.
+///
+/// Since percent-decode sets are not stateful, you only ever need to refer to their type, never an instance. The types are exposed as properties so you
+/// can use a convenient KeyPath syntax to refer to them.
+///
 public enum PercentDecodeSet {
 
-  public var percentEncodedOnly: PercentEncodeSet._Passthrough.Type { fatalError() }
-  public var form: PercentEncodeSet.FormEncoded.Type { fatalError() }
-}
-
-public enum PercentEncodeSet {
-
-  /// The [C0 control](https://url.spec.whatwg.org/#c0-control-percent-encode-set) percent-encode set.
+  /// A decoding set which only decodes percent-encoded characters and assumes that no substituted characters need to be restored.
   ///
-  public var c0Control: C0Control.Type { fatalError("Do not call") }
-
-  /// The [fragment](https://url.spec.whatwg.org/#fragment-percent-encode-set) percent-encode set.
-  ///
-  public var fragment: Fragment.Type { fatalError("Do not call") }
-
-  /// The [query](https://url.spec.whatwg.org/#query-percent-encode-set) percent-encode set.
-  ///
-  public var query_notSpecial: Query_NotSpecial.Type { fatalError("Do not call") }
-
-  /// The [special query](https://url.spec.whatwg.org/#special-query-percent-encode-set) percent-encode set.
-  ///
-  public var query_special: Query_Special.Type { fatalError("Do not call") }
-
-  /// The [path](https://url.spec.whatwg.org/#path-percent-encode-set) percent-encode set.
-  ///
-  public var path: Path.Type { fatalError("Do not call") }
-
-  /// The [userinfo](https://url.spec.whatwg.org/#userinfo-percent-encode-set) percent-encode set.
-  ///
-  public var userInfo: UserInfo.Type { fatalError("Do not call") }
-
-  /// The [component](https://url.spec.whatwg.org/#component-percent-encode-set) percent-encode set.
-  ///
-  public var component: Component.Type { fatalError("Do not call") }
+  public var percentEncodedOnly: PercentEncodeSet._Passthrough.Type { PercentEncodeSet._Passthrough.self }
 
   /// The [application/x-www-form-urlencoded](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set)
   /// percent-encode set.
   ///
-  public var form: FormEncoded.Type { fatalError("Do not call") }
+  public var form: PercentEncodeSet.FormEncoded.Type { PercentEncodeSet.FormEncoded.self }
+}
+
+/// A namespace for percent-encode sets.
+///
+/// Since percent-encode sets are not stateful, you only ever need to refer to their type, never an instance. The types are exposed as properties so you
+/// can use a convenient KeyPath syntax to refer to them.
+///
+public enum PercentEncodeSet {
+
+  /// The [C0 control](https://url.spec.whatwg.org/#c0-control-percent-encode-set) percent-encode set.
+  ///
+  public var c0Control: C0Control.Type { C0Control.self }
+
+  /// The [fragment](https://url.spec.whatwg.org/#fragment-percent-encode-set) percent-encode set.
+  ///
+  public var fragment: Fragment.Type { Fragment.self }
+
+  /// The [query](https://url.spec.whatwg.org/#query-percent-encode-set) percent-encode set.
+  ///
+  public var query_notSpecial: Query_NotSpecial.Type { Query_NotSpecial.self }
+
+  /// The [special query](https://url.spec.whatwg.org/#special-query-percent-encode-set) percent-encode set.
+  ///
+  public var query_special: Query_Special.Type { Query_Special.self }
+
+  /// The [path](https://url.spec.whatwg.org/#path-percent-encode-set) percent-encode set.
+  ///
+  public var path: Path.Type { Path.self }
+
+  /// The [userinfo](https://url.spec.whatwg.org/#userinfo-percent-encode-set) percent-encode set.
+  ///
+  public var userInfo: UserInfo.Type { UserInfo.self }
+
+  /// The [component](https://url.spec.whatwg.org/#component-percent-encode-set) percent-encode set.
+  ///
+  public var component: Component.Type { Component.self }
+
+  /// The [application/x-www-form-urlencoded](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set)
+  /// percent-encode set.
+  ///
+  public var form: FormEncoded.Type { FormEncoded.self }
 
   /// An internal percent-encode set for manipulating path components.
   ///
   @usableFromInline
-  internal var pathComponent: _PathComponent.Type { fatalError("Do not call") }
+  internal var pathComponent: _PathComponent.Type { _PathComponent.self }
 
   /// An internal percent-encode set for when content is already known to be correctly percent-encoded.
   ///
   @usableFromInline
-  internal var alreadyEncoded: _Passthrough.Type { fatalError("Do not call") }
+  internal var alreadyEncoded: _Passthrough.Type { _Passthrough.self }
 }
 
 // URL encode-set implementations.

--- a/Sources/WebURLTestSupport/URLValues.swift
+++ b/Sources/WebURLTestSupport/URLValues.swift
@@ -115,7 +115,7 @@ extension WebURL.JSModel {
       href: href, origin: origin, protocol: scheme,
       username: username, password: password,
       host: host, hostname: hostname, port: port,
-      pathname: pathname, search: search, hash: fragment
+      pathname: pathname, search: search, hash: hash
     )
   }
 }

--- a/Sources/WebURLTestSupport/WPTSetterTest+WebURLReportHarness.swift
+++ b/Sources/WebURLTestSupport/WPTSetterTest+WebURLReportHarness.swift
@@ -53,7 +53,7 @@ extension WPTSetterTest.WebURLReportHarness: WPTSetterTest.Harness {
     case .search:
       url.search = newValue
     case .hash:
-      url.fragment = newValue
+      url.hash = newValue
     case .origin:
       assertionFailure("The URL Standard does not allow setting the origin directly")
     case .host:

--- a/Tests/WebURLTests/PathComponentsTests.swift
+++ b/Tests/WebURLTests/PathComponentsTests.swift
@@ -29,38 +29,34 @@ extension PathComponentsTests {
 
   func testPathComponents_documentationExamples() {
 
-    // WebURL.pathComponents property.
+    // WebURL.PathComponents type.
     do {
-      let url = WebURL("http://example.com/swift/packages/swift-url")!
-      XCTAssertEqualElements(url.pathComponents, ["swift", "packages", "swift-url"])
-      XCTAssertEqual(url.pathComponents.last, "swift-url")
-      XCTAssertEqual(url.pathComponents.dropLast().last, "packages")
+      var url = WebURL("http://example.com/swift/packages/%F0%9F%A6%86%20tracker")!
+      XCTAssertEqual(url.pathComponents.first, "swift")
+      XCTAssertEqual(url.pathComponents.last, "🦆 tracker")
+
+      url.pathComponents.removeLast()
+      url.pathComponents.append("swift-url")
+      XCTAssertEqual(url.serialized, "http://example.com/swift/packages/swift-url")
     }
     do {
-      var url = WebURL("http://example.com/")!
-      XCTAssertEqual(url.pathComponents.last!, "")
+      var url = WebURL("file:///")!
+      XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      url.pathComponents.append("swift")
-      XCTAssertEqual(url.serialized, "http://example.com/swift")
+      url.pathComponents.append("usr")
+      XCTAssertEqual(url.serialized, "file:///usr")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      url.pathComponents.append(contentsOf: ["packages", "swift-url"])
-      XCTAssertEqual(url.serialized, "http://example.com/swift/packages/swift-url")
+      url.pathComponents += ["bin", "swift"]
+      XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
+      XCTAssertEqual(url.pathComponents.last, "swift")
       XCTAssertEqual(url.pathComponents.count, 3)
 
       url.pathComponents.ensureDirectoryPath()
-      XCTAssertEqual(url.serialized, "http://example.com/swift/packages/swift-url/")
-      XCTAssertEqual(url.pathComponents.last!, "")
-      XCTAssertEqual(url.pathComponents.count, 4)
-    }
-    // TODO: Where is this?
-    do {
-      let url = WebURL("http://example.com/swift/packages/🦆/")!
-      XCTAssertEqualElements(url.pathComponents, ["swift", "packages", "🦆", ""])
-      XCTAssertEqual(url.pathComponents.count, 4)
+      XCTAssertEqual(url.serialized, "file:///usr/bin/swift/")
       XCTAssertEqual(url.pathComponents.last, "")
-      XCTAssertEqual(url.pathComponents.dropLast().last, "🦆")
+      XCTAssertEqual(url.pathComponents.count, 4)
     }
     // WebURL.PathComponents.replaceSubrange
     do {
@@ -78,24 +74,24 @@ extension PathComponentsTests {
     }
     do {
       var url = WebURL("file:///usr/")!
-      XCTAssertEqual(url.pathComponents.last!, "")
+      XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 2)
       url.pathComponents.replaceSubrange(
         url.pathComponents.endIndex..<url.pathComponents.endIndex, with: ["bin", "swift"]
       )
       XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
-      XCTAssertEqual(url.pathComponents.last!, "swift")
+      XCTAssertEqual(url.pathComponents.last, "swift")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
     do {
-      var url = WebURL("http://example.com/foo/index.html")!
-      XCTAssertEqual(url.pathComponents.first!, "foo")
+      var url = WebURL("http://example.com/awesome_product/index.html")!
+      XCTAssertEqual(url.pathComponents.first, "awesome_product")
       XCTAssertEqual(url.pathComponents.count, 2)
       url.pathComponents.replaceSubrange(
         url.pathComponents.startIndex..<url.pathComponents.endIndex, with: [] as [String]
       )
       XCTAssertEqual(url.serialized, "http://example.com/")
-      XCTAssertEqual(url.pathComponents.first!, "")
+      XCTAssertEqual(url.pathComponents.first, "")
       XCTAssertEqual(url.pathComponents.count, 1)
     }
     // WebURL.PathComponents.insert(contentsOf:at:)
@@ -109,31 +105,31 @@ extension PathComponentsTests {
     // WebURL.PathComponents.append(contentsOf:)
     do {
       var url = WebURL("file:///")!
-      XCTAssertEqual(url.pathComponents.last!, "")
+      XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append(contentsOf: ["tmp"])
-      XCTAssertEqual(url.pathComponents.last!, "tmp")
+      XCTAssertEqual(url.pathComponents.last, "tmp")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append(contentsOf: ["my_app", "data.json"])
       XCTAssertEqual(url.serialized, "file:///tmp/my_app/data.json")
-      XCTAssertEqual(url.pathComponents.last!, "data.json")
+      XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
     // WebURL.PathComponents.+=
     do {
       var url = WebURL("file:///")!
-      XCTAssertEqual(url.pathComponents.last!, "")
+      XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents += ["tmp"]
-      XCTAssertEqual(url.pathComponents.last!, "tmp")
+      XCTAssertEqual(url.pathComponents.last, "tmp")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents += ["my_app", "data.json"]
       XCTAssertEqual(url.serialized, "file:///tmp/my_app/data.json")
-      XCTAssertEqual(url.pathComponents.last!, "data.json")
+      XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
     // WebURL.PathComponents.removeSubrange(_:)
@@ -145,7 +141,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.serialized, "http://example.com/projects")
     }
     do {
-      var url = WebURL("http://example.com/foo/index.html")!
+      var url = WebURL("http://example.com/awesome_product/index.html")!
       url.pathComponents.removeSubrange(
         url.pathComponents.startIndex..<url.pathComponents.endIndex
       )
@@ -169,7 +165,7 @@ extension PathComponentsTests {
     // WebURL.PathComponents.append(_:)
     do {
       var url = WebURL("file:///")!
-      XCTAssertEqual(url.pathComponents.last!, "")
+      XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append("tmp")
@@ -178,7 +174,7 @@ extension PathComponentsTests {
 
       url.pathComponents.append("data.json")
       XCTAssertEqual(url.serialized, "file:///tmp/data.json")
-      XCTAssertEqual(url.pathComponents.last!, "data.json")
+      XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 2)
     }
     // WebURL.PathComponents.remove(at:)

--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -24,10 +24,10 @@ func loadTestResource(name: String) -> Data? {
   // I'm pretty massively disappointed that I need to do this.
   #if os(macOS)
     let url = Bundle.module.url(forResource: "Resources/\(name)", withExtension: "json")!
-    return try? Data(contentsOf: url)  
+    return try? Data(contentsOf: url)
   #else
     var path = #filePath
-    path.removeLast(22) // "WebPlatformTests.swift"
+    path.removeLast(22)  // "WebPlatformTests.swift"
     path += "Resources/\(name).json"
     return FileManager.default.contents(atPath: path)
   #endif

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -840,66 +840,100 @@ extension WebURLTests {
   func testHost() {
 
     // Non-IP hostnames in special URLs are always domains.
-    let url1 = WebURL("http://example.com/aPath?aQuery#andFragment, too")!
-    if case .domain("example.com") = url1.host {
-      XCTAssertEqual(url1.host?.serialized, url1.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url1.host))")
+    do {
+      let url = WebURL("http://example.com/aPath?aQuery#andFragment, too")!
+      if case .domain("example.com") = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
 
     // Non-IP hostnames in non-special URLs are always opaque hostnames.
-    let url2 = WebURL("foo://example.com/aPath?aQuery#andFragment, too")!
-    if case .opaque("example.com") = url2.host {
-      XCTAssertEqual(url2.host?.serialized, url2.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url2.host))")
+    do {
+      let url = WebURL("foo://example.com/aPath?aQuery#andFragment, too")!
+      if case .opaque("example.com") = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
 
     // Special URLs detect IPv4 addresses.
-    let url3 = WebURL("http://0xbadf00d/aPath?aQuery#andFragment, too")!
-    if case .ipv4Address(.init(octets: (11, 173, 240, 13))) = url3.host {
-      XCTAssertEqual(url3.host?.serialized, url3.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url3.host))")
+    do {
+      let url = WebURL("http://0xbadf00d/aPath?aQuery#andFragment, too")!
+      if case .ipv4Address(.init(octets: (11, 173, 240, 13))) = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
     // Non-special URLs do not.
-    let url4 = WebURL("foo://11.173.240.13/aPath?aQuery#andFragment, too")!
-    if case .opaque("11.173.240.13") = url4.host {
-      XCTAssertEqual(url4.host?.serialized, url4.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url4.host))")
+    do {
+      let url = WebURL("foo://11.173.240.13/aPath?aQuery#andFragment, too")!
+      if case .opaque("11.173.240.13") = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
 
     // Both special and non-special URLs detect IPv6 addresses.
-    let url5 = WebURL("http://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
-    if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url5.host {
-      XCTAssertEqual(url5.host?.serialized, url5.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url5.host))")
+    do {
+      let url = WebURL("http://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
+      if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
+    }
+    do {
+      let url = WebURL("foo://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
+      if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
 
-    let url6 = WebURL("foo://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
-    if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url6.host {
-      XCTAssertEqual(url6.host?.serialized, url6.hostname)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url6.host))")
+    // File and non-special URLs may have empty hostnames.
+    do {
+      let url = WebURL("file:///usr/bin/swift")!
+      if case .empty = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+        XCTAssertEqual(url.host?.serialized, "")
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
+    }
+    do {
+      let url = WebURL("foo:///some/path")!
+      if case .empty = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+        XCTAssertEqual(url.host?.serialized, "")
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
 
     // Path-only and cannot-be-a-base-path URLs do not have hosts.
-    let url7 = WebURL("foo:/path/only")!
-    if case .none = url7.host {
-      XCTAssertEqual(url7.host?.serialized, url7.hostname)
-      XCTAssertFalse(url7.cannotBeABase)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url7.host))")
+    do {
+      let url = WebURL("foo:/path/only")!
+      if case .none = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+        XCTAssertFalse(url.cannotBeABase)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
-
-    let url8 = WebURL("foo:some non-path")!
-    if case .none = url8.host {
-      XCTAssertEqual(url8.host?.serialized, url8.hostname)
-      XCTAssertTrue(url8.cannotBeABase)
-    } else {
-      XCTFail("Unexpected host: \(String(describing: url8.host))")
+    do {
+      let url = WebURL("foo:some non-path")!
+      if case .none = url.host {
+        XCTAssertEqual(url.host?.serialized, url.hostname)
+        XCTAssertTrue(url.cannotBeABase)
+      } else {
+        XCTFail("Unexpected host: \(String(describing: url.host))")
+      }
     }
   }
 


### PR DESCRIPTION
- Renamed JSModel.fragment -> JSModel.hash
- Fixed some cases where the tested documentation examples didn't align with the examples in the documentation
- Added tests for WebURL.Host.empty