### PR TITLE
[Standard update] Prevent the pathname setter from erasing the path of path-only URLs.

### DIFF
--- a/Sources/WebURL/Parser/Parser+Path.swift
+++ b/Sources/WebURL/Parser/Parser+Path.swift
@@ -216,7 +216,8 @@ extension _PathParser {
   ///
   @inlinable
   internal mutating func _flushForFinalization(
-    _ deferred: inout _DeferredPathComponent<InputString.SubSequence>?, _ state: inout _PathParserState
+    _ deferred: inout _DeferredPathComponent<InputString.SubSequence>?,
+    _ state: inout _PathParserState, _ hasAuthority: Bool
   ) {
     switch deferred {
     case .potentialWindowsDrive(let firstComponent, _):
@@ -238,7 +239,7 @@ extension _PathParser {
     }
     let needsPathSigil = deferred?.needsPathSigilWhenFlushing(state) ?? false
     _flushEmptiesAssertNotWindowsDrive(&deferred, &state)
-    if needsPathSigil {
+    if needsPathSigil, !hasAuthority {
       visitPathSigil()
     }
   }
@@ -453,7 +454,7 @@ extension _PathParser {
     }
 
     guard isInputAbsolute == false, let basePath = _basePath, basePath.startIndex < basePath.endIndex else {
-      _flushForFinalization(&deferredComponent, &state)
+      _flushForFinalization(&deferredComponent, &state, hasAuthority)
       return  // Absolute paths, and relative paths with no base URL, are finished now.
     }
     assert(basePath.first == ASCII.forwardSlash.codePoint, "Normalized non-empty base paths must start with a /")
@@ -502,7 +503,7 @@ extension _PathParser {
     }
 
     assert(remainingBasePath.isEmpty, "Normalized non-empty base paths must start with a /")
-    _flushForFinalization(&deferredComponent, &state)
+    _flushForFinalization(&deferredComponent, &state, hasAuthority)
     // Finally done!
   }
 }

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -444,7 +444,8 @@ extension ParsedURLString.ProcessedMapping {
       writer.writePathMetricsHint(pathMetrics)
       writer.writeHint(.path, maySkipPercentEncoding: !pathMetrics.needsPercentEncoding)
 
-      if pathMetrics.requiresPathSigil, hasAuthority == false {
+      if pathMetrics.requiresPathSigil {
+        assert(!hasAuthority, "Must not write path sigil if the URL has an authority sigil already")
         writer.writePathSigil()
       }
       writer.writePresizedPathUnsafely(
@@ -475,7 +476,7 @@ extension ParsedURLString.ProcessedMapping {
       writer.writePath(firstComponentLength: 1) { writer in writer(CollectionOfOne(ASCII.forwardSlash.codePoint)) }
 
     default:
-      break
+      assert(info.cannotBeABaseURL || hasAuthority, "URLs must have a path, authority, or be flagged cannot-be-a-base")
     }
 
     // 5: Query.

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -436,6 +436,7 @@ extension ParsedURLString.ProcessedMapping {
         ?? PathMetrics(
           parsing: inputString[path],
           schemeKind: schemeKind,
+          hasAuthority: hasAuthority,
           baseURL: info.componentsToCopyFromBase.contains(.path) ? baseURL.unsafelyUnwrapped : nil,
           absolutePathsCopyWindowsDriveFromBase: info.absolutePathsCopyWindowsDriveFromBase
         )
@@ -453,6 +454,7 @@ extension ParsedURLString.ProcessedMapping {
         return buffer.writeNormalizedPath(
           parsing: inputString[path],
           schemeKind: schemeKind,
+          hasAuthority: hasAuthority,
           baseURL: info.componentsToCopyFromBase.contains(.path) ? baseURL.unsafelyUnwrapped : nil,
           absolutePathsCopyWindowsDriveFromBase: info.absolutePathsCopyWindowsDriveFromBase,
           needsPercentEncoding: pathMetrics.needsPercentEncoding
@@ -933,7 +935,11 @@ extension URLScanner {
     let path = input[..<(startOfNextComponent ?? input.endIndex)]
 
     // 3. Validate the path's contents.
-    PathStringValidator.validate(pathString: path, schemeKind: scheme, callback: &callback)
+    PathStringValidator.validate(
+      pathString: path, schemeKind: scheme,
+      hasAuthority: mapping.authorityRange != nil || mapping.componentsToCopyFromBase.contains(.authority),
+      callback: &callback
+    )
 
     // 4. Return the next component.
     if !(path.startIndex < path.endIndex), !scheme.isSpecial {

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -403,7 +403,7 @@ extension URLStorage {
     //       The 'pathname' setter defined in the standard always goes through the "path start" state,
     //       which never reaches "file slash" and does not include this quirk. Therefore APCWDFB should be 'false'.
     let pathInfo = PathMetrics(
-      parsing: newPath, schemeKind: oldStructure.schemeKind, baseURL: nil,
+      parsing: newPath, schemeKind: oldStructure.schemeKind, hasAuthority: oldStructure.hasAuthority, baseURL: nil,
       absolutePathsCopyWindowsDriveFromBase: false)
 
     var newStructure = oldStructure
@@ -426,6 +426,8 @@ extension URLStorage {
           writer: Sigil.path.unsafeWrite)
       )
     }
+    assert(newStructure.hasAuthority == oldStructure.hasAuthority)
+
     commands.append(
       .replace(
         subrange: oldStructure.rangeForReplacingCodeUnits(of: .path),
@@ -433,7 +435,7 @@ extension URLStorage {
         writer: { dest in
           dest.writeNormalizedPath(
             parsing: newPath, schemeKind: newStructure.schemeKind,
-            baseURL: nil,
+            hasAuthority: newStructure.hasAuthority, baseURL: nil,
             absolutePathsCopyWindowsDriveFromBase: false,
             needsPercentEncoding: pathInfo.needsPercentEncoding
           )

--- a/Tests/WebURLTests/PathComponentsTests.swift
+++ b/Tests/WebURLTests/PathComponentsTests.swift
@@ -609,22 +609,6 @@ extension PathComponentsTests {
       XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
-    // If the URL has a path sigil, it is removed.
-    do {
-      var url = WebURL("foo:/.//a/b/c/d?aQuery#someFragment")!
-      XCTAssertEqualElements(url.pathComponents, ["", "a", "b", "c", "d"])
-
-      let range = url.pathComponents.replaceSubrange(
-        url.pathComponents.startIndex..<url.pathComponents.endIndex, with: [String]()
-      )
-      XCTAssertEqual(range.lowerBound, url.pathComponents.startIndex)
-      XCTAssertEqual(range.upperBound, url.pathComponents.endIndex)
-      XCTAssertEqualElements(url.pathComponents, [""])
-      XCTAssertEqualElements(url.pathComponents[range], [""])
-
-      XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
-      XCTAssertURLIsIdempotent(url)
-    }
     // Non-special URLs with an authority support empty paths.
     do {
       var url = WebURL("foo://example.com/a/b/c/d?aQuery#someFragment")!
@@ -640,6 +624,22 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents[range], [])
 
       XCTAssertEqual(url.serialized, "foo://example.com?aQuery#someFragment")
+      XCTAssertURLIsIdempotent(url)
+    }
+    // If the URL has a path sigil, it is removed when setting an empty path.
+    do {
+      var url = WebURL("foo:/.//a/b/c/d?aQuery#someFragment")!
+      XCTAssertEqualElements(url.pathComponents, ["", "a", "b", "c", "d"])
+
+      let range = url.pathComponents.replaceSubrange(
+        url.pathComponents.startIndex..<url.pathComponents.endIndex, with: [String]()
+      )
+      XCTAssertEqual(range.lowerBound, url.pathComponents.startIndex)
+      XCTAssertEqual(range.upperBound, url.pathComponents.endIndex)
+      XCTAssertEqualElements(url.pathComponents, [""])
+      XCTAssertEqualElements(url.pathComponents[range], [""])
+
+      XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -2073,6 +2073,32 @@ extension PathComponentsTests {
       XCTAssertEqual(url.pathComponents.count, 1)
 
       XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertURLIsIdempotent(url)
+    }
+    // Remove all components, non-special URL with hostname.
+    do {
+      var url = WebURL("foo://example.com/1/2/3")!
+      XCTAssertEqualElements(url.pathComponents, ["1", "2", "3"])
+
+      url.pathComponents.removeLast(3)
+      XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertEqual(url.path, "")
+      XCTAssertEqual(url.pathComponents.count, 0)
+
+      XCTAssertEqual(url.serialized, "foo://example.com")
+      XCTAssertURLIsIdempotent(url)
+    }
+    // Remove all components, non-special URL without hostname.
+    do {
+      var url = WebURL("foo:/1/2/3")!
+      XCTAssertEqualElements(url.pathComponents, ["1", "2", "3"])
+
+      url.pathComponents.removeLast(3)
+      XCTAssertEqualElements(url.pathComponents, [""])
+      XCTAssertEqual(url.path, "/")
+      XCTAssertEqual(url.pathComponents.count, 1)
+
+      XCTAssertEqual(url.serialized, "foo:/")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove 1, empty component.

--- a/Tests/WebURLTests/Resources/setters_tests.json
+++ b/Tests/WebURLTests/Resources/setters_tests.json
@@ -1612,6 +1612,51 @@
             }
         },
         {
+            "comment": "Special URLs cannot have their paths erased",
+            "href": "file:///some/path",
+            "new_value": "",
+            "expected": {
+                "href": "file:///",
+                "pathname": "/"
+            }
+        },
+        {
+            "comment": "Non-special URLs can have their paths erased",
+            "href": "foo://somehost/some/path",
+            "new_value": "",
+            "expected": {
+                "href": "foo://somehost",
+                "pathname": ""
+            }
+        },
+        {
+            "comment": "Non-special URLs with an empty host can have their paths erased",
+            "href": "foo:///some/path",
+            "new_value": "",
+            "expected": {
+                "href": "foo://",
+                "pathname": ""
+            }
+        },
+        {
+            "comment": "Path-only URLs cannot have their paths erased",
+            "href": "foo:/some/path",
+            "new_value": "",
+            "expected": {
+                "href": "foo:/",
+                "pathname": "/"
+            }
+        },
+        {
+            "comment": "Path-only URLs always have an initial slash",
+            "href": "foo:/some/path",
+            "new_value": "test",
+            "expected": {
+                "href": "foo:/test",
+                "pathname": "/test"
+            }
+        },
+        {
             "href": "unix:/run/foo.socket?timeout=10",
             "new_value": "/var/log/../run/bar.socket",
             "expected": {

--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -96,7 +96,7 @@ extension WebPlatformTests {
 // MARK: - Setters
 // --------------------------------------------
 // https://github.com/web-platform-tests/wpt/blob/master/url/resources/setters_tests.json
-// at version 2cfdb63014d1158fd15eb1f798f6b1610c275271
+// at version 77d54aa9e0405f737987b59331f3584e3e1c26f9
 
 
 extension WebPlatformTests {

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -351,7 +351,7 @@ extension WebURLTests {
     XCTAssertEqual(url.serialized, "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
-    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("hel:lo") }
+    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("hello:99") }
     XCTAssertEqual(url.serialized, "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
@@ -480,31 +480,20 @@ extension WebURLTests {
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Invalid hostnames.
-    let invalidHostnames = [
-      "@",
-      "/a/b/c",
-      "a/b/c",
-      "[:::]",
-      "example:.net",
-      "example.net:",
-      "example.net:99",
-      "example.net?something",
-      "example.net#something",
-    ]
-    let urlStrings = [
-      "foo://example.com/",
-      "https://example.com/",
-    ]
-    for urlString in urlStrings {
-      url = WebURL(urlString)!
-      for hostname in invalidHostnames {
-        XCTAssertEqual(url.hostname, "example.com")
-        XCTAssertEqual(url.serialized, urlString)
-        XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname(hostname) }
-        XCTAssertEqual(url.serialized, urlString)
-        XCTAssertURLIsIdempotent(url)
-      }
-    }
+    url = WebURL("foo://example.com/")!
+    XCTAssertEqual(url.hostname, "example.com")
+    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("@") }
+    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertURLIsIdempotent(url)
+
+    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("/a/b/c") }
+    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertURLIsIdempotent(url)
+
+    XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("[:::]") }
+    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertURLIsIdempotent(url)
   }
 
   /// Tests the Swift model 'port' property.


### PR DESCRIPTION
Aligns with whatwg/url 0672f2e2ef43aca18b59d90abb6dac21712399bb