### PR TITLE
Add WebURLSystemExtras library, including FilePath <-> WebURL functions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,20 +19,48 @@ import PackageDescription
 let package = Package(
   name: "swift-url",
   products: [
+    // Core functionality.
     .library(name: "WebURL", targets: ["WebURL"]),
+
+    // Integration with swift-system.
+    // FIXME: This should become a cross-import overlay once they exist and are supported by SwiftPM.
+    .library(name: "WebURLSystemExtras", targets: ["WebURLSystemExtras"]),
+
+    // Test support library.
+    // Various infrastructure components to run the URL web-platform-tests and other tests contained in JSON files.
+    // Used by https://github.com/karwa/swift-url-tools to provide a GUI test runner.
     .library(name: "WebURLTestSupport", targets: ["WebURLTestSupport"]),
   ],
   dependencies: [
-    // Swift-checkit for testing protocol conformances.
+    // swift-system for WebURLSystemExtras.
+    // FIXME: Move to a tagged release which includes https://github.com/apple/swift-system/pull/51
+    .package(url: "https://github.com/apple/swift-system.git", .branch("main")),
+
+    // swift-checkit for testing protocol conformances. Test-only dependency.
     .package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", from: "0.0.2"),
   ],
   targets: [
-    .target(name: "WebURL"),
-    .target(name: "WebURLTestSupport", dependencies: ["WebURL"]),
+    // Products.
+    .target(
+      name: "WebURL"
+    ),
+    .target(
+      name: "WebURLSystemExtras",
+      dependencies: ["WebURL", .product(name: "SystemPackage", package: "swift-system")]
+    ),
+    .target(
+      name: "WebURLTestSupport",
+      dependencies: ["WebURL"]
+    ),
+		// Tests.
     .testTarget(
       name: "WebURLTests",
       dependencies: ["WebURL", "WebURLTestSupport", "Checkit"],
       resources: [.copy("Resources")]
+    ),
+    .testTarget(
+      name: "WebURLSystemExtrasTests",
+      dependencies: ["WebURLSystemExtras", "WebURL", .product(name: "SystemPackage", package: "swift-system")]
     ),
   ]
 )

