### PR TITLE
[GHA] Update to macOS 11 for GitHub Actions. macOS-latest is still 10.15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It's complicated, apparently.

See: https://github.com/actions/virtual-environments