### PR TITLE
[Tests] Mark tests of deprecated APIs as themselves deprecated

### DIFF
--- a/Tests/WebURLDeprecatedAPITests/IPv4AddressTests.swift
+++ b/Tests/WebURLDeprecatedAPITests/IPv4AddressTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import WebURL
 
+@available(*, deprecated)
 final class IPv4AddressTests_Deprecated: XCTestCase {
 
   func testParseWithParseResult() {

--- a/Tests/WebURLDeprecatedAPITests/WebURLAPITests.swift
+++ b/Tests/WebURLDeprecatedAPITests/WebURLAPITests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 @testable import WebURL
 
+@available(*, deprecated)
 final class WebURLAPITests_Deprecated: XCTestCase {
 
   func testCannotBeABase() {


### PR DESCRIPTION
in order to suppress deprecation warnings.