### PR TITLE
Replace NoOverflowUnsafeBufferPointer with UnsafeBoundsCheckedBufferPointer

### DIFF
--- a/Sources/WebURL/IPAddress.swift
+++ b/Sources/WebURL/IPAddress.swift
@@ -258,7 +258,7 @@ extension IPv6Address {
     var callback = IgnoreIPAddressParserErrors()
     let _parsed =
       utf8.withContiguousStorageIfAvailable {
-        IPv6Address.parse(utf8: $0.withoutTrappingOnIndexOverflow, callback: &callback)
+        IPv6Address.parse(utf8: $0.boundsChecked, callback: &callback)
       } ?? IPv6Address.parse(utf8: utf8, callback: &callback)
     guard let parsed = _parsed else {
       return nil
@@ -745,7 +745,7 @@ extension IPv4Address {
   ) -> ParserResult where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
     var callback = IgnoreIPAddressParserErrors()
     return utf8.withContiguousStorageIfAvailable {
-      parse(utf8: $0.withoutTrappingOnIndexOverflow, callback: &callback)
+      parse(utf8: $0.boundsChecked, callback: &callback)
     } ?? parse(utf8: utf8, callback: &callback)
   }
 
@@ -914,7 +914,7 @@ extension IPv4Address {
   public init?<S>(dottedDecimal string: S) where S: StringProtocol {
     let _parsed =
       string.utf8.withContiguousStorageIfAvailable {
-        IPv4Address(dottedDecimalUTF8: $0.withoutTrappingOnIndexOverflow)
+        IPv4Address(dottedDecimalUTF8: $0.boundsChecked)
       } ?? IPv4Address(dottedDecimalUTF8: string.utf8)
     guard let parsed = _parsed else { return nil }
     self = parsed

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -46,7 +46,7 @@ where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
 
   var callback = IgnoreValidationErrors()
   return inputString.withContiguousStorageIfAvailable {
-    _urlFromBytes_impl($0.withoutTrappingOnIndexOverflow, baseURL: baseURL, callback: &callback)
+    _urlFromBytes_impl($0.boundsChecked, baseURL: baseURL, callback: &callback)
   } ?? _urlFromBytes_impl(inputString, baseURL: baseURL, callback: &callback)
 }
 

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -417,7 +417,7 @@ extension Collection where Element == UInt8 {
     as encodeSet: KeyPath<PercentEncodeSet, EncodeSet.Type>
   ) -> String {
     withContiguousStorageIfAvailable {
-      String(decoding: $0.withoutTrappingOnIndexOverflow.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
+      String(decoding: $0.boundsChecked.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
     } ?? String(decoding: self.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
   }
 
@@ -704,7 +704,7 @@ extension Collection where Element == UInt8 {
     from decodeSet: KeyPath<PercentDecodeSet, EncodeSet.Type>
   ) -> String where EncodeSet: PercentEncodeSetProtocol {
     withContiguousStorageIfAvailable {
-      String(decoding: $0.withoutTrappingOnIndexOverflow.lazy.percentDecodedUTF8(from: decodeSet), as: UTF8.self)
+      String(decoding: $0.boundsChecked.lazy.percentDecodedUTF8(from: decodeSet), as: UTF8.self)
     } ?? String(decoding: self.lazy.percentDecodedUTF8(from: decodeSet), as: UTF8.self)
   }
 

--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -160,197 +160,308 @@ internal func withUnsafeMutableBufferPointerToElements<T, Result>(
 
 
 // --------------------------------------------
-// MARK: - Reducing arithmetic overflow traps
-// --------------------------------------------
-// The implementation of UnsafeBufferPointer uses arithmetic which traps on overflow in its indexing operations
-// (e.g. index(after:)). This isn't a part of memory safety - UnsafeBufferPointer is, as the name suggests, unsafe.
-// The thing that makes it unsafe is that it lacks bounds-checking in release mode, so you can tell it to read from
-// any nonsense offset (too large, negative, whatever), and it'll just do it and think everything was fine.
-//
-// Collection doesn't make any guarantees about what happens when you use a Collection incorrectly;
-// incrementing an invalid index could trap, or it could always return startIndex, endIndex, or anything.
-// The same goes for subscripting - a Collection of Ints could trap, or return 0 or -1 if you ask for an out-of-bounds
-// element. Generic Collection code has to do things like checking an index is less than endIndex before incrementing -
-// otherwise it will invoke _unspecified_ behaviour (not the same as UB in C) and may give you nonsense results.
-//
-// The one thing a Collection should never do (or any type in Swift, Collection or not), is violate memory safety.
-// --> **Even if you use it incorrectly** <--. That's the difference with C-style undefined behaviour.
-// The exception to this rule is UnsafeBufferPointer - as explained above, if you ask it to read from an invalid index,
-// it will happily do so. Incorrect usage _will_ invoke C-style undefined behaviour and violate memory safety.
-//
-// This tweaked implementation of UnsafeBufferPointer makes some changes to the stdlib's implementation,
-// but is no more or less safe (you can't be "more or less safe" than something else; something is safe or it isn't):
-//
-// - Indexing operations do not overflow. As explained above, there is no requirement to trap.
-//   UnsafeBufferPointer won't bounds-check the index anyway, so trap or not, reading from an index you incremented
-//   too far will violate memory safety. Trapping on overflow doesn't make incorrect code safe.
-//
-//   See discussion at:
-//   https://forums.swift.org/t/is-it-okay-to-ignore-overflow-when-incrementing-decrementing-collection-indexes/47416
-//
-// - It is self-slicing. This helps to ensure that `Slice` doesn't mess up any of the low-level performance tweaks.
-//   It also allows us to implement `_copyContents` without having to create a custom iterator, which is nice.
-//
+// MARK: - Bounds-checked unsafe buffer
 // --------------------------------------------
 
 
 extension UnsafeBufferPointer {
 
   @inlinable
-  internal var withoutTrappingOnIndexOverflow: NoOverflowUnsafeBufferPointer<Element> {
-    NoOverflowUnsafeBufferPointer(self)
+  internal var boundsChecked: UnsafeBoundsCheckedBufferPointer<Element> {
+    UnsafeBoundsCheckedBufferPointer(self)
   }
 }
 
+/// A re-imagined contiguous buffer type, which attempts to protect against buffer over-reads in release builds with a negligible performance hit, and in some
+/// cases even an overall performance _improvement_ over the standard library's `UnsafeBufferPointer`.
+///
+/// The idea behind this type is that we start with a buffer, in the form of a base pointer and (unsigned) size, `buffer_size`.
+/// The indices, which are offsets from the pointer, are also unsigned integers; meaning they can never be negative, and bounds-checking can be simplified
+/// to `index < buffer_size`.
+/// The type is self-slicing, and the only rule to check that a slice's bounds are safe is that the maximum addressable offset must never increase over the slice's base.
+/// Since indices are unsigned, all offsets up to the maximum addressable offset are within the bounds of the original buffer, and hence safe to access.
+///
+/// ## What don't we need to do?
+///
+/// The thing to remember is that we're not under any obligation to detect misuses of the `Collection` protocol.
+/// If you have a buffer of 10 elements, and you increment its `startIndex` 1000 times, it may trigger a runtime error, or it may well return a garbage result index.
+/// And if you take that garbage result and pass it in to `distance(from: Index, to: Index)`, it may also trigger a runtime error - or it may not;
+/// it's perfectly valid for it to return a garbage number of elements instead. And garbage means garbage - for any reason - it doesn't matter if your index is beyond
+/// the bounds of the collection, or if the calculation overflows; it's all equally garbage and you shouldn't expect a meaningful result.
+/// You may, by some happy accident, land at a valid index, but you also might not, and nobody is under any obligation to trigger a runtime error along the way.
+///
+/// It isn't just unsafe types that are free from this obligation, either; even `Array` - the paragon of safe `Collection`s in Swift - won't trigger runtime errors
+/// for many misuses of the `Collection` protocol. You have a 10-element `Array`? Want to increment its `startIndex` by 1000? No problem.
+/// How about decrementing it by 1000? Also not a problem. Seriously, try it. I'm not lying:
+///
+/// ```swift
+/// let arr = Array(10..<20)
+/// arr.index(arr.startIndex, offsetBy: 1000)  // Returns 1000. No runtime error.
+/// arr.index(arr.startIndex, offsetBy: -1000) // Returns -1000. No runtime error.
+/// ```
+///
+/// This is really important. It means that we can provide the bare minimum bounds-checking needed for memory safety with very few actual checks,
+/// many of which can be relatively simple for the compiler to prove away, providing we express them in the right way.
+///
+/// ## Slicing
+///
+/// Bounds-checking in slices is particularly interesting, because we really want to keep the simplified `index < buffer_size` bounds check.
+/// But while the first buffer starts with indices `0..<buffer_size`, slices (and slices of slices) can have a non-zero offset from the start of the buffer.
+/// So just checking `index < buffer_size` is not enough to say that an index is within the _slice's_ bounds.
+///
+/// But we can get around this in a bit of cheeky way: by just allowing certain reads outside of the slice's bounds 😅. I know, it sounds wrong, but actually - is it?
+/// Again, we're trying to do the bare minimum to guarantee we never over-read the original buffer - as long as that is true, we don't _really_ care about
+/// the slice's bounds. The slice bounds are mostly only needed for `Collection` semantics, (e.g. that `startIndex` and `count` return correct values),
+/// and reads from other, invalid indexes are not _required_ to always trigger a runtime error. As mentioned above, as long as we always check that slices
+/// (and slices of slices) never increase the maximum addressable offset, we can guarantee not to over-read the buffer just by checking the slice's upper bound.
+///
+/// To illustrate: if the slice bounds are `4..<10`, and you want to read from offset `2`, that's not actually a memory-safety issue.
+/// We know that offset `2` is within the buffer; we don't need to fail in that situation. But if you try to read from offset `11` - well, we don't know that the buffer
+/// extends that far, so we do need to fail in order to preserve memory-safety.
+///
+/// A related problem is invalid `Range`s; i.e. situations where `range.lowerBound > range.upperBound`. It turns out that, again, as long as we always
+/// check that successive slices never increase the `upperBound` over their base (only decrease the addressable buffer or stay the same), we don't need
+/// to check that the range is properly formed, or even that `startIndex` is in-bounds (until we try to access from it, of course).
+///
+/// ## A delicate balance
+///
+/// This is a delicate balance, for sure. It definitely does **not** protect against logic bugs which can happen by invoking behaviour unspecified by `Collection`
+/// (e.g. reading from an invalid index), but it does provide effective protection against reading outside the bounds of a buffer of memory,
+/// and hence provides meaningful safety guarantees beyond what `UnsafeBufferPointer` provides (which is nothing; no meaningful checks whatsoever).
+///
+/// Moreover (and perhaps most importantly), it does so with a negligible impact on performance. In the "AverageURLs" benchmark, I've seen the performance
+/// difference when switching from UBP to this type range from about -5% (~ 32.2ms to 33.8ms) to about +8% (~32.2ms vs 29.7ms). My guess is that the use of
+/// unsigned integers helps the compiler avoid some runtime checks when constructing `Range` literals, which are frequently used in generic `Collection` code.
+///
+/// But overall it's kind of margin-of-error-ish stuff, which is a great result considering the added memory-safety. By comparison, a type which adds
+/// naive bounds-checking (including being strict about slice lower bounds) on an unsafe buffer with `Int` indexes, comes with a 20-25% performance hit.
+///
+/// ## Great! So, why is this still called 'Unsafe'?
+///
+/// Bounds-checking alone isn't enough for memory safety. In particular, this type:
+///
+/// 1. Doesn't guarantee the lifetime of the underlying memory. It's still a pointer underneath, after all.
+/// 2. Doesn't guarantee that the buffer has been fully initialized. You're supposed to do that before you create this view over the buffer.
+///
+/// So it's still unsafe, but the situations where unsafe, undefined behaviour could be invoked are easier to spot, even in complex `Collection` algorithms.
+///
 @usableFromInline
-internal struct NoOverflowUnsafeBufferPointer<Element> {
+internal struct UnsafeBoundsCheckedBufferPointer<Element> {
 
   @usableFromInline
   internal var baseAddress: UnsafePointer<Element>?
 
   @usableFromInline
-  internal var bounds: Range<Int>
+  internal var bounds: Range<UInt>
 
-  @inlinable
-  internal init(baseAddress: UnsafePointer<Element>?, count: Int) {
-    assert(count >= 0)
-    assert(count == 0 || baseAddress != nil)
-    self.baseAddress = baseAddress
-    self.bounds = Range(uncheckedBounds: (0, count))
-  }
-
+  /// Convenience initializer for creating a bounds-checked view of the given `UnsafeBufferPointer`.
+  ///
   @inlinable
   internal init(_ buffer: UnsafeBufferPointer<Element>) {
-    self.init(baseAddress: buffer.baseAddress, count: buffer.count)
+    self.init(baseAddress: buffer.baseAddress, size: UInt(bitPattern: buffer.count))
   }
 
+  /// Creates a bounds-checked buffer view covering the memory from `baseAddress` and spanning `size` elements.
+  ///
+  /// - precondition: `size` must not be greater than `Int.max`.
+  /// - precondition: If `size` is greater than 0, `baseAddress` must not be `nil`.
+  ///                 If `size` is 0, `baseAddress` may be `nil`, but doesn't have to be.
+  ///
   @inlinable
-  internal init(slicing base: Self, bounds: Range<Int>) {
-    base._failEarlyRangeCheck(bounds, bounds: base.bounds)
+  internal init(baseAddress: UnsafePointer<Element>?, size: UInt) {
+    // By limiting the size to `Int.max`, and bounds-checking every slice's (upperBound <= base.endIndex),
+    // we ensure that every valid index, and every distance between valid indices, fits in a signed integer.
+    //
+    // This allows us to use `Int(bitPattern:)` to convert valid indexes without range/overflow checks.
+    // We don't care about invalid indices; they are garbage values and will be rejected by bounds-checking if
+    // they point outside of the buffer's known safe bounds.
+    precondition(size <= UInt(Int.max), "buffer size is greater than Int.max!")
+    precondition(size == 0 || baseAddress != nil, "buffer size > 0, but baseAddress is nil!")
+    self.baseAddress = baseAddress
+    self.bounds = 0..<size
+  }
+
+  /// Do not use. `internal` for inline purposes only.
+  ///
+  @inlinable
+  internal init(_doNotUse_precheckedSliceOf base: Self, bounds: Range<UInt>) {
+    // When slicing, we don't actually check that `bounds.lowerBound` (i.e. our new `startIndex`) is actually in-bounds,
+    // only that the new `endIndex` is not greater than the parent's `endIndex`.
+    //
+    // For subscript accesses, that's fine, bounds-checking will handle it.
+    // For other operations (like wCSIA, _copyContents) which bypass the subscript, extra checks are needed.
     self.baseAddress = base.baseAddress
     self.bounds = bounds
   }
+
+  @inlinable @inline(__always)
+  internal func boundsCheckForRead(_ index: UInt) {
+    assert(index >= startIndex, "UnsafeBoundsCheckedBufferPointer: Invalid read. index < startIndex")
+    precondition(index < endIndex, "UnsafeBoundsCheckedBufferPointer: Invalid read. index >= endIndex")
+  }
+
+  @inlinable @inline(__always)
+  internal func boundsCheckForSlice(_ range: Range<UInt>) {
+    assert(range.lowerBound >= startIndex, "UnsafeBoundsCheckedBufferPointer: Invalid slice. lowerBound < startIndex")
+    precondition(range.upperBound <= endIndex, "UnsafeBoundsCheckedBufferPointer: Invalid slice. upperBound > endIndex")
+  }
 }
 
-extension NoOverflowUnsafeBufferPointer: RandomAccessCollection {
+extension UnsafeBoundsCheckedBufferPointer: RandomAccessCollection {
 
   @inlinable
-  internal var startIndex: Int {
-    _assumeNonNegative(bounds.lowerBound)
+  internal var startIndex: UInt {
+    bounds.lowerBound
   }
 
   @inlinable
-  internal var endIndex: Int {
-    _assumeNonNegative(bounds.upperBound)
+  internal var endIndex: UInt {
+    bounds.upperBound
   }
 
   @inlinable
   internal var count: Int {
-    endIndex &- startIndex
+    Int(bitPattern: endIndex &- startIndex)
   }
 
   @inlinable
   internal var isEmpty: Bool {
-    // startIndex will never be greater than endIndex, but by writing it this way (rather than startIndex != endIndex),
-    // we communicate that when 'isEmpty == false', startIndex is definitely < endIndex. This means:
-    // - startIndex + 1 won't overflow
-    // - The range startIndex..<endIndex is well-formed and shouldn't trap, and
-    // - startIndex + 1 will at most be equal to endIndex
-    //
-    // This can indeed be shown to make an observable difference in smaller code snippets,
-    // although most uses of 'isEmpty == false' have been changed to 'startIndex < endIndex' anyway.
+    // We don't expect startIndex to regularly be greater than endIndex, but by writing it this way
+    // (rather than startIndex != endIndex), we communicate that !isEmpty is a synonym for startIndex < endIndex.
+    // This can help eliminate some bounds checks.
     startIndex >= endIndex
   }
 
-  @inlinable
-  internal subscript(position: Int) -> Element {
-    _failEarlyRangeCheck(position, bounds: bounds)
-    return baseAddress.unsafelyUnwrapped[position]
-  }
-
-  @inlinable
-  internal subscript(sliceBounds: Range<Int>) -> NoOverflowUnsafeBufferPointer<Element> {
-    NoOverflowUnsafeBufferPointer(slicing: self, bounds: sliceBounds)
-  }
-
-  @inlinable
-  internal func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
-    assert(index >= bounds.lowerBound)
-    assert(index < bounds.upperBound)
-  }
-
-  @inlinable
-  internal func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
-    assert(range.lowerBound >= bounds.lowerBound)
-    assert(range.upperBound <= bounds.upperBound)
-  }
-
-  @inlinable
-  internal func _copyContents(
-    initializing destination: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
-    guard !isEmpty && !destination.isEmpty else { return (makeIterator(), 0) }
-    let src = self.baseAddress.unsafelyUnwrapped + bounds.lowerBound
-    let dst = destination.baseAddress.unsafelyUnwrapped
-    let n = Swift.min(destination.count, self.count)
-    dst.initialize(from: src, count: n)
-    return (self[Range(uncheckedBounds: (bounds.lowerBound &+ n, bounds.upperBound))].makeIterator(), n)
-  }
-
-  @inlinable
-  internal var indices: Range<Int> {
-    bounds
+  @inlinable @inline(__always)
+  internal subscript(position: UInt) -> Element {
+    boundsCheckForRead(position)
+    return baseAddress.unsafelyUnwrapped[Int(bitPattern: position)]
   }
 
   @inlinable @inline(__always)
-  internal func index(after i: Int) -> Int {
+  internal subscript(sliceBounds: Range<UInt>) -> UnsafeBoundsCheckedBufferPointer<Element> {
+    boundsCheckForSlice(sliceBounds)
+    return UnsafeBoundsCheckedBufferPointer(_doNotUse_precheckedSliceOf: self, bounds: sliceBounds)
+  }
+
+  @inlinable
+  internal var indices: Range<UInt> {
+    bounds
+  }
+
+  // All of these indexing methods return essentially junk values (albeit deterministic junk) if you use them
+  // in a way that Collection does not specify.
+  //
+  // It's no different to a 10-element Array giving you an Index of 1000 if you call 'index(after:)' enough times.
+  // The important thing for memory safety is that we bounds-check the actual read from the pointer.
+
+  @inlinable @inline(__always)
+  internal func index(after i: UInt) -> UInt {
     i &+ 1
   }
 
   @inlinable @inline(__always)
-  internal func formIndex(after i: inout Int) {
+  internal func formIndex(after i: inout UInt) {
     i &+= 1
   }
 
-  @inlinable
-  internal func index(_ i: Int, offsetBy distance: Int) -> Int {
-    i &+ distance
-  }
-
-  @inlinable
-  internal func formIndex(_ i: inout Int, offsetBy distance: Int) {
-    i &+= distance
-  }
-
-  @inlinable
-  internal func index(_ i: Int, offsetBy n: Int, limitedBy limit: Int) -> Int? {
-    let l = limit &- i
-    if n > 0 ? l >= 0 && l < n : l <= 0 && n < l {
-      return nil
-    }
-    return i &+ n
-  }
-
   @inlinable @inline(__always)
-  internal func index(before i: Int) -> Int {
+  internal func index(before i: UInt) -> UInt {
     i &- 1
   }
 
   @inlinable @inline(__always)
-  internal func formIndex(before i: inout Int) {
+  internal func formIndex(before i: inout UInt) {
     i &-= 1
   }
 
   @inlinable
-  internal func distance(from start: Int, to end: Int) -> Int {
-    end &- start
+  internal func index(_ i: UInt, offsetBy distance: Int) -> UInt {
+    UInt(bitPattern: Int(bitPattern: i) &+ distance)
+  }
+
+  @inlinable
+  internal func formIndex(_ i: inout UInt, offsetBy distance: Int) {
+    i = UInt(bitPattern: Int(bitPattern: i) &+ distance)
+  }
+
+  @inlinable
+  internal func index(_ i: UInt, offsetBy n: Int, limitedBy limit: UInt) -> UInt? {
+    let l = limit &- i
+    if n > 0 ? l >= 0 && l < n : l <= 0 && n < l {
+      return nil
+    }
+    return UInt(bitPattern: Int(bitPattern: i) &+ n)
+  }
+
+  @inlinable
+  internal func distance(from start: UInt, to end: UInt) -> Int {
+    Int(bitPattern: end) &- Int(bitPattern: start)
   }
 
   @inlinable
   internal func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    guard let baseAddress = baseAddress else { return try body(UnsafeBufferPointer(start: nil, count: 0)) }
-    return try body(UnsafeBufferPointer(start: baseAddress + startIndex, count: _assumeNonNegative(count)))
+    // Watch out!
+    // 'guard startIndex <= endIndex' is effectively a bounds-check for 'startIndex'.
+    // We otherwise don't check the collection's lower bound.
+    guard let baseAddress = baseAddress, startIndex <= endIndex else {
+      return try body(UnsafeBufferPointer(start: nil, count: 0))
+    }
+    return try body(UnsafeBufferPointer(start: baseAddress + Int(bitPattern: startIndex), count: count))
+  }
+
+  @inlinable @inline(__always)
+  internal func _failEarlyRangeCheck(_ index: UInt, bounds: Range<UInt>) {}
+
+  @inlinable @inline(__always)
+  internal func _failEarlyRangeCheck(_ range: Range<UInt>, bounds: Range<UInt>) {}
+
+  @inlinable
+  internal func _copyContents(
+    initializing destination: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
+    // Watch out!
+    // 'startIndex < endIndex' is effectively a bounds-check for 'startIndex', as well as checking for an empty buffer.
+    // We otherwise don't check the collection's lower bound.
+    guard startIndex < endIndex, !destination.isEmpty else { return (makeIterator(), 0) }
+    let src = baseAddress.unsafelyUnwrapped + Int(bitPattern: bounds.lowerBound)
+    let dst = destination.baseAddress.unsafelyUnwrapped
+    let n = Swift.min(destination.count, count)
+    dst.initialize(from: src, count: n)
+    return (Iterator(pointer: self, idx: bounds.lowerBound &+ UInt(bitPattern: n)), n)
+  }
+}
+
+extension UnsafeBoundsCheckedBufferPointer {
+
+  @inlinable
+  internal func makeIterator() -> Iterator {
+    Iterator(pointer: self, idx: startIndex)
+  }
+
+  @usableFromInline
+  internal struct Iterator: IteratorProtocol {
+
+    @usableFromInline
+    internal var pointer: UnsafeBoundsCheckedBufferPointer
+
+    @usableFromInline
+    internal var idx: UInt
+
+    @inlinable
+    internal init(pointer: UnsafeBoundsCheckedBufferPointer<Element>, idx: UInt) {
+      self.pointer = pointer
+      self.idx = idx
+    }
+
+    @inlinable @inline(__always)
+    internal mutating func next() -> Element? {
+      guard idx < pointer.endIndex else { return nil }
+      let i = idx
+      pointer.formIndex(after: &idx)
+      return pointer[i]
+    }
   }
 }


### PR DESCRIPTION
It still doesn't overflow on indexing operations, but now it also uses an unsigned integer index and
bounds-checks accesses to protect against buffer over-reads.

And best of all? It does it with a negligible impact on performance! 🏄‍♂️