--- a/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
+++ b/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
@@ -1,0 +1,349 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// --------------------------------------------
+// FilePath -> WebURL and WebURL -> FilePath conversions, for both SystemPackage and System.framework.
+// This file is written in such a way that all implementations of 'swift-system' discoverable via canImport
+// will be supported, and at least one must be present.
+//
+// Technically, this means that software targeting newer Darwin platforms could omit SystemPackage and rely on
+// System.framework instead. That is difficult (perhaps impossible) to express with SwiftPM currently,
+// and toolchain versions behave differently.
+//
+// For now, the 'WebURLSystemExtras' module depends on SystemPackage unconditionally.
+// If that is a problem, commenting out the dependency in 'Package.swift' should allow you to depend only
+// on System.framework, without any other changes to the library source.
+// --------------------------------------------
+
+import WebURL
+
+// --------------------------------------------
+// MARK: - SystemPackage interface
+// --------------------------------------------
+
+
+#if canImport(SystemPackage)
+  import SystemPackage
+
+  extension WebURL {
+
+    /// Creates a `file:` URL representation of the given `FilePath`.
+    ///
+    /// The given path must be absolute and must not contain any components which traverse to their parent directories (`..` components).
+    /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path if it is not.
+    /// Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `..` components.
+    ///
+    /// - parameters:
+    ///   - filePath: The file path from which to create the file URL.
+    ///
+    /// - throws: `URLFromFilePathError`
+    ///
+    public init(filePath: SystemPackage.FilePath) throws {
+      self = try filePath.withPlatformString { platformStr in
+        try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
+          guard let mbStr = $0 else { throw URLFromFilePathError.transcodingFailure }
+          precondition(mbStr.last == 0, "Expected a null-terminated string")
+          return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+        }
+      }
+    }
+  }
+
+  extension SystemPackage.FilePath {
+
+    /// Reconstructs a `FilePath` from its URL representation.
+    ///
+    /// The given URL must be a `file:` URL representation of an absolute path according to this system's path format.
+    /// The resulting `FilePath` is both absolute and lexically normalized.
+    ///
+    /// On Windows, the reconstructed path is first interpreted as UTF-8. Should it not contain valid UTF-8, it will be interpreted
+    /// using the system's active code-page and converted to its Unicode representation.
+    ///
+    /// - parameters:
+    ///   - url: The file URL from which to reconstruct the file path.
+    ///
+    /// - throws: `FilePathFromURLError`
+    ///
+    public init(url: WebURL) throws {
+      self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+        try PlatformStringConversions.fromMultiByte($0) {
+          guard let platformString = $0 else { throw FilePathFromURLError.transcodingFailure }
+          return FilePath(platformString: platformString.baseAddress!)
+        }
+      }
+    }
+  }
+#endif
+
+
+// --------------------------------------------
+// MARK: - System.framework interface
+// --------------------------------------------
+
+
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && canImport(System)
+  import System
+
+  @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+  extension WebURL {
+
+    /// Creates a `file:` URL representation of the given `FilePath`.
+    ///
+    /// The given path must be absolute and must not contain any components which traverse to their parent directories (`..` components).
+    /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path if it is not.
+    /// Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `..` components.
+    ///
+    /// - parameters:
+    ///   - filePath: The file path from which to create the file URL.
+    ///
+    /// - throws: `URLFromFilePathError`
+    ///
+    public init(filePath: System.FilePath) throws {
+      self = try filePath.withCString { platformStr in
+        try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
+          guard let mbStr = $0 else { throw URLFromFilePathError.transcodingFailure }
+          precondition(mbStr.last == 0, "Expected a null-terminated string")
+          return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+        }
+      }
+    }
+  }
+
+  @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+  extension System.FilePath {
+
+    /// Reconstructs a `FilePath` from its URL representation.
+    ///
+    /// The given URL must be a `file:` URL representation of an absolute path according to this system's path format.
+    /// The resulting `FilePath` is both absolute and lexically normalized.
+    ///
+    /// On Windows, the reconstructed path is first interpreted as UTF-8. Should it not contain valid UTF-8, it will be interpreted
+    /// using the system's active code-page and converted to its Unicode representation.
+    ///
+    /// - parameters:
+    ///   - url: The file URL from which to reconstruct the file path.
+    ///
+    /// - throws: `FilePathFromURLError`
+    ///
+    public init(url: WebURL) throws {
+      self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+        try PlatformStringConversions.fromMultiByte($0) {
+          guard let platformString = $0 else { throw FilePathFromURLError.transcodingFailure }
+          return FilePath(cString: platformString.baseAddress!)
+        }
+      }
+    }
+  }
+#endif
+
+
+// --------------------------------------------
+// MARK: - Platform string conversions
+// --------------------------------------------
+
+
+#if canImport(SystemPackage)
+  import SystemPackage
+  typealias CInterop_PlatformChar = CInterop.PlatformChar
+#elseif (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && canImport(System)
+  typealias CInterop_PlatformChar = CChar
+#endif
+
+private protocol PlatformStringConversionsProtocol {
+
+  /// Converts a null-terminated buffer of platform characters to a null-terminated buffer of bytes.
+  ///
+  /// If the platform string is known to contain textual code-points, the buffer passed to `body` will be encoded with UTF-8.
+  ///
+  static func toMultiByte<ResultType>(
+    _ platformString: UnsafeBufferPointer<CInterop_PlatformChar>,
+    _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+  ) rethrows -> ResultType
+
+  /// Converts a null-terminated buffer of bytes to a null-terminated platform string.
+  ///
+  /// If the platform string requires its contents to be textual code-points, this function will attempt to infer the encoding of the bytes.
+  ///
+  static func fromMultiByte<ResultType>(
+    _ mbString: UnsafeBufferPointer<UInt8>,
+    _ body: (UnsafeBufferPointer<CInterop_PlatformChar>?) throws -> ResultType
+  ) rethrows -> ResultType
+}
+
+#if os(Windows)
+
+  import WinSDK
+
+  // Windows paths.
+  // --------------
+  // - Platform string: Unicode codepoints (UTF-16/UCS-2).
+  // - Multi-byte string: Depends.
+  //                       - For `toMultiByte`, we choose UTF-8.
+  //                       - For `fromMultiByte`, we expect UTF-8 but fall back to the system's code-page.
+  //
+  // This follows the principle of being strict when sending and lenient when receiving,
+  // and matches the behaviour of Chromium/Edge, so it should match the expectations of Windows users.
+  // https://github.com/chromium/chromium/blob/7417fc2bd5c8cf0e6dbf7ca4b599603c67d3edf3/net/base/filename_util.cc#L138
+  //
+  // The Windows system routines are WideCharToMultiByte and MultiByteToWideChar.
+  // The documentation for those functions includes the following note:
+  //
+  // > Starting with Windows Vista, this function fully conforms with the Unicode 4.1 specification
+  // > for UTF-8 and UTF-16. The function used on earlier operating systems encodes or decodes lone surrogate halves
+  // > or mismatched surrogate pairs. Code written in earlier versions of Windows that rely on this behavior to
+  // > encode random non-text binary data might run into problems.
+  //
+  // https://web.archive.org/web/20210225215335if_/https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar#remarks
+  //
+  // Assuming this is accurate, the standard library's built-in routines should do just as good a job.
+  // MultiByteToWideChar is still useful as a fallback for transcoding from a Windows code-page to UTF-16, however.
+  //
+  internal enum PlatformStringConversions: PlatformStringConversionsProtocol {
+
+    fileprivate static func toMultiByte<ResultType>(
+      _ plString: UnsafeBufferPointer<UInt16>,
+      _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(plString.last == 0, "Expected a null-terminated string")
+
+      var transcoded = ContiguousArray<UInt8>()
+      transcoded.reserveCapacity(plString.count)
+      let invalidUnicode = transcode(plString.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: true) {
+        codeUnit in transcoded.append(codeUnit)
+      }
+      guard !invalidUnicode else {
+        return try body(nil)
+      }
+      precondition(transcoded.last == 0, "Expected the transcoded result to be null-terminated")
+      return try transcoded.withUnsafeBufferPointer(body)
+    }
+
+    fileprivate static func fromMultiByte<ResultType>(
+      _ mbString: UnsafeBufferPointer<UInt8>,
+      _ body: (UnsafeBufferPointer<UInt16>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(mbString.last == 0, "Expected a null-terminated string")
+
+      var transcoded = ContiguousArray<UInt16>()
+      transcoded.reserveCapacity(mbString.count)
+      let invalidUnicode = transcode(mbString.makeIterator(), from: UTF8.self, to: UTF16.self, stoppingOnError: true) {
+        codeUnit in transcoded.append(codeUnit)
+      }
+      if invalidUnicode {
+        guard mbString.withMemoryRebound(to: CChar.self, { FallbackCPtoWide($0, &transcoded) }) else {
+          return try body(nil)
+        }
+      }
+      precondition(transcoded.last == 0, "Expected the transcoded result to be null-terminated")
+      return try transcoded.withUnsafeBufferPointer(body)
+    }
+
+    /// Interprets `input` as a string in the fallback code-page and attempts to transcode it to UTF-16, storing the result in `output`.
+    ///
+    /// Note that `input` must be null-terminated, and the result will be null-terminated. `output` will have its contents replaced with the resulting string
+    /// and will be resized as needed, reusing any previously-allocated capacity if possible. If transcoding fails, the contents of `output` are unspecified.
+    ///
+    /// - returns: `true` if transcoding was successful, otherwise `false`.
+    ///
+    private static func FallbackCPtoWide(
+      _ input: UnsafeBufferPointer<CChar>,
+      _ output: inout ContiguousArray<UInt16>
+    ) -> Bool {
+
+      precondition(input.last == 0, "Expected a null-terminated string")
+
+      let codePage = Self.FallbackCodePage
+      let requiredCapacity = MultiByteToWideChar(
+        codePage, DWORD(bitPattern: MB_ERR_INVALID_CHARS),
+        input.baseAddress, Int32(input.count), nil, 0
+      )
+      guard requiredCapacity > 0 else {
+        return false
+      }
+      output.replaceSubrange(0..<output.count, with: repeatElement(0, count: Int(requiredCapacity)))
+      let stringLength = output.withUnsafeMutableBufferPointer { buffer in
+        // swift-format-ignore
+        Int(MultiByteToWideChar(
+          codePage, DWORD(bitPattern: MB_ERR_INVALID_CHARS),
+          input.baseAddress, Int32(input.count), buffer.baseAddress, Int32(buffer.count)
+        ))
+      }
+      guard stringLength == output.count else {
+        return false
+      }
+      precondition(output.last == 0, "Expected the transcoded result to be null-terminated")
+      return true
+    }
+
+    // Code-page testing.
+
+    #if DEBUG
+      private static var FallbackCodePage = UINT(bitPattern: CP_ACP)
+
+      /// Makes platform-string conversions fall back to interpreting bytes using the given code-page,
+      /// rather than the system's active code-page, for the duration of `body`.
+      ///
+      internal static func simulatingActiveCodePage<T>(
+        _ newCodePage: UINT, _ body: () throws -> T
+      ) rethrows -> T {
+
+        let previousCodePage = FallbackCodePage
+        FallbackCodePage = newCodePage
+        defer {
+          FallbackCodePage = previousCodePage
+        }
+        return try body()
+      }
+    #else
+      private static let FallbackCodePage = UINT(bitPattern: CP_ACP)
+    #endif
+  }
+
+#else
+
+  // POSIX paths.
+  // ------------
+  // - Platform string: opaque bytes.
+  // - Multi-byte string: opaque bytes.
+  //
+  // POSIX platform strings are natively multi-byte. We can't assume that they contain Unicode text,
+  // so we couldn't transcode them even if we wanted to.
+  //
+  // Essentially this conversion, then, papers over signed/unsigned char from the platform string
+  // and normalizes them as UInt8. Which is what the WebURL functions accept/return, because they treat
+  // the string as semi-opaque octets and don't care about the sign of the numeric value.
+  //
+  enum PlatformStringConversions: PlatformStringConversionsProtocol {
+
+    static func toMultiByte<ResultType>(
+      _ platformString: UnsafeBufferPointer<CChar>,
+      _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(platformString.last == 0, "Expected a null-terminated string")
+      return try platformString.withMemoryRebound(to: UInt8.self, body)
+    }
+
+    static func fromMultiByte<ResultType>(
+      _ mbString: UnsafeBufferPointer<UInt8>,
+      _ body: (UnsafeBufferPointer<CChar>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(mbString.last == 0, "Expected a null-terminated string")
+      return try mbString.withMemoryRebound(to: CChar.self, body)
+    }
+  }
+
+#endif

--- a/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
+++ b/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
@@ -38,10 +38,10 @@ extension FilePathToURLTests.WebURLReportHarness: FilePathToURLTests.Harness {
     _ path: String, format: FilePathFormat
   ) -> Result<String, FilePathToURLTests.FailureReason> {
     Result { try WebURL(filePath: path, format: format).serialized }
-      .mapError { Self.errorToFailureReason($0 as! FilePathToURLError) }
+      .mapError { Self.errorToFailureReason($0 as! URLFromFilePathError) }
   }
 
-  private static func errorToFailureReason(_ error: FilePathToURLError) -> FilePathToURLTests.FailureReason {
+  private static func errorToFailureReason(_ error: URLFromFilePathError) -> FilePathToURLTests.FailureReason {
     switch error {
     case .emptyInput: return .emptyInput
     case .nullBytes: return .nullBytes
@@ -102,10 +102,10 @@ extension URLToFilePathTests.WebURLReportHarness: URLToFilePathTests.Harness {
   ) -> Result<String, URLToFilePathTests.FailureReason> {
     Result {
       String(decoding: try WebURL.filePathBytes(from: url, format: format, nullTerminated: false), as: UTF8.self)
-    }.mapError { Self.errorToFailureReason($0 as! URLToFilePathError) }
+    }.mapError { Self.errorToFailureReason($0 as! FilePathFromURLError) }
   }
 
-  private static func errorToFailureReason(_ error: URLToFilePathError) -> URLToFilePathTests.FailureReason {
+  private static func errorToFailureReason(_ error: FilePathFromURLError) -> URLToFilePathTests.FailureReason {
     switch error {
     case .notAFileURL: return .notAFileURL
     case .encodedNullBytes: return .encodedNullByte

--- a/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
+++ b/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
@@ -37,7 +37,7 @@ extension FilePathToURLTests.WebURLReportHarness: FilePathToURLTests.Harness {
   public func filePathToURL(
     _ path: String, format: FilePathFormat
   ) -> Result<String, FilePathToURLTests.FailureReason> {
-    Result { try WebURL.fromFilePathBytes(path.utf8, format: format).serialized }
+    Result { try WebURL(filePath: path, format: format).serialized }
       .mapError { Self.errorToFailureReason($0 as! FilePathToURLError) }
   }
 

--- a/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
+++ b/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
@@ -1,0 +1,733 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import WebURL
+import XCTest
+
+@testable import WebURLSystemExtras
+
+final class SystemFilePathTests: XCTestCase {}
+
+
+// --------------------------------------------
+// MARK: - Windows
+// --------------------------------------------
+
+
+#if os(Windows)
+  import SystemPackage
+
+  extension SystemFilePathTests {
+
+    func testASCII() throws {
+
+      // Start with an ASCII file path.
+      let filePath: FilePath = #"C:\foo\bar.txt"#
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x0043 /* C */, 0x003A /* : */,
+            0x005C /* \ */, 0x0066 /* f */, 0x006F /* o */, 0x006F /* o */,
+            0x005C /* \ */, 0x0062 /* b */, 0x0061 /* a */, 0x0072 /* r */,
+            0x002E /* . */, 0x0074 /* t */, 0x0078 /* x */, 0x0074 /* t */,
+          ]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\foo\bar.txt"#)
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnicode() throws {
+
+      // Start with a Unicode file path.
+      let filePath: FilePath = #"C:\f🦆o\b🏆🏎r.💩"#
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x0043 /* C */, 0x003A /* : */,
+            0x005C /* \ */, 0x0066 /* f */, 0xD83E, 0xDD86 /* 🦆 */, 0x006F /* o */,
+            0x005C /* \ */, 0x0062 /* b */, 0xD83C, 0xDFC6 /* 🏆 */, 0xD83C, 0xDFCE /* 🏎 */, 0x0072 /* r */,
+            0x002E /* . */, 0xD83D, 0xDCA9 /* 💩 */,
+          ]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\f🦆o\b🏆🏎r.💩"#)
+
+      // Use WebURL(filePath: FilePath) to create a file URL. Should be transcoded to UTF-8.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(
+        fileURL, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly. Should be transcoded back to UTF-16.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(
+        fileURL2, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL2.pathComponents.count, 3)
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnpairedSurrogateInURL() throws {
+
+      let unpairedSurrogate: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x5C /* \ */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // TODO: It is questionable what we should do here. There are 3 possibile courses of action:
+      //
+      // 1. As usual, interpret the bytes as non-UTF-8 and fall back to the system's code-page.
+      // 2. Recognize lone surrogates as being botched UTF-8, don't fall back to system code-page.
+      //   2a. We could be strict and fail to transcode to UTF-16, or
+      //   2b. We could be lenient and decode them anyway.
+
+      // If the system's active code-page is UTF-8, we should fail in any case.
+      XCTAssertThrowsSpecific(FilePathFromURLError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(65001) { try FilePath(url: fileURL) }
+      }
+
+      // Code page 437 = IBM extended ASCII. Every code-unit is defined.
+      XCTAssertNoThrow {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(437) { try FilePath(url: fileURL) }
+      }
+    }
+
+    func testUnpairedSurrogateInFilePath() throws {
+
+      let unpairedSurrogate: [UInt16] = [
+        0x0043 /* C */, 0x003A /* : */,
+        0x005C /* \ */, 0x0066 /* f */, 0x006F /* o */, 0x0D800, 0x006F /* o */,
+        0x005C /* \ */, 0x0062 /* b */, 0x0061 /* a */, 0x0072 /* r */,
+        0x0000,
+      ]
+      let filePath = FilePath(platformString: unpairedSurrogate)
+      XCTAssertThrowsSpecific(URLFromFilePathError.transcodingFailure) { let _ = try WebURL(filePath: filePath) }
+    }
+
+    func testFallbackCodePage_latin1() throws {
+
+      let latin1: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x63 /* c */, 0x61 /* a */, 0x66 /* f */, 0xE9 /* é */, 0xDD /* Ý */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path.
+      // Since the path is not valid UTF-8, it will be transcoded using the system's code-page.
+      let filePath = try PlatformStringConversions.simulatingActiveCodePage(1252) { try FilePath(url: fileURL) }
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [0x0043, 0x003A, 0x005C, 0x0063, 0x0061, 0x0066, 0x00E9, 0x00DD]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\caféÝ"#)
+
+      // Transcoding failures will be caught.
+      // 1255 = Hebrew, where the byte 0xDD is undefined.
+      XCTAssertThrowsSpecific(FilePathFromURLError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(1255) { try FilePath(url: fileURL) }
+      }
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
+      // the contents should be transcoded to UTF-8.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/caf%C3%A9%C3%9D")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/caf%C3%A9%C3%9D")
+      XCTAssertEqual(fileURL2.pathComponents.count, 2)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      // Since the URL contents are now valid UTF-8, the system code-page shouldn't matter.
+      let filePath2 = try PlatformStringConversions.simulatingActiveCodePage(1255) { try FilePath(url: fileURL2) }
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+    }
+
+    func testFallbackCodePage_greek() throws {
+
+      let greek: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x68 /* h */, 0x69 /* i */, 0xE1 /* α */, 0xE2 /* β */, 0xE3 /* γ */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path.
+      // Since the path is not valid UTF-8, it will be transcoded using the system's code-page.
+      let filePath = try PlatformStringConversions.simulatingActiveCodePage(1253) { try FilePath(url: fileURL) }
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [0x0043, 0x003A, 0x005C, 0x0068, 0x0069, 0x03B1, 0x03B2, 0x03B3]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\hiαβγ"#)
+
+      // Transcoding failures will be caught.
+      // 932 = Windows-31J, where the bytes 0xE? denote the start of a multi-byte sequence,
+      // meaning the sequence [0xE1, 0xE2] is nonsense.
+      XCTAssertThrowsSpecific(FilePathFromURLError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(932) { try FilePath(url: fileURL) }
+      }
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
+      // the contents should be transcoded to UTF-8.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/hi%CE%B1%CE%B2%CE%B3")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/hi%CE%B1%CE%B2%CE%B3")
+      XCTAssertEqual(fileURL2.pathComponents.count, 2)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      // Since the URL contents are now valid UTF-8, the system code-page shouldn't matter.
+      let filePath2 = try PlatformStringConversions.simulatingActiveCodePage(932) { try FilePath(url: fileURL2) }
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+    }
+
+    /// Make sure we agree with FilePath about which paths are absolute vs. relative.
+    func testRelativePaths() {
+
+      let relativePaths: [FilePath] = [
+        #"C:"#,
+        #"C:foo"#,
+        #"foo"#,
+        #"\foo"#,
+        #"/foo"#,
+      ]
+      for path in relativePaths {
+        XCTAssertTrue(path.isRelative)
+        XCTAssertFalse(path.isAbsolute)
+        XCTAssertThrowsSpecific(URLFromFilePathError.relativePath) {
+          let _ = try WebURL(filePath: path)
+        }
+      }
+
+      let absolutePaths: [FilePath] = [
+        #"C:\"#,
+        #"C:/"#,
+        #"C:\foo"#,
+        #"C:/foo"#,
+        #"\\server\"#,
+        #"//server"#,
+        #"\\server\share"#,
+        #"//server/share/foo"#,
+        #"\\?\C:\foo"#,
+        #"\\?\UNC\server\share\foo"#,
+      ]
+      for path in absolutePaths {
+        XCTAssertFalse(path.isRelative)
+        XCTAssertTrue(path.isAbsolute)
+        XCTAssertNoThrow { let _ = try WebURL(filePath: path) }
+      }
+    }
+  }
+
+#endif  // os(Windows)
+
+
+// --------------------------------------------
+// MARK: - POSIX: Test specifications
+// --------------------------------------------
+
+
+#if !os(Windows)
+
+  /// A FilePath abstraction for SystemFilePathTests.
+  /// Requirements reflect the minimum API available in System.framework (macOS 11/iOS 14).
+  ///
+  private protocol POSIXFilePathProtocol: ExpressibleByStringLiteral {
+
+    init(cString: UnsafePointer<CChar>)
+    func withCString<T>(_ body: (UnsafePointer<CChar>) throws -> T) rethrows -> T
+    var length: Int { get }
+
+    init(url: WebURL) throws
+    func toURL() throws -> WebURL
+
+    func toString() -> String
+  }
+
+  /// A FilePath abstraction for SystemFilePathTests.
+  /// Requirements reflect APIs added to System.framework on macOS 12/iOS 15.
+  ///
+  private protocol POSIXFilePathProtocolV2: POSIXFilePathProtocol {
+    var isAbsolute: Bool { get }
+    var isRelative: Bool { get }
+  }
+
+  /// Tests for WebURL <-> FilePath conversion on systems with POSIX-style paths.
+  /// Test implementations are generic so they can be executed against both SystemPackage and System.framework.
+  ///
+  private struct POSIXFilePathTestSpecs<PathType: POSIXFilePathProtocol> {
+
+    static func testASCII() throws {
+
+      // Start with an ASCII file path.
+      let filePath: PathType = "/tmp/foo/bar.txt"
+      filePath.withCString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x2F /* / */, 0x74 /* t */, 0x6D /* m */, 0x70 /* p */,
+            0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0x6F /* o */,
+            0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+            0x2E /* . */, 0x74 /* t */, 0x78 /* x */, 0x74 /* t */,
+          ]
+        )
+      }
+      XCTAssertEqual(filePath.toString(), "/tmp/foo/bar.txt")
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      let fileURL = try filePath.toURL()
+      XCTAssertEqual(fileURL.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      let filePath2 = try PathType(url: fileURL)
+      filePath.withCString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withCString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try filePath2.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    static func testUnicode() throws {
+
+      // Start with a Unicode file path.
+      let filePath: PathType = "/tmp/f🦆o/b🏆🏎r.💩"
+      filePath.withCString {
+        // swift-format-ignore
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x2F /* / */, 0x74 /* t */, 0x6D /* m */, 0x70 /* p */,
+            0x2F /* / */, 0x66 /* f */, 0xF0, 0x9F, 0xA6, 0x86 /* 🦆 */, 0x6F /* o */,
+            0x2F /* / */, 0x62 /* b */, 0xF0, 0x9F, 0x8F, 0x86 /* 🏆 */, 0xF0, 0x9F, 0x8F, 0x8E /* 🏎 */, 0x72 /* r */,
+            0x2E /* . */, 0xF0, 0x9F, 0x92, 0xA9 /* 💩 */,
+          ].map { CChar(bitPattern: $0) }
+        )
+      }
+      XCTAssertEqual(filePath.toString(), "/tmp/f🦆o/b🏆🏎r.💩")
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      let fileURL = try filePath.toURL()
+      XCTAssertEqual(fileURL.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(
+        fileURL, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      let filePath2 = try PathType(url: fileURL)
+      filePath.withCString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withCString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try filePath2.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(
+        fileURL2, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL2.pathComponents.count, 3)
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    static func testUnpairedSurrogateInURL() throws {
+
+      let unpairedSurrogate: [UInt8] = [
+        0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+      ]
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try PathType(url: fileURL)
+      filePath.withCString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, unpairedSurrogate)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try filePath.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    static func testUnpairedSurrogateInFilePath() throws {
+
+      let unpairedSurrogate: [CChar] = [
+        0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+        0x00 as UInt8,
+      ].map { CChar(bitPattern: $0) }
+
+      // Start with a file path containing a UTF-8-encoded unpaired surrogate.
+      let filePath = PathType(cString: unpairedSurrogate)
+
+      // Use WebURL(filePath: FilePath) to create a file URL.
+      let fileURL = try filePath.toURL()
+      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath(url: WebURL) to reconstruct the file path exactly.
+      let filePath2 = try PathType(url: fileURL)
+      filePath.withCString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withCString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try filePath.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    static func testLatin1() throws {
+
+      let latin1: [UInt8] = [
+        0x2F /* / */, 0x63 /* c */, 0x61 /* a */, 0x66 /* f */, 0xE9 /* é */, 0xDD /* Ý */,
+      ]
+      XCTAssertEqual(String(decoding: latin1, as: UTF8.self), "/caf��")
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
+      XCTAssertEqual(fileURL.pathComponents.count, 1)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try PathType(url: fileURL)
+      filePath.withCString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, latin1)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try filePath.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/caf%E9%DD")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    static func testGreek() throws {
+
+      let greek: [UInt8] = [
+        0x2F /* / */, 0x68 /* h */, 0x69 /* i */, 0xE1 /* α */, 0xE2 /* β */, 0xE3 /* γ */,
+      ]
+      XCTAssertEqual(String(decoding: greek, as: UTF8.self), "/hi���")
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.pathComponents.count, 1)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try PathType(url: fileURL)
+      filePath.withCString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, greek)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try filePath.toURL()
+      XCTAssertEqual(fileURL2.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    /// Make sure we agree with FilePath about which paths are absolute vs. relative.
+    static func testRelativePaths() where PathType: POSIXFilePathProtocolV2 {
+
+      do {
+        let relativePaths: [PathType] = [
+          "foo",
+          #"\foo"#,
+          #"\foo\bar\"#,
+          #"\\foo"#,
+          #"\\foo\bar\"#,
+          #"\\\foo"#,
+          #"\\\foo\bar\"#,
+        ]
+        for path in relativePaths {
+          XCTAssertTrue(path.isRelative)
+          XCTAssertFalse(path.isAbsolute)
+          XCTAssertThrowsSpecific(URLFromFilePathError.relativePath) {
+            let _ = try path.toURL()
+          }
+        }
+      }
+      do {
+        let absolutePaths: [PathType] = [
+          "/foo",
+          "/foo/bar",
+          "//foo",
+          "//foo/bar",
+          "///foo",
+          "///foo/bar",
+        ]
+        for path in absolutePaths {
+          XCTAssertFalse(path.isRelative)
+          XCTAssertTrue(path.isAbsolute)
+          XCTAssertNoThrow { let _ = try path.toURL() }
+        }
+      }
+    }
+  }
+
+
+  // --------------------------------------------
+  // MARK: - POSIX: SystemPackage tests
+  // --------------------------------------------
+
+
+  #if canImport(SystemPackage)
+    import SystemPackage
+
+    extension SystemPackage.FilePath: POSIXFilePathProtocol {
+
+      func toURL() throws -> WebURL {
+        try WebURL(filePath: self)
+      }
+      func toString() -> String {
+        String(decoding: self)
+      }
+    }
+
+    extension SystemPackage.FilePath: POSIXFilePathProtocolV2 {}
+
+    extension SystemFilePathTests {
+
+      func testASCII_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testASCII()
+      }
+
+      func testUnicode_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testUnicode()
+      }
+
+      func testUnpairedSurrogateInURL_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testUnpairedSurrogateInURL()
+      }
+
+      func testUnpairedSurrogateInFilePath_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testUnpairedSurrogateInFilePath()
+      }
+
+      func testLatin1_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testLatin1()
+      }
+
+      func testGreek_package() throws {
+        try POSIXFilePathTestSpecs<SystemPackage.FilePath>.testGreek()
+      }
+
+      func testRelativePaths_package() {
+        POSIXFilePathTestSpecs<SystemPackage.FilePath>.testRelativePaths()
+      }
+    }
+  #endif  // canImport(SystemPackage)
+
+
+  // --------------------------------------------
+  // MARK: - POSIX: System.framework tests
+  // --------------------------------------------
+
+
+  #if canImport(System)
+    import System
+
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+    extension System.FilePath: POSIXFilePathProtocol {
+
+      func toURL() throws -> WebURL {
+        try WebURL(filePath: self)
+      }
+      func toString() -> String {
+        String(decoding: self)
+      }
+    }
+
+    // Requires beta SDK:
+    // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    // extension System.FilePath: POSIXFilePathProtocolV2 {}
+    // + add testRelativePaths_framework
+
+    extension SystemFilePathTests {
+
+      func testASCII_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testASCII()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+
+      func testUnicode_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testUnicode()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+
+      func testUnpairedSurrogateInURL_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInURL()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+
+      func testUnpairedSurrogateInFilePath_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInFilePath()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+
+      func testLatin1_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testLatin1()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+
+      func testGreek_framework() throws {
+        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+          try POSIXFilePathTestSpecs<System.FilePath>.testGreek()
+        } else {
+          try XCTSkipIf(true)
+        }
+      }
+    }
+  #endif  // canImport(System)
+
+#endif  // !os(Windows)

--- a/Tests/WebURLSystemExtrasTests/Utils.swift
+++ b/Tests/WebURLSystemExtrasTests/Utils.swift
@@ -1,0 +1,79 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import WebURL
+
+/// Asserts that two sequences contain the same elements in the same order.
+///
+func XCTAssertEqualElements<Left: Sequence, Right: Sequence>(
+  _ left: Left, _ right: Right, file: StaticString = #file, line: UInt = #line
+) where Left.Element == Right.Element, Left.Element: Equatable {
+  XCTAssertTrue(left.elementsEqual(right), file: file, line: line)
+}
+
+/// Asserts that a closure throws a particular error.
+///
+func XCTAssertThrowsSpecific<E>(
+  _ expectedError: E, file: StaticString = #file, line: UInt = #line, _ body: () throws -> Void
+) where E: Error, E: Equatable {
+  do {
+    try body()
+    XCTFail("Expected an error to be thrown")
+  } catch let error as E {
+    XCTAssertEqual(error, expectedError)
+  } catch {
+    XCTFail("Unexpected error \(error)")
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - WebURL test utilities
+// --------------------------------------------
+
+
+/// Checks that the given URL returns precisely the same value when its serialized representation is re-parsed.
+///
+func XCTAssertURLIsIdempotent(_ url: WebURL) {
+  var serialized = url.serialized
+  serialized.makeContiguousUTF8()
+  guard let reparsed = WebURL(serialized) else {
+    XCTFail("Failed to reparse URL string: \(serialized)")
+    return
+  }
+  // Check that the URLStructure (i.e. code-unit offsets, flags, etc) are the same.
+  XCTAssertTrue(url.storage.structure.describesSameStructure(as: reparsed.storage.structure))
+  // Check that the code-units are the same.
+  XCTAssertEqualElements(url.utf8, reparsed.utf8)
+  // Triple check: check that the serialized representations are the same.
+  XCTAssertEqual(serialized, reparsed.serialized)
+}
+
+/// Checks the component values of the given URL. Any components not specified are checked to have a `nil` value.
+///
+func XCTAssertURLComponents(
+  _ url: WebURL, scheme: String, username: String? = nil, password: String? = nil, hostname: String? = nil,
+  port: Int? = nil, path: String, query: String? = nil, fragment: String? = nil
+) {
+  XCTAssertEqual(url.scheme, scheme)
+  XCTAssertEqual(url.username, username)
+  XCTAssertEqual(url.password, password)
+  XCTAssertEqual(url.hostname, hostname)
+  XCTAssertEqual(url.port, port)
+  XCTAssertEqual(url.path, path)
+  XCTAssertEqual(url.query, query)
+  XCTAssertEqual(url.fragment, fragment)
+}

--- a/Tests/WebURLTests/FilePathTests.swift
+++ b/Tests/WebURLTests/FilePathTests.swift
@@ -108,7 +108,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), "/hi")
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .posix)
       }
     }
