### PR TITLE
[Experiment] system framework

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -19,20 +19,48 @@ import PackageDescription
 let package = Package(
   name: "swift-url",
   products: [
+    // Core functionality.
     .library(name: "WebURL", targets: ["WebURL"]),
+
+    // Integration with swift-system.
+    // FIXME: This should become a cross-import overlay once they exist and are supported by SwiftPM.
+    .library(name: "WebURLSystemExtras", targets: ["WebURLSystemExtras"]),
+
+    // Test support library.
+    // Various infrastructure components to run the URL web-platform-tests and other tests contained in JSON files.
+    // Used by https://github.com/karwa/swift-url-tools to provide a GUI test runner.
     .library(name: "WebURLTestSupport", targets: ["WebURLTestSupport"]),
   ],
   dependencies: [
-    // Swift-checkit for testing protocol conformances.
+    // swift-system for WebURLSystemExtras.
+    // FIXME: Move to a tagged release which includes https://github.com/apple/swift-system/pull/51
+    .package(url: "https://github.com/apple/swift-system.git", .branch("main")),
+
+    // swift-checkit for testing protocol conformances. Test-only dependency.
     .package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", from: "0.0.2"),
   ],
   targets: [
-    .target(name: "WebURL"),
-    .target(name: "WebURLTestSupport", dependencies: ["WebURL"]),
+    // Products.
+    .target(
+      name: "WebURL"
+    ),
+    .target(
+      name: "WebURLSystemExtras",
+      dependencies: ["WebURL", .product(name: "SystemPackage", package: "swift-system")]
+    ),
+    .target(
+      name: "WebURLTestSupport",
+      dependencies: ["WebURL"]
+    ),
+		// Tests.
     .testTarget(
       name: "WebURLTests",
       dependencies: ["WebURL", "WebURLTestSupport", "Checkit"],
       resources: [.copy("Resources")]
+    ),
+    .testTarget(
+      name: "WebURLSystemExtrasTests",
+      dependencies: ["WebURLSystemExtras", "WebURL", .product(name: "SystemPackage", package: "swift-system")]
     ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,9 @@ let package = Package(
     ),
     .target(
       name: "WebURLSystemExtras",
-      dependencies: ["WebURL", .product(name: "SystemPackage", package: "swift-system")]
+      dependencies: ["WebURL", .product(name: "SystemPackage", package: "swift-system", condition: .when(platforms: [
+        .android, .linux, .wasi, .windows
+      ]))]
     ),
     .target(
       name: "WebURLTestSupport",

--- a/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
+++ b/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
@@ -1,0 +1,333 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SystemPackage
+import WebURL
+
+// --------------------------------------------
+// MARK: - SystemPackage interface
+// --------------------------------------------
+
+
+extension WebURL {
+
+  /// Creates a `file:` URL representation of the given `FilePath`.
+  ///
+  /// The given path must be absolute and must not contain any components which traverse to their parent directories (`..` components).
+  /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path if it is not.
+  /// Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `..` components.
+  ///
+  /// - parameters:
+  ///   - filePath: The file path from which to create the file URL.
+  ///
+  /// - throws: `FilePathToURLError`
+  ///
+  public init(filePath: SystemPackage.FilePath) throws {
+    self = try filePath.withPlatformString { platformStr in
+      try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
+        guard let mbStr = $0 else { throw FilePathToURLError.transcodingFailure }
+        precondition(mbStr.last == 0, "Expected a null-terminated string")
+        return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+      }
+    }
+  }
+}
+
+extension SystemPackage.FilePath {
+
+  /// Reconstructs a `FilePath` from its URL representation.
+  ///
+  /// The given URL must be a `file:` URL representation of an absolute path according to this system's path format.
+  /// The resulting `FilePath` is both absolute and lexically normalized.
+  ///
+  /// On Windows, the reconstructed path is first interpreted as UTF-8. Should it not contain valid UTF-8, it will be interpreted
+  /// using the system's active code-page and converted to its Unicode representation.
+  ///
+  /// - parameters:
+  ///   - url: The file URL from which to reconstruct the file path.
+  ///
+  /// - throws: `URLToFilePathError`
+  ///
+  public init(url: WebURL) throws {
+    self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+      try PlatformStringConversions.fromMultiByte($0) {
+        guard let platformString = $0 else { throw URLToFilePathError.transcodingFailure }
+        return FilePath(platformString: platformString.baseAddress!)
+      }
+    }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - System.framework interface
+// --------------------------------------------
+// The same API as for SystemPackage, but using C strings rather than 'platform strings'.
+// On Darwin, which is the only platform family with binary 'System' modules, they are the same thing.
+//
+// This technically means that SystemPackage is an entirely optional dependency on Darwin platforms,
+// depending on deployment target, but SwiftPM has some difficulty with that. We can't make dependencies
+// conditional based on deployment target _version_, and even if we drop older systems,
+// we can't make it optional for WebURLSystemExtras but required for WebURLSystemExtrasTests.
+
+
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && canImport(System)
+  import System
+
+  @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+  extension WebURL {
+
+    /// Creates a `file:` URL representation of the given `FilePath`.
+    ///
+    /// The given path must be absolute and must not contain any components which traverse to their parent directories (`..` components).
+    /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path if it is not.
+    /// Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `..` components.
+    ///
+    /// - parameters:
+    ///   - filePath: The file path from which to create the file URL.
+    ///
+    /// - throws: `FilePathToURLError`
+    ///
+    public init(filePath: System.FilePath) throws {
+      self = try filePath.withCString { platformStr in
+        try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
+          guard let mbStr = $0 else { throw FilePathToURLError.transcodingFailure }
+          precondition(mbStr.last == 0, "Expected a null-terminated string")
+          return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+        }
+      }
+    }
+  }
+
+  @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+  extension System.FilePath {
+
+    /// Reconstructs a `FilePath` from its URL representation.
+    ///
+    /// The given URL must be a `file:` URL representation of an absolute path according to this system's path format.
+    /// The resulting `FilePath` is both absolute and lexically normalized.
+    ///
+    /// On Windows, the reconstructed path is first interpreted as UTF-8. Should it not contain valid UTF-8, it will be interpreted
+    /// using the system's active code-page and converted to its Unicode representation.
+    ///
+    /// - parameters:
+    ///   - url: The file URL from which to reconstruct the file path.
+    ///
+    /// - throws: `URLToFilePathError`
+    ///
+    public init(url: WebURL) throws {
+      self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+        try PlatformStringConversions.fromMultiByte($0) {
+          guard let platformString = $0 else { throw URLToFilePathError.transcodingFailure }
+          return FilePath(cString: platformString.baseAddress!)
+        }
+      }
+    }
+  }
+#endif
+
+
+// --------------------------------------------
+// MARK: - Platform string conversions
+// --------------------------------------------
+
+
+private protocol PlatformStringConversionsProtocol {
+
+  /// Converts a null-terminated buffer of platform characters to a null-terminated buffer of bytes.
+  ///
+  /// If the platform string is known to contain textual code-points, the buffer passed to `body` will be encoded with UTF-8.
+  ///
+  static func toMultiByte<ResultType>(
+    _ platformString: UnsafeBufferPointer<CInterop.PlatformChar>,
+    _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+  ) rethrows -> ResultType
+
+  /// Converts a null-terminated buffer of bytes to a null-terminated platform string.
+  ///
+  /// If the platform string requires its contents to be textual code-points, this function will attempt to infer the encoding of the bytes.
+  ///
+  static func fromMultiByte<ResultType>(
+    _ mbString: UnsafeBufferPointer<UInt8>,
+    _ body: (UnsafeBufferPointer<CInterop.PlatformChar>?) throws -> ResultType
+  ) rethrows -> ResultType
+}
+
+#if os(Windows)
+
+  import WinSDK
+
+  // Windows paths.
+  // --------------
+  // - Platform string: Unicode codepoints (UTF-16/UCS-2).
+  // - Multi-byte string: Depends.
+  //                       - For `toMultiByte`, we choose UTF-8.
+  //                       - For `fromMultiByte`, we expect UTF-8 but fall back to the system's code-page.
+  //
+  // This follows the principle of being strict when sending and lenient when receiving,
+  // and matches the behaviour of Chromium/Edge, so it should match the expectations of Windows users.
+  // https://github.com/chromium/chromium/blob/7417fc2bd5c8cf0e6dbf7ca4b599603c67d3edf3/net/base/filename_util.cc#L138
+  //
+  // The Windows system routines are WideCharToMultiByte and MultiByteToWideChar.
+  // The documentation for those functions includes the following note:
+  //
+  // > Starting with Windows Vista, this function fully conforms with the Unicode 4.1 specification
+  // > for UTF-8 and UTF-16. The function used on earlier operating systems encodes or decodes lone surrogate halves
+  // > or mismatched surrogate pairs. Code written in earlier versions of Windows that rely on this behavior to
+  // > encode random non-text binary data might run into problems.
+  //
+  // https://web.archive.org/web/20210225215335if_/https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar#remarks
+  //
+  // Assuming this is accurate, the standard library's built-in routines should do just as good a job.
+  // MultiByteToWideChar is still useful as a fallback for transcoding from a Windows code-page to UTF-16, however.
+  //
+  internal enum PlatformStringConversions: PlatformStringConversionsProtocol {
+
+    fileprivate static func toMultiByte<ResultType>(
+      _ plString: UnsafeBufferPointer<CInterop.PlatformChar>,
+      _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(plString.last == 0, "Expected a null-terminated string")
+
+      var transcoded = ContiguousArray<UInt8>()
+      transcoded.reserveCapacity(plString.count)
+      let invalidUnicode = transcode(plString.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: true) {
+        codeUnit in transcoded.append(codeUnit)
+      }
+      guard !invalidUnicode else {
+        return try body(nil)
+      }
+      precondition(transcoded.last == 0, "Expected the transcoded result to be null-terminated")
+      return try transcoded.withUnsafeBufferPointer(body)
+    }
+
+    fileprivate static func fromMultiByte<ResultType>(
+      _ mbString: UnsafeBufferPointer<UInt8>,
+      _ body: (UnsafeBufferPointer<CInterop.PlatformChar>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(mbString.last == 0, "Expected a null-terminated string")
+
+      var transcoded = ContiguousArray<CInterop.PlatformChar>()
+      transcoded.reserveCapacity(mbString.count)
+      let invalidUnicode = transcode(mbString.makeIterator(), from: UTF8.self, to: UTF16.self, stoppingOnError: true) {
+        codeUnit in transcoded.append(codeUnit)
+      }
+      if invalidUnicode {
+        guard mbString.withMemoryRebound(to: CChar.self, { FallbackCPtoWide($0, &transcoded) }) else {
+          return try body(nil)
+        }
+      }
+      precondition(transcoded.last == 0, "Expected the transcoded result to be null-terminated")
+      return try transcoded.withUnsafeBufferPointer(body)
+    }
+
+    /// Interprets `input` as a string in the fallback code-page and attempts to transcode it to UTF-16, storing the result in `output`.
+    ///
+    /// Note that `input` must be null-terminated, and the result will be null-terminated. `output` will have its contents replaced with the resulting string
+    /// and will be resized as needed, reusing any previously-allocated capacity if possible. If transcoding fails, the contents of `output` are unspecified.
+    ///
+    /// - returns: `true` if transcoding was successful, otherwise `false`.
+    ///
+    private static func FallbackCPtoWide(
+      _ input: UnsafeBufferPointer<CChar>,
+      _ output: inout ContiguousArray<UInt16>
+    ) -> Bool {
+
+      precondition(input.last == 0, "Expected a null-terminated string")
+
+      let codePage = Self.FallbackCodePage
+      let requiredCapacity = MultiByteToWideChar(
+        codePage, DWORD(bitPattern: MB_ERR_INVALID_CHARS),
+        input.baseAddress, Int32(input.count), nil, 0
+      )
+      guard requiredCapacity > 0 else {
+        return false
+      }
+      output.replaceSubrange(0..<output.count, with: repeatElement(0, count: Int(requiredCapacity)))
+      let stringLength = output.withUnsafeMutableBufferPointer { buffer in
+        // swift-format-ignore
+        Int(MultiByteToWideChar(
+          codePage, DWORD(bitPattern: MB_ERR_INVALID_CHARS),
+          input.baseAddress, Int32(input.count), buffer.baseAddress, Int32(buffer.count)
+        ))
+      }
+      guard stringLength == output.count else {
+        return false
+      }
+      precondition(output.last == 0, "Expected the transcoded result to be null-terminated")
+      return true
+    }
+
+    // Code-page testing.
+
+    #if DEBUG
+      private static var FallbackCodePage = UINT(bitPattern: CP_ACP)
+
+      /// Makes platform-string conversions fall back to interpreting bytes using the given code-page,
+      /// rather than the system's active code-page, for the duration of `body`.
+      ///
+      internal static func simulatingActiveCodePage<T>(
+        _ newCodePage: UINT, _ body: () throws -> T
+      ) rethrows -> T {
+
+        let previousCodePage = FallbackCodePage
+        FallbackCodePage = newCodePage
+        defer {
+          FallbackCodePage = previousCodePage
+        }
+        return try body()
+      }
+    #else
+      private static let FallbackCodePage = UINT(bitPattern: CP_ACP)
+    #endif
+  }
+
+#else
+
+  // POSIX paths.
+  // ------------
+  // - Platform string: opaque bytes.
+  // - Multi-byte string: opaque bytes.
+  //
+  // POSIX platform strings are natively multi-byte. We can't assume that they contain Unicode text,
+  // so we couldn't transcode them even if we wanted to.
+  //
+  // Essentially this conversion, then, papers over signed/unsigned char from the platform string
+  // and normalizes them as UInt8. Which is what the WebURL functions accept/return, because they treat
+  // the string as semi-opaque octets and don't care about the sign of the numeric value.
+  //
+  enum PlatformStringConversions: PlatformStringConversionsProtocol {
+
+    static func toMultiByte<ResultType>(
+      _ platformString: UnsafeBufferPointer<CInterop.PlatformChar>,
+      _ body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(platformString.last == 0, "Expected a null-terminated string")
+      return try platformString.withMemoryRebound(to: UInt8.self, body)
+    }
+
+    static func fromMultiByte<ResultType>(
+      _ mbString: UnsafeBufferPointer<UInt8>,
+      _ body: (UnsafeBufferPointer<CInterop.PlatformChar>?) throws -> ResultType
+    ) rethrows -> ResultType {
+
+      precondition(mbString.last == 0, "Expected a null-terminated string")
+      return try mbString.withMemoryRebound(to: CInterop.PlatformChar.self, body)
+    }
+  }
+
+#endif

--- a/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
+++ b/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
@@ -1,0 +1,546 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SystemPackage
+import WebURL
+import XCTest
+
+@testable import WebURLSystemExtras
+
+final class SystemFilePathTests: XCTestCase {}
+
+#if os(Windows)
+
+  extension SystemFilePathTests {
+
+    func testASCII() throws {
+
+      // Start with an ASCII file path.
+      let filePath: FilePath = #"C:\foo\bar.txt"#
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x0043 /* C */, 0x003A /* : */,
+            0x005C /* \ */, 0x0066 /* f */, 0x006F /* o */, 0x006F /* o */,
+            0x005C /* \ */, 0x0062 /* b */, 0x0061 /* a */, 0x0072 /* r */,
+            0x002E /* . */, 0x0074 /* t */, 0x0078 /* x */, 0x0074 /* t */,
+          ]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\foo\bar.txt"#)
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL.init(FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnicode() throws {
+
+      // Start with a Unicode file path.
+      let filePath: FilePath = #"C:\f🦆o\b🏆🏎r.💩"#
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x0043 /* C */, 0x003A /* : */,
+            0x005C /* \ */, 0x0066 /* f */, 0xD83E, 0xDD86 /* 🦆 */, 0x006F /* o */,
+            0x005C /* \ */, 0x0062 /* b */, 0xD83C, 0xDFC6 /* 🏆 */, 0xD83C, 0xDFCE /* 🏎 */, 0x0072 /* r */,
+            0x002E /* . */, 0xD83D, 0xDCA9 /* 💩 */,
+          ]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\f🦆o\b🏆🏎r.💩"#)
+
+      // Use WebURL.init(FilePath) to create a file URL. Should be transcoded to UTF-8.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(
+        fileURL, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly. Should be transcoded back to UTF-16.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL.init(FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(
+        fileURL2, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL2.pathComponents.count, 3)
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnpairedSurrogateInURL() throws {
+
+      let unpairedSurrogate: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x5C /* \ */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // TODO: It is questionable what we should do here. There are 3 possibile courses of action:
+      //
+      // 1. As usual, interpret the bytes as non-UTF-8 and fall back to the system's code-page.
+      // 2. Recognize lone surrogates as being botched UTF-8, don't fall back to system code-page.
+      //   2a. We could be strict and fail to transcode to UTF-16, or
+      //   2b. We could be lenient and decode them anyway.
+
+      // If the system's active code-page is UTF-8, we should fail in any case.
+      XCTAssertThrowsSpecific(URLToFilePathError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(65001) { try FilePath(url: fileURL) }
+      }
+
+      // Code page 437 = IBM extended ASCII. Every code-unit is defined.
+      XCTAssertNoThrow {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(437) { try FilePath(url: fileURL) }
+      }
+    }
+
+    func testUnpairedSurrogateInFilePath() throws {
+
+      let unpairedSurrogate: [UInt16] = [
+        0x0043 /* C */, 0x003A /* : */,
+        0x005C /* \ */, 0x0066 /* f */, 0x006F /* o */, 0x0D800, 0x006F /* o */,
+        0x005C /* \ */, 0x0062 /* b */, 0x0061 /* a */, 0x0072 /* r */,
+        0x0000,
+      ]
+      let filePath = FilePath(platformString: unpairedSurrogate)
+      XCTAssertThrowsSpecific(FilePathToURLError.transcodingFailure) { let _ = try WebURL(filePath: filePath) }
+    }
+
+    func testFallbackCodePage_latin1() throws {
+
+      let latin1: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x63 /* c */, 0x61 /* a */, 0x66 /* f */, 0xE9 /* é */, 0xDD /* Ý */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path.
+      // Since the path is not valid UTF-8, it will be transcoded using the system's code-page.
+      let filePath = try PlatformStringConversions.simulatingActiveCodePage(1252) { try FilePath(url: fileURL) }
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [0x0043, 0x003A, 0x005C, 0x0063, 0x0061, 0x0066, 0x00E9, 0x00DD]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\caféÝ"#)
+
+      // Transcoding failures will be caught.
+      // 1255 = Hebrew, where the byte 0xDD is undefined.
+      XCTAssertThrowsSpecific(URLToFilePathError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(1255) { try FilePath(url: fileURL) }
+      }
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
+      // the contents should be transcoded to UTF-8.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/caf%C3%A9%C3%9D")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/caf%C3%A9%C3%9D")
+      XCTAssertEqual(fileURL2.pathComponents.count, 2)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      // Since the URL contents are now valid UTF-8, the system code-page shouldn't matter.
+      let filePath2 = try PlatformStringConversions.simulatingActiveCodePage(1255) { try FilePath(url: fileURL2) }
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+    }
+
+    func testFallbackCodePage_greek() throws {
+
+      let greek: [UInt8] = [
+        0x43 /* C */, 0x3A /* : */,
+        0x5C /* \ */, 0x68 /* h */, 0x69 /* i */, 0xE1 /* α */, 0xE2 /* β */, 0xE3 /* γ */,
+      ]
+
+      // Create a file URL from the raw bytes.
+      let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
+      XCTAssertEqual(fileURL.serialized, "file:///C:/hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path.
+      // Since the path is not valid UTF-8, it will be transcoded using the system's code-page.
+      let filePath = try PlatformStringConversions.simulatingActiveCodePage(1253) { try FilePath(url: fileURL) }
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [0x0043, 0x003A, 0x005C, 0x0068, 0x0069, 0x03B1, 0x03B2, 0x03B3]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), #"C:\hiαβγ"#)
+
+      // Transcoding failures will be caught.
+      // 932 = Windows-31J, where the bytes 0xE? denote the start of a multi-byte sequence,
+      // meaning the sequence [0xE1, 0xE2] is nonsense.
+      XCTAssertThrowsSpecific(URLToFilePathError.transcodingFailure) {
+        let _ = try PlatformStringConversions.simulatingActiveCodePage(932) { try FilePath(url: fileURL) }
+      }
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
+      // the contents should be transcoded to UTF-8.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///C:/hi%CE%B1%CE%B2%CE%B3")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/hi%CE%B1%CE%B2%CE%B3")
+      XCTAssertEqual(fileURL2.pathComponents.count, 2)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      // Since the URL contents are now valid UTF-8, the system code-page shouldn't matter.
+      let filePath2 = try PlatformStringConversions.simulatingActiveCodePage(932) { try FilePath(url: fileURL2) }
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+    }
+
+    /// Make sure we agree with FilePath about which paths are absolute vs. relative.
+    func testRelativePaths() {
+
+      let relativePaths: [FilePath] = [
+        #"C:"#,
+        #"C:foo"#,
+        #"foo"#,
+        #"\foo"#,
+        #"/foo"#,
+      ]
+      for path in relativePaths {
+        XCTAssertTrue(path.isRelative)
+        XCTAssertFalse(path.isAbsolute)
+        XCTAssertThrowsSpecific(FilePathToURLError.relativePath) {
+          let _ = try WebURL(filePath: path)
+        }
+      }
+
+      let absolutePaths: [FilePath] = [
+        #"C:\"#,
+        #"C:/"#,
+        #"C:\foo"#,
+        #"C:/foo"#,
+        #"\\server\"#,
+        #"//server"#,
+        #"\\server\share"#,
+        #"//server/share/foo"#,
+        #"\\?\C:\foo"#,
+        #"\\?\UNC\server\share\foo"#,
+      ]
+      for path in absolutePaths {
+        XCTAssertFalse(path.isRelative)
+        XCTAssertTrue(path.isAbsolute)
+        XCTAssertNoThrow { let _ = try WebURL(filePath: path) }
+      }
+    }
+  }
+
+#else
+
+  extension SystemFilePathTests {
+
+    func testASCII() throws {
+
+      // Start with an ASCII file path.
+      let filePath: FilePath = "/tmp/foo/bar.txt"
+      filePath.withPlatformString {
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x2F /* / */, 0x74 /* t */, 0x6D /* m */, 0x70 /* p */,
+            0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0x6F /* o */,
+            0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+            0x2E /* . */, 0x74 /* t */, 0x78 /* x */, 0x74 /* t */,
+          ]
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), "/tmp/foo/bar.txt")
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL.init(FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnicode() throws {
+
+      // Start with a Unicode file path.
+      let filePath: FilePath = "/tmp/f🦆o/b🏆🏎r.💩"
+      filePath.withPlatformString {
+        // swift-format-ignore
+        XCTAssertEqualElements(
+          UnsafeBufferPointer(start: $0, count: filePath.length),
+          [
+            0x2F /* / */, 0x74 /* t */, 0x6D /* m */, 0x70 /* p */,
+            0x2F /* / */, 0x66 /* f */, 0xF0, 0x9F, 0xA6, 0x86 /* 🦆 */, 0x6F /* o */,
+            0x2F /* / */, 0x62 /* b */, 0xF0, 0x9F, 0x8F, 0x86 /* 🏆 */, 0xF0, 0x9F, 0x8F, 0x8E /* 🏎 */, 0x72 /* r */,
+            0x2E /* . */, 0xF0, 0x9F, 0x92, 0xA9 /* 💩 */,
+          ].map { CChar(bitPattern: $0) }
+        )
+      }
+      XCTAssertEqual(String(decoding: filePath), "/tmp/f🦆o/b🏆🏎r.💩")
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(
+        fileURL, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL.pathComponents.count, 3)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Use WebURL.init(FilePath) to create another file URL which should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath2)
+      XCTAssertEqual(fileURL2.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(
+        fileURL2, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
+      )
+      XCTAssertEqual(fileURL2.pathComponents.count, 3)
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnpairedSurrogateInURL() throws {
+
+      let unpairedSurrogate: [UInt8] = [
+        0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+      ]
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, unpairedSurrogate)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testUnpairedSurrogateInFilePath() throws {
+
+      let unpairedSurrogate: [CChar] = [
+        0x2F /* / */, 0x66 /* f */, 0x6F /* o */, 0xED, 0xA0, 0x80, 0x6F /* o */,
+        0x2F /* / */, 0x62 /* b */, 0x61 /* a */, 0x72 /* r */,
+        0x00 as UInt8,
+      ].map { CChar(bitPattern: $0) }
+
+      // Start with a file path containing a UTF-8-encoded unpaired surrogate.
+      let filePath = FilePath(platformString: unpairedSurrogate)
+
+      // Use WebURL.init(FilePath) to create a file URL.
+      let fileURL = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.pathComponents.count, 2)
+
+      // Use FilePath.init(WebURL) to reconstruct the file path exactly.
+      let filePath2 = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        let filePath1Chars = UnsafeBufferPointer(start: $0, count: filePath.length)
+        filePath2.withPlatformString {
+          let filePath2Chars = UnsafeBufferPointer(start: $0, count: filePath2.length)
+          XCTAssertEqualElements(filePath1Chars, filePath2Chars)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testLatin1() throws {
+
+      let latin1: [UInt8] = [
+        0x2F /* / */, 0x63 /* c */, 0x61 /* a */, 0x66 /* f */, 0xE9 /* é */, 0xDD /* Ý */,
+      ]
+      XCTAssertEqual(String(decoding: latin1, as: UTF8.self), "/caf��")
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
+      XCTAssertEqual(fileURL.pathComponents.count, 1)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, latin1)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///caf%E9%DD")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/caf%E9%DD")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    func testGreek() throws {
+
+      let greek: [UInt8] = [
+        0x2F /* / */, 0x68 /* h */, 0x69 /* i */, 0xE1 /* α */, 0xE2 /* β */, 0xE3 /* γ */,
+      ]
+      XCTAssertEqual(String(decoding: greek, as: UTF8.self), "/hi���")
+
+      // Create a file URL from the raw bytes. No UTF-8 validation is performed.
+      let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
+      XCTAssertEqual(fileURL.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL)
+      XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.pathComponents.count, 1)
+
+      // Create a file path from the URL. Should preserve the bytes exactly.
+      let filePath = try FilePath(url: fileURL)
+      filePath.withPlatformString {
+        UnsafeBufferPointer(start: $0, count: filePath.length).withMemoryRebound(to: UInt8.self) { filePathChars in
+          XCTAssertEqualElements(filePathChars, greek)
+        }
+      }
+
+      // Create another file URL from the path. Should exactly match the first one.
+      let fileURL2 = try WebURL(filePath: filePath)
+      XCTAssertEqual(fileURL2.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertURLIsIdempotent(fileURL2)
+      XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL, fileURL2)
+    }
+
+    /// Make sure we agree with FilePath about which paths are absolute vs. relative.
+    func testRelativePaths() {
+
+      do {
+        let path: FilePath = "foo"
+        XCTAssertTrue(path.isRelative)
+        XCTAssertFalse(path.isAbsolute)
+        XCTAssertThrowsSpecific(FilePathToURLError.relativePath) {
+          let _ = try WebURL(filePath: path)
+        }
+      }
+      do {
+        let path: FilePath = "/foo"
+        XCTAssertFalse(path.isRelative)
+        XCTAssertTrue(path.isAbsolute)
+        XCTAssertNoThrow {
+          let _ = try WebURL(filePath: path)
+        }
+      }
+    }
+  }
+
+#endif

--- a/Tests/WebURLSystemExtrasTests/Utils.swift
+++ b/Tests/WebURLSystemExtrasTests/Utils.swift
@@ -1,0 +1,79 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import WebURL
+
+/// Asserts that two sequences contain the same elements in the same order.
+///
+func XCTAssertEqualElements<Left: Sequence, Right: Sequence>(
+  _ left: Left, _ right: Right, file: StaticString = #file, line: UInt = #line
+) where Left.Element == Right.Element, Left.Element: Equatable {
+  XCTAssertTrue(left.elementsEqual(right), file: file, line: line)
+}
+
+/// Asserts that a closure throws a particular error.
+///
+func XCTAssertThrowsSpecific<E>(
+  _ expectedError: E, file: StaticString = #file, line: UInt = #line, _ body: () throws -> Void
+) where E: Error, E: Equatable {
+  do {
+    try body()
+    XCTFail("Expected an error to be thrown")
+  } catch let error as E {
+    XCTAssertEqual(error, expectedError)
+  } catch {
+    XCTFail("Unexpected error \(error)")
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - WebURL test utilities
+// --------------------------------------------
+
+
+/// Checks that the given URL returns precisely the same value when its serialized representation is re-parsed.
+///
+func XCTAssertURLIsIdempotent(_ url: WebURL) {
+  var serialized = url.serialized
+  serialized.makeContiguousUTF8()
+  guard let reparsed = WebURL(serialized) else {
+    XCTFail("Failed to reparse URL string: \(serialized)")
+    return
+  }
+  // Check that the URLStructure (i.e. code-unit offsets, flags, etc) are the same.
+  XCTAssertTrue(url.storage.structure.describesSameStructure(as: reparsed.storage.structure))
+  // Check that the code-units are the same.
+  XCTAssertEqualElements(url.utf8, reparsed.utf8)
+  // Triple check: check that the serialized representations are the same.
+  XCTAssertEqual(serialized, reparsed.serialized)
+}
+
+/// Checks the component values of the given URL. Any components not specified are checked to have a `nil` value.
+///
+func XCTAssertURLComponents(
+  _ url: WebURL, scheme: String, username: String? = nil, password: String? = nil, hostname: String? = nil,
+  port: Int? = nil, path: String, query: String? = nil, fragment: String? = nil
+) {
+  XCTAssertEqual(url.scheme, scheme)
+  XCTAssertEqual(url.username, username)
+  XCTAssertEqual(url.password, password)
+  XCTAssertEqual(url.hostname, hostname)
+  XCTAssertEqual(url.port, port)
+  XCTAssertEqual(url.path, path)
+  XCTAssertEqual(url.query, query)
+  XCTAssertEqual(url.fragment, fragment)
+}


### PR DESCRIPTION
Try to make it such that:

- On non-Darwin platforms, `WebURLSystemExtras` depends on `SystemPackage`. That's the only implementation available.
- On Darwin platforms, `WebURLSystemExtras` _does not_ depend on `SystemPackage`, but offers support for it via `canImport` if your project happens to use it. It also offers support for `System`. So whichever implementation you choose to use, it should provide URL <-> FilePath conversion utilities to match.

- `WebURLSystemExtrasTests` requires `SystemPackage`, because obviously we want to test that it works. It will also test against `System` if the system has it, because we should test that nothing is different.

I have absolute no idea if this is supposed to work. On older toolchains, SwiftPM will not see that the tests require `SystemPackage`, so `canImport` will return `false` and only the `System` tests will run. If you have a downstream project which depends on `WebURLSystemExtras` and `SystemPackage`, `canImport` will again return `false` and nothing will work.

BUT - on newer toolchains, everything is different. SwiftPM _does_ see the dependency, `canImport` returns `true`, and both the tests and downstream projects just work.

So who knows? 🤷‍♂️