### PR TITLE
Deprecate IPv4Address.ParseResult

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,10 @@ let package = Package(
       resources: [.copy("Resources")]
     ),
     .testTarget(
+      name: "WebURLDeprecatedAPITests",
+      dependencies: ["WebURL"]
+    ),
+    .testTarget(
       name: "WebURLSystemExtrasTests",
       dependencies: ["WebURLSystemExtras", "WebURL", .product(name: "SystemPackage", package: "swift-system")]
     ),

--- a/Sources/WebURL/DeprecatedAPIs.swift
+++ b/Sources/WebURL/DeprecatedAPIs.swift
@@ -1,0 +1,114 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These APIs will be deprecated at the next opportunity.
+
+extension IPv4Address {
+
+  // swift-format-ignore
+  /// A tri-state result which captures whether an IPv4 address failed to parse because it was invalid,
+  /// or whether it failed because the given string does not look like an IP address.
+  ///
+  /// **This API is deprecated and will be removed in a future version.**
+  ///
+  @available(*, deprecated, message:
+    "Changes to the way hostnames are parsed in the URL standard make it impractical for the IPv4 parser to detect when a hostname should not be parsed as an IPv4Address. A future API may address this more thoroughly; see github.com/karwa/swift-url/issues/63 for details."
+  )
+  public enum ParserResult {
+
+    /// The string was successfully parsed as an IPv4 address.
+    ///
+    case success(IPv4Address)
+
+    /// The string was recognized as probably being an IPv4 address, but was invalid and could not be parsed (e.g. because the value would overflow).
+    ///
+    case failure
+
+    /// The string cannot be recognized as an IPv4 address. This is not the same as being an invalid IP address - for example, the string "9999999999.com" fails
+    /// to parse because the non-numeric characters "com" mean it isn't even an IP address string, whereas the string "9999999999" _is_ a properly-formatted
+    /// IP address string, but fails to parse because the value would overflow.
+    ///
+    /// When parsing "9999999999.com" as a hostname, it should be treated as a domain or opaque hostname rather than an invalid IP address.
+    /// The string "9999999999" should be treated as a invalid IP address.
+    ///
+    case notAnIPAddress
+  }
+
+  // swift-format-ignore
+  /// Parses an IPv4 address from a buffer of UTF-8 codeunits, returning a tri-state `ParserResult` which is useful for parsing content which _might_ be
+  /// an IPv4 address.
+  ///
+  /// **This API is deprecated and will be removed in a future version.**
+  ///
+  /// The following formats are recognized:
+  ///
+  ///  - _a.b.c.d_, where each numeric part defines the value of the address' octet at that position.
+  ///  - _a.b.c_, where _a_ and _b_ define the address' first 2 octets, and _c_ is interpreted as a 16-bit integer whose most and least significant bytes define
+  ///    the address' 3rd and 4th octets respectively.
+  ///  - _a.b_, where _a_ defines the address' first octet, and _b_ is interpreted as a 24-bit integer whose bytes define the remaining octets from most to least
+  ///    significant.
+  ///  - _a_, where _a_ is interpreted as a 32-bit integer whose bytes define the octets of the address in order from most to least significant.
+  ///
+  /// The numeric parts may be written in decimal, octal (prefixed with a `0`), or hexadecimal (prefixed with `0x`, case-insensitive).
+  /// Additionally, a single trailing '.' is permitted (e.g. `a.b.c.d.`).
+  ///
+  /// Examples:
+  /// ```
+  /// IPv4Address("0x7f.0.0.1")!.octets == (0x7f, 0x00, 0x00, 0x01) == "127.0.0.1"
+  /// IPv4Address("10.1.0x12.")!.octets == (0x0a, 0x01, 0x00, 0x12) == "10.1.0.18"
+  /// IPv4Address("0300.0xa80032")!.octets == (0xc0, 0xa8, 0x00, 0x32) == "192.168.0.50"
+  /// IPv4Address("0x8Badf00d")!.octets == (0x8b, 0xad, 0xf0, 0x0d) == "139.173.240.13"
+  /// ```
+  ///
+  /// - parameters:
+  ///     - utf8: The string to parse, as a collection of UTF-8 code-units.
+  /// - returns: A tri-state result which captures whether the string should even be interpreted as an IPv4 address.
+  ///            See `ParserResult` for more information.
+  ///
+  @available(*, deprecated, message:
+    "Changes to the way hostnames are parsed in the URL standard make it impractical for the IPv4 parser to detect when a hostname should not be parsed as an IPv4Address. A future API may allow direct access to the URL host parser instead. Please leave a comment at github.com/karwa/swift-url/issues/63 so we can learn more about your use-case."
+  )
+  public static func parse<UTF8Bytes>(
+    utf8: UTF8Bytes
+  ) -> ParserResult where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
+
+    // Find the content of the last piece.
+    var lastPieceStart = utf8.startIndex
+    var lastPieceEnd = utf8.endIndex
+    for idx in utf8.indices {
+      if utf8[idx] == ASCII.period.codePoint {
+        let pieceStart = utf8.index(after: idx)
+        if pieceStart == utf8.endIndex {
+          lastPieceEnd = idx
+        } else {
+          lastPieceStart = pieceStart
+        }
+      }
+    }
+    let lastPiece = utf8[lastPieceStart..<lastPieceEnd]
+    // To be parsed as an IPv4 address, the last piece must:
+    // - not be empty
+    // - contain an number, regardless of whether that number overflows an IPv4 address.
+    var isHex = ASCII.Lowercased(lastPiece).starts(with: "0x".utf8)
+    isHex = isHex && lastPiece.dropFirst(2).allSatisfy({ ASCII($0)?.isHexDigit == true })
+    guard !lastPiece.isEmpty, lastPiece.allSatisfy({ ASCII($0)?.isDigit == true }) || isHex else {
+      return .notAnIPAddress
+    }
+
+    guard let address = IPv4Address(utf8: utf8) else {
+      return .failure
+    }
+    return .success(address)
+  }
+}

