### PR TITLE
Update WPT tests as far as possible without functional changes

### DIFF
--- a/Tests/WebURLTests/Resources/additional_constructor_tests.json
+++ b/Tests/WebURLTests/Resources/additional_constructor_tests.json
@@ -861,16 +861,5 @@
     "pathname": "/",
     "search": "",
     "hash": ""
-  },
-  "[HOST]: Domain is ASCII, but a component contains invalid IDNA",
-  {
-    "input": "http://a.b.c.xn--pokxncvks",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://10.0.0.xn--pokxncvks",
-    "base": "about:blank",
-    "failure": true
   }
 ]

--- a/Tests/WebURLTests/Resources/setters_tests.json
+++ b/Tests/WebURLTests/Resources/setters_tests.json
@@ -990,6 +990,26 @@
                 "hostname": "test",
                 "port": "12"
             }
+        },
+        {
+            "comment": "Leading / is not stripped",
+            "href": "http://example.com/",
+            "new_value": "///bad.com",
+            "expected": {
+                "href": "http://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "comment": "Leading / is not stripped",
+            "href": "sc://example.com/",
+            "new_value": "///bad.com",
+            "expected": {
+                "href": "sc:///",
+                "host": "",
+                "hostname": ""
+            }
         }
     ],
     "hostname": [
@@ -1345,6 +1365,26 @@
                 "hostname": "",
                 "pathname": "//p"
             }
