### PR TITLE
Change .pathComponents to not automatically unescape its elements

### DIFF
--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -40,16 +40,18 @@ extension WebURL {
   /// A view of the components in a hierarchical URL's path.
   ///
   /// This collection provides efficient, bidirectional, read-write access to the URL's path components.
-  /// Components are percent-decoded when they are returned and percent-encoded when they are replaced.
+  /// Components read via this view are returned as they appear in the URL string, including any percent-encoding.
+  /// Percent-encoding is added to inserted components as necessary.
   ///
   /// ```swift
-  /// var url = WebURL("http://example.com/swift/packages/%F0%9F%A6%86%20tracker")!
-  /// url.pathComponents.first! // "swift"
-  /// url.pathComponents.last! // "🦆 tracker"
+  /// var url = WebURL("http://example.com/packages/swift-url/documentation")!
+  /// url.pathComponents.first! // "packages"
+  /// url.pathComponents.last! // "documentation"
   ///
   /// url.pathComponents.removeLast()
-  /// url.pathComponents.append("swift-url")
-  /// print(url) // Prints "http://example.com/swift/packages/swift-url"
+  /// url.pathComponents.append("📚")
+  /// print(url) // Prints "http://example.com/packages/swift-url/%F0%9F%93%9A"
+  /// url.pathComponents.last!.percentDecoded "📚"
   /// ```
   ///
   /// Path components extend from their leading slash until the leading slash of the next component (or the end of the path). That means that a URL whose
@@ -155,7 +157,7 @@ extension WebURL.PathComponents: BidirectionalCollection {
   }
 
   public subscript(position: Index) -> String {
-    storage.utf8.pathComponent(position).percentDecodedString
+    String(decoding: storage.utf8.pathComponent(position), as: UTF8.self)
   }
 
   public func distance(from start: Index, to end: Index) -> Int {

--- a/Tests/WebURLTests/FilePathTests.swift
+++ b/Tests/WebURLTests/FilePathTests.swift
@@ -159,9 +159,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.first, "caf��")
+      XCTAssertEqual(fileURL.pathComponents.first, "caf%E9%DD")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1)
@@ -180,9 +178,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.first, "hi���")
+      XCTAssertEqual(fileURL.pathComponents.first, "hi%E1%E2%E3")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek)
@@ -300,9 +296,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.last, "caf��")
+      XCTAssertEqual(fileURL.pathComponents.last, "caf%E9%DD")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1)
@@ -322,9 +316,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.last, "hi���")
+      XCTAssertEqual(fileURL.pathComponents.last, "hi%E1%E2%E3")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek)
@@ -482,9 +474,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.last, "caf��")
+      XCTAssertEqual(fileURL.pathComponents.last, "caf%E9%DD")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1.dropFirst(4) /* \\?\ prefix */)
@@ -505,9 +495,7 @@ extension FilePathTests {
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
-
-      // FIXME: Perhaps don't automatically percent-decode path components?
-      XCTAssertEqual(fileURL.pathComponents.last, "hi���")
+      XCTAssertEqual(fileURL.pathComponents.last, "hi%E1%E2%E3")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek.dropFirst(4) /* \\?\ prefix */)


### PR DESCRIPTION
See https://forums.swift.org/t/api-changes-for-0-2-0/51647 for discussion

I'm going to leave this up while I gather feedback and think about it. In addition to the reasons discussed in that post, there is also obviously a performance win for the _even more common_ case that the URL's path components are ASCII and you don't want/need to decode them.

But yeah, really unsure what to do here. I like the idea of this being a simple model type - letting you read/write URL components with a Swifty interface, but not doing anything too fancy and basically just giving you slices of the underlying URL string, as they appear in that string. At the same time, I want it to be convenient and easy to use.

Looking at other libraries:

- rust-url's `path_segments` iterator [keeps](https://github.com/servo/rust-url/blob/d673c4d5e22b3a8ac91b7f52faa45dc32a275f75/url/src/lib.rs#L1201) percent-encoding.

- .Net's `Uri.Segments` [keeps](https://dotnetfiddle.net/NWYZbH) percent-encoding.

- Python's `urllib` just splits a URL string in to a tuple. It [keeps](https://docs.python.org/3/library/urllib.parse.html) percent-encoding, but doesn't offer a path component view.
  > \> urlparse('//www.cwi.nl:80/%7Eguido/Python.html')
  >     _ParseResult(scheme='', netloc='www.cwi.nl:80', path='/%7Eguido/Python.html',
              params='', query='', fragment='')_


- Java's `Uri` class [decodes](https://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getPath()) in all regular component getters, and includes ["Raw" versions](https://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getRawPath()) which don't. It does not offer a specific path-components view.
- Java's [`URL` class](https://docs.oracle.com/javase/7/docs/api/java/net/URL.html) does not encode or decode in any component getters or setters:
  > The URL class does not itself encode or decode any URL components according to the escaping mechanism defined in RFC2396. It is the responsibility of the caller to encode any fields, which need to be escaped prior to calling URL, and also to decode any escaped fields, that are returned from URL. 

- [Go](https://pkg.go.dev/net/url) does something pretty weird. They have `Path`, `RawPath`, and `EscapedPath`, and there's this tidbit that I'm not sure what to make of. I think they actually store the path twice?!?!
  > Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/. A consequence is that it is impossible to tell which slashes in the Path were slashes in the raw URL and which were %2f. This distinction is rarely important, but when it is, the code should use RawPath, an optional field which only gets set if the default encoding is different from Path.

- Foundation [`URL`](https://developer.apple.com/documentation/foundation/url) decodes in all regular component getters (undocumented) and does not offer "raw" versions. [`URLComponents`](https://developer.apple.com/documentation/foundation/urlcomponents) will automatically encode/decode, and _does_ offer "raw" versions. It also exposes raw query items, but no decoded or raw path components views. 