@@ -122,7 +122,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), "/hi")
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(includesNulls, format: .posix)
       }
     }
@@ -246,7 +246,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), #"C:\hi"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .windows)
       }
     }
@@ -261,7 +261,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), #"C:\hi"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(includesNulls, format: .windows)
       }
     }
@@ -382,7 +382,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"\\caf��\hi\bye\"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(latin1, format: .windows)
       }
     }
@@ -397,7 +397,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"\\ca���\hi\bye\"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
       }
     }
@@ -405,7 +405,7 @@ extension FilePathTests {
     // Currently, all Unicode (including valid Unicode) is banned from UNC server names because we don't have IDNA.
     do {
       let unicode = #"\\🦆\share\bread\"#
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(unicode.utf8, format: .windows)
       }
     }
@@ -425,7 +425,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), #"\\?\C:\hi"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .windows)
       }
     }
@@ -441,7 +441,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), #"\\?\C:\hi"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.nullBytes) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
         let _ = try WebURL.fromFilePathBytes(includesNulls, format: .windows)
       }
     }
@@ -565,7 +565,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"\\?\UNC\caf��\hi\bye\"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(latin1, format: .windows)
       }
     }
@@ -582,7 +582,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"\\?\UNC\ca���\hi\bye\"#)
 
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
       }
     }
@@ -590,7 +590,7 @@ extension FilePathTests {
     // Currently, all Unicode (including valid Unicode) is banned from UNC server names because we don't have IDNA.
     do {
       let unicode = #"\\?\UNC\🦆\share\bread\"#
-      XCTAssertThrowsSpecific(FilePathToURLError.invalidHostname) {
+      XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
         let _ = try WebURL.fromFilePathBytes(unicode.utf8, format: .windows)
       }
     }


### PR DESCRIPTION
1. I'll also add a `WebURL(filePath: StringProtocol)` version, but not a corresponding way to reconstruct the file path as a `String`. It's not entirely pleasing to have this asymmetry in the API design, but it makes sense because while a `String` may be a valid _source_ of a file path, it is not necessarily a valid container to store a path in.

    It's also kind of necessary because of Windows. Currently, `WebURL(filePath: #"C:\Windows\"#)` will use `FilePath`'s `ExpressibleByStringLiteral` conformance, which will transcode the string's UTF-8 data to UTF-16, only for the `WebURL` initializer to transcode it straight back to UTF-8 again 😵

    To avoid that double-conversion, we need to add a `String` overload.

2. I'm going to mess around a bit and see if I can maybe support _both_ `System.FilePath` and `SystemPackage.FilePath`.