### PR TITLE
[Standard][JSModel] Make override hostname state return early if a port is given.

### DIFF
--- a/Sources/WebURL/WebURL+JSModel.swift
+++ b/Sources/WebURL/WebURL+JSModel.swift
@@ -262,6 +262,10 @@ extension WebURL.JSModel {
       guard let hostnameEnd = findEndOfHostnamePrefix(filtered, scheme: schemeKind, callback: &callback) else {
         return
       }
+      // Unlike other delimiters, including a port causes the entire operation to fail.
+      if hostnameEnd < filtered.endIndex, filtered[hostnameEnd] == ASCII.colon.codePoint {
+        return
+      }
       try? swiftModel.utf8.setHostname(filtered[..<hostnameEnd])
     }
   }

--- a/Tests/WebURLTests/Resources/setters_tests.json
+++ b/Tests/WebURLTests/Resources/setters_tests.json
@@ -1153,24 +1153,24 @@
             }
         },
         {
-            "comment": "Stuff after a : delimiter is ignored",
+            "comment": ": delimiter invalidates entire value",
             "href": "http://example.net/path",
             "new_value": "example.com:8080",
             "expected": {
-                "href": "http://example.com/path",
-                "host": "example.com",
-                "hostname": "example.com",
+                "href": "http://example.net/path",
+                "host": "example.net",
+                "hostname": "example.net",
                 "port": ""
             }
         },
         {
-            "comment": "Stuff after a : delimiter is ignored",
+            "comment": ": delimiter invalidates entire value",
             "href": "http://example.net:8080/path",
             "new_value": "example.com:",
             "expected": {
-                "href": "http://example.com:8080/path",
-                "host": "example.com:8080",
-                "hostname": "example.com",
+                "href": "http://example.net:8080/path",
+                "host": "example.net:8080",
+                "hostname": "example.net",
                 "port": "8080"
             }
         },

--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -100,7 +100,7 @@ extension WebPlatformTests {
 // MARK: - Setters
 // --------------------------------------------
 // https://github.com/web-platform-tests/wpt/blob/master/url/resources/setters_tests.json
-// at version 050308a616a8388f1ad5d6e87eac0270fd35023f
+// at version 67a580b4a11da1dca6c1195a2b670e361e4013c9
 
 
 extension WebPlatformTests {

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -480,20 +480,31 @@ extension WebURLTests {
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Invalid hostnames.
-    url = WebURL("foo://example.com/")!
-    XCTAssertEqual(url.hostname, "example.com")
-    XCTAssertEqual(url.serialized, "foo://example.com/")
-    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("@") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
-    XCTAssertURLIsIdempotent(url)
-
-    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("/a/b/c") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
-    XCTAssertURLIsIdempotent(url)
-
-    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("[:::]") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
-    XCTAssertURLIsIdempotent(url)
+    let invalidHostnames = [
+      "@",
+      "/a/b/c",
+      "a/b/c",
+      "[:::]",
+      "example:.net",
+      "example.net:",
+      "example.net:99",
+      "example.net?something",
+      "example.net#something",
+    ]
+    let urlStrings = [
+      "foo://example.com/",
+      "https://example.com/",
+    ]
+    for urlString in urlStrings {
+      url = WebURL(urlString)!
+      for hostname in invalidHostnames {
+        XCTAssertEqual(url.hostname, "example.com")
+        XCTAssertEqual(url.serialized, urlString)
+        XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname(hostname) }
+        XCTAssertEqual(url.serialized, urlString)
+        XCTAssertURLIsIdempotent(url)
+      }
+    }
   }
 
   /// Tests the Swift model 'port' property.


### PR DESCRIPTION
Also, add more tests to the swift-model for hostnames containing delimiters for other components.
Aligns with whatwg/url ec96993653a70d063843e0198694028c63348db4