+        },
+        {
+            "comment": "Leading / is not stripped",
+            "href": "http://example.com/",
+            "new_value": "///bad.com",
+            "expected": {
+                "href": "http://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "comment": "Leading / is not stripped",
+            "href": "sc://example.com/",
+            "new_value": "///bad.com",
+            "expected": {
+                "href": "sc:///",
+                "host": "",
+                "hostname": ""
+            }
         }
     ],
     "port": [
@@ -1665,6 +1705,24 @@
             "expected": {
                 "href": "sc://example.net/%23",
                 "pathname": "/%23"
+            }
+        },
+        {
+            "comment": "? doesn't mess up encoding",
+            "href": "http://example.net",
+            "new_value": "/?é",
+            "expected": {
+                "href": "http://example.net/%3F%C3%A9",
+                "pathname": "/%3F%C3%A9"
+            }
+        },
+        {
+            "comment": "# doesn't mess up encoding",
+            "href": "http://example.net",
+            "new_value": "/#é",
+            "expected": {
+                "href": "http://example.net/%23%C3%A9",
+                "pathname": "/%23%C3%A9"
             }
         },
         {

--- a/Tests/WebURLTests/Resources/urltestdata.json
+++ b/Tests/WebURLTests/Resources/urltestdata.json
@@ -540,6 +540,36 @@
     "hash": ""
   },
   {
+    "input": "\\x",
+    "base": "http://example.org/foo/bar",
+    "href": "http://example.org/x",
+    "origin": "http://example.org",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "example.org",
+    "hostname": "example.org",
+    "port": "",
+    "pathname": "/x",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "\\\\x\\hello",
+    "base": "http://example.org/foo/bar",
+    "href": "http://x/hello",
+    "origin": "http://x",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "x",
+    "hostname": "x",
+    "port": "",
+    "pathname": "/hello",
+    "search": "",
+    "hash": ""
+  },
+  {
     "input": "::",
     "base": "http://example.org/foo/bar",
     "href": "http://example.org/foo/::",
@@ -3156,7 +3186,8 @@
   {
     "input": "http:/:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://user@/www.example.com",
@@ -3166,12 +3197,14 @@
   {
     "input": "http:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://@/www.example.com",
@@ -3181,17 +3214,20 @@
   {
     "input": "https:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:a:b@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/a:b@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://a:b@/www.example.com",
@@ -3201,7 +3237,8 @@
   {
     "input": "http::@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:a:@www.example.com",
@@ -3266,12 +3303,14 @@
   {
     "input": "http:@:www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/@:www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://@:www.example.com",
@@ -3644,6 +3683,17 @@
     "pathname": "/%EF%BF%BD",
     "search": "?%EF%BF%BD",
     "hash": "#%EF%BF%BD"
+  },
+  "Domain is ASCII, but a label is invalid IDNA",
+  {
+    "input": "http://a.b.c.xn--pokxncvks",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://10.0.0.xn--pokxncvks",
+    "base": "about:blank",
+    "failure": true
   },
   "Test name prepping, fullwidth input should be converted to ASCII and NOT IDN-ized. This is 'Go' in fullwidth UTF-8/UTF-16.",
   {
@@ -4677,6 +4727,140 @@
   },
   {
     "input": "non-special://a^b",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "foo://ho\u0000st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "foo://ho|st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  "Forbidden host codepoints: tabs and newlines are removed during preprocessing",
+  {
+    "input": "foo://ho\u0009st/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "foo://ho\u000Ast/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "foo://ho\u000Dst/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  "Encoded forbidden host codepoints in special URLs",
+  {
+    "input": "http://ho%00st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%09st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%20st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%23st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%2Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Est/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%40st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Bst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%7Cst/",
     "base": "about:blank",
     "failure": true
   },
@@ -6191,7 +6375,8 @@
   {
     "input": "\\\\\\.\\Y:",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "# file: drive letter cases from https://crbug.com/1078698 but lowercased",
   {
@@ -6253,7 +6438,8 @@
   {
     "input": "\\\\\\.\\y:",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "# Additional file URL tests for (https://github.com/whatwg/url/issues/405)",
   {
@@ -7320,17 +7506,20 @@
   {
     "input": "a",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "a/",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "a//",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "Bases that don't fail to parse but fail to be bases",
   {
@@ -7655,7 +7844,8 @@
     "search": "",
     "username": "joe"
   },
-  { "input": "foo://!\"$%&'()*+,-.;=_`{}~/",
+  {
+    "input": "foo://!\"$%&'()*+,-.;=_`{}~/",
     "base": "about:blank",
     "hash": "",
     "host": "!\"$%&'()*+,-.;=_`{}~",
@@ -7773,5 +7963,73 @@
     "protocol": "wss:",
     "search": "",
     "username": ""
+  },
+  "Ensure that input schemes are not ignored when resolving non-special URLs",
+  {
+    "input": "abc:rootless",
+    "base": "abc://host/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:rootless",
+    "base": "abc:/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:rootless",
+    "base": "abc:path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:/rooted",
+    "base": "abc://host/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:/rooted",
+    "password": "",
+    "pathname": "/rooted",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  "Empty query and fragment with blank should throw an error",
+  {
+    "input": "#",
+    "base": null,
+    "failure": true
+  },
+  {
+    "input": "?",
+    "base": null,
+    "failure": true
   }
 ]

--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -38,7 +38,7 @@ fileprivate func loadTestResource(name: String) -> Data? {
 // MARK: - URL Constructor
 // --------------------------------------------
 // https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json
-// at version 52e358a1209a23c42e9443641c7ed0ba23600c93
+// at version 18bb9ddd69d646a4c260eb3a0ccc0caab63dec7e
 // Adjusted to remove an invalid surrogate pair which Foundation's JSON parser refuses to parse.
 
 
@@ -48,7 +48,7 @@ extension WebPlatformTests {
     let data = loadTestResource(name: "urltestdata")!
     let testFile = try JSONDecoder().decode(WPTConstructorTest.TestFile.self, from: data)
     assert(
-      testFile.tests.count == 696,
+      testFile.tests.count == 732,
       "Incorrect number of test cases. If you updated the test list, be sure to update the expected failure indexes"
     )
 
@@ -56,19 +56,19 @@ extension WebPlatformTests {
       // These test failures are due to us not having implemented the `domain2ascii` transform,
       // often in combination with other features (e.g. with percent encoding).
       //
-      261,  // domain2ascii: (no-break, zero-width, zero-width-no-break) are name-prepped away to nothing.
-      263,  // domain2ascii: U+3002 is mapped to U+002E (dot).
-      269,  // domain2ascii: fullwidth input should be converted to ASCII and NOT IDN-ized.
-      274,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
-      275,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
-      286,  // domain2ascii: Fullwidth and escaped UTF-8 fullwidth should still be treated as IP.
-      369,  // domain2ascii: Hosts and percent-encoding.
-      370,  // domain2ascii: Hosts and percent-encoding.
-      582,  // domain2ascii: IDNA ignored code points in file URLs hosts.
-      583,  // domain2ascii: IDNA ignored code points in file URLs hosts.
+      263,  // domain2ascii: (no-break, zero-width, zero-width-no-break) are name-prepped away to nothing.
+      265,  // domain2ascii: U+3002 is mapped to U+002E (dot).
+      273,  // domain2ascii: fullwidth input should be converted to ASCII and NOT IDN-ized.
+      278,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
+      279,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
+      290,  // domain2ascii: Fullwidth and escaped UTF-8 fullwidth should still be treated as IP.
+      394,  // domain2ascii: Hosts and percent-encoding.
+      395,  // domain2ascii: Hosts and percent-encoding.
+      607,  // domain2ascii: IDNA ignored code points in file URLs hosts.
+      608,  // domain2ascii: IDNA ignored code points in file URLs hosts.
     ])
     harness.runTests(testFile)
-    XCTAssert(harness.entriesSeen == 696, "Unexpected number of tests executed.")
+    XCTAssertEqual(harness.entriesSeen, 732, "Unexpected number of tests executed.")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")
 
     let reportURL = fileURLForReport(named: "weburl_constructor_wpt.txt")

--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -79,14 +79,10 @@ extension WebPlatformTests {
   func testURLConstructor_additional() throws {
     let data = loadTestResource(name: "additional_constructor_tests")!
     let testFile = try JSONDecoder().decode(WPTConstructorTest.TestFile.self, from: data)
-    assert(
-      testFile.tests.count == 82,
-      "Incorrect number of test cases. If you updated the test list, be sure to update the expected failure indexes"
-    )
 
     var harness = WPTConstructorTest.WebURLReportHarness()
     harness.runTests(testFile)
-    XCTAssert(harness.entriesSeen == 82, "Unexpected number of tests executed.")
+    XCTAssert(harness.entriesSeen > 0, "Failed to execute any tests")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")
 
     let reportURL = fileURLForReport(named: "weburl_constructor_more.txt")
@@ -100,7 +96,7 @@ extension WebPlatformTests {
 // MARK: - Setters
 // --------------------------------------------
 // https://github.com/web-platform-tests/wpt/blob/master/url/resources/setters_tests.json
-// at version 67a580b4a11da1dca6c1195a2b670e361e4013c9
+// at version 2cfdb63014d1158fd15eb1f798f6b1610c275271
 
 
 extension WebPlatformTests {
@@ -111,7 +107,7 @@ extension WebPlatformTests {
 
     var harness = WPTSetterTest.WebURLReportHarness()
     harness.runTests(testFile)
-    XCTAssertEqual(harness.entriesSeen, 156, "Unexpected number of tests executed.")
+    XCTAssert(harness.entriesSeen > 0, "Failed to execute any tests")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")
 
     let reportURL = fileURLForReport(named: "weburl_setters_wpt.txt")
@@ -125,7 +121,7 @@ extension WebPlatformTests {
 
     var harness = WPTSetterTest.WebURLReportHarness()
     harness.runTests(testFile)
-    XCTAssertEqual(harness.entriesSeen, 5, "Unexpected number of tests executed.")
+    XCTAssert(harness.entriesSeen > 0, "Failed to execute any tests")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")
 
     let reportURL = fileURLForReport(named: "weburl_setters_more.txt")


### PR DESCRIPTION
Going further will require:

1. The fix for setting an empty path string on path-only URLs
2. Recent changes to reject numeric TLDs