--- a/Sources/WebURL/Parser/Parser+Host.swift
+++ b/Sources/WebURL/Parser/Parser+Host.swift
@@ -52,11 +52,11 @@ extension ParsedHost {
         callback.validationError(.unclosedIPv6Address)
         return nil
       }
-      guard let result = IPv6Address(utf8: ipv6Slice) else {
+      guard let address = IPv6Address(utf8: ipv6Slice) else {
         callback.validationError(.invalidIPv6Address)
         return nil
       }
-      self = .ipv6Address(result)
+      self = .ipv6Address(address)
       return
     }
 
@@ -89,7 +89,7 @@ extension ParsedHost {
     case .forbiddenHostCodePoint:
       return nil
     case .endsInANumber:
-      guard case .success(let address) = IPv4Address.parse(utf8: domain) else {
+      guard let address = IPv4Address(utf8: domain) else {
         return nil
       }
       self = .ipv4Address(address)

--- a/Tests/WebURLDeprecatedAPITests/IPv4AddressTests.swift
+++ b/Tests/WebURLDeprecatedAPITests/IPv4AddressTests.swift
@@ -1,0 +1,82 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import WebURL
+
+final class IPv4AddressTests_Deprecated: XCTestCase {
+
+  func testParseWithParseResult() {
+
+    // Regular, well-formed addresses work.
+    do {
+      let hostStrings = [
+        "127.0.0.1",
+        "192.168.0.1",
+        "123.456",
+        "0xBADF00D",
+        "0xBADF00D.",
+        "045.0xFE",
+        "045.0xFE.",
+      ]
+      for hostString in hostStrings {
+        switch IPv4Address.parse(utf8: hostString.utf8) {
+        case .success(_):
+          break
+        default:
+          XCTFail()
+        }
+      }
+    }
+
+    // These should return .notAnIPAddress, not .failure
+    do {
+      let hostStrings = [
+        "example.com",
+        "123.example.com",
+        "9999999999.com",
+        "9999999999..",
+        "1.2.3.0xFG",
+      ]
+      for hostString in hostStrings {
+        switch IPv4Address.parse(utf8: hostString.utf8) {
+        case .notAnIPAddress:
+          break
+        default:
+          XCTFail()
+        }
+      }
+    }
+
+    // These should return .failure, not .notAnIPAddress
+    do {
+      let hostStrings = [
+        "9999999999",
+        "9999999999.",
+        "123.com.456",  // This is a change which follows the URL standard update. Numeric TLDs are not valid.
+        "123.com.456.",
+        "0xFFFFFFFFF",
+      ]
+      for hostString in hostStrings {
+        switch IPv4Address.parse(utf8: hostString.utf8) {
+        case .failure:
+          break
+        default:
+          XCTFail()
+        }
+      }
+    }
+  }
+}

--- a/docs-excluded-symbols
+++ b/docs-excluded-symbols
@@ -15,3 +15,6 @@ PercentEncodeSet._Passthrough
 WebURL.FormEncodedQueryParameters.KeyValuePairs.Iterator
 WebURL.PathComponents.Index
 Collection._longestSubrange(equalTo:)
+
+IPv4Address.ParserResult
+IPv4Address.parse(utf8:)


### PR DESCRIPTION
It is impractical to make this distinction at the IPv4 parser level. Recent changes expose the fact that this API is too tightly coupled to the details of how the URL Standard parses hostnames (and since it's a living standard, that can change). The decisions it makes shouldn't be happening here.

We shouldn't include this in the library's stable API, so it's best to drop it ASAP. We could perhaps offer a more comprehensive host-parsing interface instead (#63), which provides a more suitable level of abstraction.