### PR TITLE
Add some simple benchmarks for component setters and pathComponents, improve performance

### DIFF
--- a/Benchmarks/Sources/WebURLBenchmark/ComponentSetters.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/ComponentSetters.swift
@@ -1,0 +1,245 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import WebURL
+
+/// Benchmarks the WebURL component setters (e.g. `url.query = "..."`).
+///
+let componentSetters = BenchmarkSuite(name: "ComponentSetters") { suite in
+
+  // Scheme.
+
+  suite.benchmark("Unique.Scheme") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.scheme = "hTtPs"
+      url.scheme = "wSs"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Scheme.Long") { state in
+    var url = WebURL("foo://example.com/")!
+    try state.measure {
+      url.scheme = "thisisaverylongschemebutistechnicallyvalid-ihopenobodyisusingschemesthislongthough-welltheymight-buticantthinkofareasonto"
+    }
+    blackHole(url)
+  }
+
+  // Username.
+
+  suite.benchmark("Unique.Username") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.username = "username"
+      url.username = "karl"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Username.PercentEncoding") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.username = "some username"
+      url.username = "🦆"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Username.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.username = "thisisaverylongusernamewhichisalmostcertainlynotusedbyanybodybutitsworthbenchmarkingthebehaviourtoseehowitshandled"
+    }
+    blackHole(url)
+  }
+
+  // Password.
+
+  suite.benchmark("Unique.Password") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.password = "password"
+      url.password = "somesecret"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Password.PercentEncoding") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.password = "some password"
+      url.password = "🦆🦆🦆"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Password.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.password = "thisisaverylongpasswordwhichisalmostcertainlynotusedbyanybodybutitsworthbenchmarkingthebehaviourtoseehowitshandled"
+    }
+    blackHole(url)
+  }
+
+  // Hostname.
+
+  suite.benchmark("Unique.Hostname.Domain.ASCII") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.hostname = "foo.bar.net"
+      url.hostname = "m.cash.somebank.net"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Hostname.IPv4") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.hostname = "192.168.0.34"
+      url.hostname = "0xBADF00D"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Hostname.IPv6") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.hostname = "[2608::3:5]"
+      url.hostname = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Hostname.Opaque") { state in
+    var url = WebURL("foo://example.com/")!
+    try state.measure {
+      url.hostname = "some-hostname"
+      url.hostname = "m.cash.somebank.net"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Hostname.Domain.ASCII.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.hostname = "this.is.a.very.long.domain.which.totally.isnt.valid.because.dns.has.length.restrictions.but.those.arent.considered.at.the.url.level"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Hostname.Opaque.Long") { state in
+    var url = WebURL("foo://example.com/")!
+    try state.measure {
+      url.hostname = "this-is-a-very-long-hostname-which-is-probably-wildly-unrealistic-and-not-used-by-anybody-but-we-have-to-handle-it-so-might-as-well-see-how-it-fares"
+    }
+    blackHole(url)
+  }
+
+  // Path.
+
+  suite.benchmark("Unique.Path.Simple") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.path = "/some/path/with/a/bunch/of/components.txt"
+      url.path = "/how/much/wood/would/a/woodchuck/chuck/if/a/woodchuck/could/chuck/wood"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Path.DotDot") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.path = "/some/../path/./with/./dot/../components/"
+      // Despite the length, this only results in 10 components.
+      url.path =
+        "/a/./woodchuck/../would/../chuck/../as/much/wood/../as/a/./woochuck/../could/../chuck/../if/a/../woochuck/could/chuck/wood/.."
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Path.PercentEncoding") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.path = "/a/🐢/path/🦖/./🦆/"
+      url.path = "/👶/🙍‍♂️/👨/👴"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Path.Simple.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.path = "/this/is/a/long/path/which/unlike/the/other/long/tests/might/actually/be/kinda/sorta/realistic/although/probably/not/at/the/length/were/going/to"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Path.PercentEncoding.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.path = "/there once was a 👨 from Nantucket/who kept all his 💵 in a bucket/but his 👧, named Nan/🏃‍♀️ away with a 🙍‍♂️/and as for the bucket? nantucket."
+    }
+    blackHole(url)
+  }
+
+  // Query
+
+  suite.benchmark("Unique.Query") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.query = "from=EUR&to=USD&amount=500"
+      url.query = "utm_source=share&utm_medium=web2x&context=3"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Query.PercentEncoding") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.query = #"Quoth the 🐧 “Nevermore.”"#
+      url.query = "Gotta love them spaces!"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Query.Long") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.query = "chs=500x500&chma=0,0,100,100&cht=p&chco=FF0000%2CFFFF00%7CFF8000%2C00FF00%7C00FF00%2C0000FF&chd=t%3A122%2C42%2C17%2C10%2C8%2C7%2C7%2C7%2C7%2C6%2C6%2C6%2C6%2C5%2C5&chl=122%7C42%7C17%7C10%7C8%7C7%7C7%7C7%7C7%7C6%7C6%7C6%7C6%7C5%7C5&chdl=android%7Cjava%7Cstack-trace%7Cbroadcastreceiver%7Candroid-ndk%7Cuser-agent%7Candroid-webview%7Cwebview%7Cbackground%7Cmultithreading%7Candroid-source%7Csms%7Cadb%7Csollections%7Cactivity|Chart"
+    }
+    blackHole(url)
+  }
+
+  // Fragment
+
+  suite.benchmark("Unique.Fragment") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.fragment = "title-of-some-heading"
+      url.fragment = "not-too-big-not-too-small"
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Unique.Fragment.PercentEncoding") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.fragment = #"Quoth the 🐧 “Nevermore.”"#
+      url.fragment = "Gotta love them spaces!"
+    }
+    blackHole(url)
+  }
+}

--- a/Benchmarks/Sources/WebURLBenchmark/PathComponents.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/PathComponents.swift
@@ -1,0 +1,121 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import WebURL
+
+/// Benchmarks the WebURL `.pathComponents` view.
+///
+let pathComponents = BenchmarkSuite(name: "PathComponents") { suite in
+
+  // Iteration.
+
+  suite.benchmark("Iteration.Small.Forwards") { state in
+    var url = WebURL("http://example.com/hello/this/a/path/with/a/couple/of/components")!
+    try state.measure {
+      for component in url.pathComponents {
+        blackHole(component)
+      }
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Iteration.Small.Reverse") { state in
+    var url = WebURL("http://example.com/hello/this/a/path/with/a/couple/of/components")!
+    try state.measure {
+      for component in url.pathComponents.reversed() as ReversedCollection {
+        blackHole(component)
+      }
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Iteration.Long.Forwards") { state in
+    var url = WebURL("http://example.com/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components//hello/this/a/path/with/a/couple/of/components")!
+    try state.measure {
+      for component in url.pathComponents {
+        blackHole(component)
+      }
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Iteration.Long.Reverse") { state in
+    var url = WebURL("http://example.com/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components/hello/this/a/path/with/a/couple/of/components//hello/this/a/path/with/a/couple/of/components")!
+    try state.measure {
+      for component in url.pathComponents.reversed() as ReversedCollection {
+        blackHole(component)
+      }
+    }
+    blackHole(url)
+  }
+
+  // Append.
+
+  suite.benchmark("Append.Single") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.pathComponents.append("foo")
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("Append.Multiple") { state in
+    var url = WebURL("http://example.com/")!
+    try state.measure {
+      url.pathComponents += ["foo", "bar", "baz"]
+    }
+    blackHole(url)
+  }
+
+  // RemoveLast.
+
+  suite.benchmark("RemoveLast.Single") { state in
+    var url = WebURL("http://example.com/foo/bar/baz")!
+    try state.measure {
+      url.pathComponents.removeLast()
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("RemoveLast.Multiple") { state in
+    var url = WebURL("http://example.com/foo/bar/baz/qux")!
+    try state.measure {
+      url.pathComponents.removeLast(3)
+    }
+    blackHole(url)
+  }
+
+  // ReplaceSubrange.
+
+  suite.benchmark("ReplaceSubrange.Shrink") { state in
+    var url = WebURL("http://example.com/foo/bar/baz/qux/")!
+    let start = url.pathComponents.index(url.pathComponents.startIndex, offsetBy: 1)
+    let end   = url.pathComponents.index(start, offsetBy: 2)
+    try state.measure {
+      url.pathComponents.replaceSubrange(start..<end, with: ["test"])
+    }
+    blackHole(url)
+  }
+
+  suite.benchmark("ReplaceSubrange.Grow") { state in
+    var url = WebURL("http://example.com/foo/bar/baz/qux/")!
+    let start = url.pathComponents.index(url.pathComponents.startIndex, offsetBy: 1)
+    let end   = url.pathComponents.index(start, offsetBy: 2)
+    try state.measure {
+      url.pathComponents.replaceSubrange(start..<end, with: ["test", "with", "more", "components"])
+    }
+    blackHole(url)
+  }
+}

--- a/Benchmarks/Sources/WebURLBenchmark/main.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/main.swift
@@ -30,5 +30,7 @@ internal func blackHole<T>(_ x: T) {
 
 Benchmark.main([
   constructor_specialNonFile,
-  urlEncoded_Decoded
+  urlEncoded_Decoded,
+  componentSetters,
+  pathComponents
 ])

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -23,7 +23,7 @@ extension URLStorage {
   /// Attempts to set the scheme component to the given UTF8-encoded string.
   /// The new value may contain a trailing colon (e.g. `http`, `http:`). Colons are only allowed as the last character of the string.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setScheme<UTF8Bytes>(
     to newValue: UTF8Bytes
   ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -85,7 +85,7 @@ extension URLStorage {
   /// - Note: Usernames and Passwords are never filtered of ASCII tab or newline characters.
   ///         If the given `newValue` contains any such characters, they will be percent-encoded in to the result.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setUsername<UTF8Bytes>(
     to newValue: UTF8Bytes?
   ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -137,7 +137,7 @@ extension URLStorage {
   /// - Note: Usernames and Passwords are never filtered of ASCII tab or newline characters.
   ///         If the given `newValue` contains any such characters, they will be percent-encoded in to the result.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setPassword<UTF8Bytes>(
     to newValue: UTF8Bytes?
   ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -203,7 +203,7 @@ extension URLStorage {
   /// An empty hostname preserves the `//` separator after the scheme, but the authority component will be empty (e.g. `unix://oldhost/some/path` -> `unix:///some/path`).
   /// A `nil` hostname removes the `//` separator after the scheme, resulting in a so-called "path-only" URL (e.g. `unix://oldhost/some/path` -> `unix:/some/path`).
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setHostname<UTF8Bytes>(
     to newValue: UTF8Bytes?
   ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
@@ -320,7 +320,7 @@ extension URLStorage {
 
   /// Attempts to set the port component to the given value. A value of `nil` removes the port.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setPort(
     to newValue: UInt16?
   ) -> (AnyURLStorage, URLSetterError?) {
@@ -378,7 +378,7 @@ extension URLStorage {
 
   /// Attempts to set the path component to the given UTF8-encoded string.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setPath<UTF8Bytes>(
     to newPath: UTF8Bytes
   ) -> (AnyURLStorage, URLSetterError?) where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
@@ -454,7 +454,7 @@ extension URLStorage {
   ///
   /// A value of `nil` removes the query.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setQuery<UTF8Bytes>(
     to newValue: UTF8Bytes?
   ) -> AnyURLStorage where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -487,7 +487,7 @@ extension URLStorage {
 
   /// Set the query component to the given UTF8-encoded string, assuming that the string is already `application/x-www-form-urlencoded`.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setQuery<UTF8Bytes>(
     toKnownFormEncoded newValue: UTF8Bytes?
   ) -> AnyURLStorage where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -508,7 +508,7 @@ extension URLStorage {
   ///
   /// A value of `nil` removes the query.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal mutating func setFragment<UTF8Bytes>(
     to newValue: UTF8Bytes?
   ) -> AnyURLStorage where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {

--- a/Sources/WebURL/URLStorage.swift
+++ b/Sources/WebURL/URLStorage.swift
@@ -555,16 +555,22 @@ extension Sigil {
   /// - returns: The actual number of bytes written (always 2, unless the buffer is `nil`).
   ///
   @inlinable
-  internal func unsafeWrite(to buffer: inout UnsafeMutableBufferPointer<UInt8>) -> Int {
-    guard let ptr = buffer.baseAddress else { return 0 }
-    switch self {
+  internal static func unsafeWrite(_ sigil: Sigil) -> (_ buffer: inout UnsafeMutableBufferPointer<UInt8>) -> Int {
+    switch sigil {
     case .authority:
-      ptr.initialize(repeating: ASCII.forwardSlash.codePoint, count: 2)
+      return { buffer in
+        guard let ptr = buffer.baseAddress else { return 0 }
+        ptr.initialize(repeating: ASCII.forwardSlash.codePoint, count: 2)
+        return 2
+      }
     case .path:
-      ptr[0] = ASCII.forwardSlash.codePoint
-      ptr[1] = ASCII.period.codePoint
+      return { buffer in
+        guard let ptr = buffer.baseAddress else { return 0 }
+        ptr.initialize(to: ASCII.forwardSlash.codePoint)
+        (ptr + 1).initialize(to: ASCII.period.codePoint)
+        return 2
+      }
     }
-    return 2
   }
 }
 

--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -125,6 +125,18 @@ extension UnsafeMutableRawBufferPointer {
   }
 }
 
+// Arity 2:
+
+@inlinable @inline(__always)
+internal func withUnsafeMutableBufferPointerToElements<T, Result>(
+  tuple: inout (T, T), _ body: (inout UnsafeMutableBufferPointer<T>) -> Result
+) -> Result {
+  return withUnsafeMutableBytes(of: &tuple) {
+    var ptr = $0._assumingMemoryBound(to: T.self)
+    return body(&ptr)
+  }
+}
+
 // Arity 4:
 
 @inlinable @inline(__always)

--- a/Sources/WebURL/Util/UnsafeSmallStack.swift
+++ b/Sources/WebURL/Util/UnsafeSmallStack.swift
@@ -1,0 +1,115 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A fixed-capacity stack view over unowned memory.
+///
+/// This type allows for a variable `count` Collection view over a region of memory.
+/// Append items using the `push` method, and remove them using `pop`. Appending more elements
+/// than the stack has capacity for, or popping elements when the stack is empty, will trigger a runtime error.
+///
+/// This type is unsafe, as it does not own the memory used to store elements, and it is your responsibility
+/// to ensure that its lifetime does not exceed that of the memory it points to.
+///
+@usableFromInline
+internal struct UnsafeSmallStack<Element> {
+
+  @usableFromInline
+  internal var _storage: UnsafeMutablePointer<Element?>
+
+  @usableFromInline
+  internal var _capacity: UInt8
+
+  @usableFromInline
+  internal var _count: UInt8
+
+  /// Creates an `UnsafeSmallStack` over the given region of memory, containing instances of `Optional<Element>`.
+  /// The entire capacity must be initialized - e.g. to `Optional<Element>.none`/`nil`.
+  ///
+  @inlinable
+  internal init(ptr: UnsafeMutablePointer<Element?>, capacity: UInt8) {
+    self._storage = ptr
+    self._capacity = capacity
+    self._count = 0
+  }
+}
+
+extension UnsafeSmallStack: RandomAccessCollection {
+
+  @usableFromInline
+  internal typealias Index = UInt8
+
+  @inlinable
+  internal var startIndex: UInt8 { 0 }
+
+  @inlinable
+  internal var endIndex: UInt8 { _count }
+
+  @inlinable
+  internal var count: Int { Int(_count) }
+
+  @inlinable
+  internal func index(after i: UInt8) -> UInt8 { i &+ 1 }
+
+  @inlinable
+  internal func index(before i: UInt8) -> UInt8 { i &- 1 }
+
+  @inlinable
+  internal subscript(position: UInt8) -> Element {
+    precondition(position < _count)
+    return (_storage + Int(position)).pointee.unsafelyUnwrapped
+  }
+}
+
+extension UnsafeSmallStack {
+
+  /// Appends an item to the end of the stack.
+  /// If the stack has no more capacity, a runtime error is triggered.
+  ///
+  @inlinable
+  internal mutating func push(_ newElement: Element) {
+    precondition(_count < _capacity)
+    (_storage + Int(_count)).pointee = newElement
+    _count &+= 1
+  }
+
+  /// Removes the last item from the stack.
+  /// If the stack is empty, a runtime error is triggered.
+  ///
+  @inlinable
+  internal mutating func pop(_ newElement: Element) {
+    precondition(_count > 0)
+    (_storage + Int(_count)).pointee = nil
+    _count &-= 1
+  }
+
+  @inlinable
+  internal static func += (_ stack: inout Self, _ newElement: Element) {
+    stack.push(newElement)
+  }
+}
+
+/// Executes `body`, passing in an `UnsafeSmallStack` with capacity for 2 elements of the given type.
+///
+/// - important: The lifetime of the `UnsafeSmallStack` must not escape the duration of `body`.
+///
+@inlinable @inline(__always)
+func withUnsafeSmallStack_2<Element, Result>(
+  of: Element.Type, _ body: (inout UnsafeSmallStack<Element>) -> Result
+) -> Result {
+  var storage: (Element?, Element?) = (nil, nil)
+  return withUnsafeMutableBufferPointerToElements(tuple: &storage) {
+    var arrayView = UnsafeSmallStack(ptr: $0.baseAddress.unsafelyUnwrapped, capacity: 2)
+    return body(&arrayView)
+  }
+}

--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -750,14 +750,14 @@ extension URLStorage {
       var commands = [ReplaceSubrangeOperation]()
       var newStructure = oldStructure
       if case .path = oldStructure.sigil {
-        commands.append(.remove(subrange: oldStructure.rangeForReplacingSigil))
+        commands.append(.remove(oldStructure.rangeForReplacingSigil))
         newStructure.sigil = .none
       }
       newStructure.pathLength = 1
       newStructure.firstPathComponentLength = 1
       commands.append(
         .replace(
-          subrange: oldPathRange, withCount: 1,
+          oldPathRange, withCount: 1,
           writer: { buffer in
             buffer.baseAddress.unsafelyUnwrapped.initialize(to: ASCII.forwardSlash.codePoint)
             return 1
@@ -861,14 +861,14 @@ extension URLStorage {
     case (.none, true):
       commands.append(
         .replace(
-          subrange: oldStructure.rangeForReplacingSigil,
+          oldStructure.rangeForReplacingSigil,
           withCount: Sigil.path.length,
-          writer: Sigil.path.unsafeWrite)
+          writer: Sigil.unsafeWrite(.path))
       )
       newStructure.sigil = .path
       pathOffsetFromModifiedSigil = 2
     case (.path, false):
-      commands.append(.remove(subrange: oldStructure.rangeForReplacingSigil))
+      commands.append(.remove(oldStructure.rangeForReplacingSigil))
       newStructure.sigil = .none
       pathOffsetFromModifiedSigil = -2
     }
@@ -879,7 +879,7 @@ extension URLStorage {
 
     commands.append(
       .replace(
-        subrange: replacedRange, withCount: insertedPathLength,
+        replacedRange, withCount: insertedPathLength,
         writer: { buffer in
           var bytesWritten = 0
           for component in components {

--- a/Sources/WebURL/WebURL+Scheme.swift
+++ b/Sources/WebURL/WebURL+Scheme.swift
@@ -48,10 +48,8 @@ extension WebURL.SchemeKind {
   internal init<UTF8Bytes>(parsing schemeContent: UTF8Bytes) where UTF8Bytes: Sequence, UTF8Bytes.Element == UInt8 {
 
     if let contiguouslyParsed = schemeContent.withContiguousStorageIfAvailable({ buffer -> Self in
-      guard buffer.count != 0 else { return .other }
-      return WebURL.SchemeKind(
-        ptr: UnsafeRawPointer(buffer.baseAddress.unsafelyUnwrapped), count: UInt8(truncatingIfNeeded: buffer.count)
-      )
+      guard let count = UInt8(exactly: buffer.count), count > 0 else { return .other }
+      return WebURL.SchemeKind(ptr: UnsafeRawPointer(buffer.baseAddress.unsafelyUnwrapped), count: count)
     }) {
       self = contiguouslyParsed
       return

--- a/Sources/WebURL/WebURL+UTF8View.swift
+++ b/Sources/WebURL/WebURL+UTF8View.swift
@@ -222,10 +222,16 @@ extension WebURL.UTF8View {
   public mutating func setScheme<UTF8Bytes>(
     _ newScheme: UTF8Bytes
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setScheme(to: newScheme) },
-      { large in large.setScheme(to: newScheme) }
-    )
+    try newScheme.withContiguousStorageIfAvailable { newSchemeBytes in
+      try storage.withUnwrappedMutableStorage(
+        { small in small.setScheme(to: newSchemeBytes.boundsChecked) },
+        { large in large.setScheme(to: newSchemeBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setScheme(to: newScheme) },
+        { large in large.setScheme(to: newScheme) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `username`, if present.
@@ -244,10 +250,22 @@ extension WebURL.UTF8View {
   public mutating func setUsername<UTF8Bytes>(
     _ newUsername: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setUsername(to: newUsername) },
-      { large in large.setUsername(to: newUsername) }
-    )
+    guard let newValue = newUsername else {
+      return try storage.withUnwrappedMutableStorage(
+        { small in small.setUsername(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) },
+        { large in large.setUsername(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) }
+      )
+    }
+    try newValue.withContiguousStorageIfAvailable { newUsernameBytes in
+      try storage.withUnwrappedMutableStorage(
+        { small in small.setUsername(to: newUsernameBytes.boundsChecked) },
+        { large in large.setUsername(to: newUsernameBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setUsername(to: newValue) },
+        { large in large.setUsername(to: newValue) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `password`, if present.
@@ -268,10 +286,22 @@ extension WebURL.UTF8View {
   public mutating func setPassword<UTF8Bytes>(
     _ newPassword: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setPassword(to: newPassword) },
-      { large in large.setPassword(to: newPassword) }
-    )
+    guard let newValue = newPassword else {
+      return try storage.withUnwrappedMutableStorage(
+        { small in small.setPassword(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) },
+        { large in large.setPassword(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) }
+      )
+    }
+    try newValue.withContiguousStorageIfAvailable { newPasswordBytes in
+      try storage.withUnwrappedMutableStorage(
+        { small in small.setPassword(to: newPasswordBytes.boundsChecked) },
+        { large in large.setPassword(to: newPasswordBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setPassword(to: newValue) },
+        { large in large.setPassword(to: newValue) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `hostname`, if present.
@@ -293,10 +323,22 @@ extension WebURL.UTF8View {
   public mutating func setHostname<UTF8Bytes>(
     _ newHostname: UTF8Bytes?
   ) throws where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setHostname(to: newHostname) },
-      { large in large.setHostname(to: newHostname) }
-    )
+    guard let newValue = newHostname else {
+      return try storage.withUnwrappedMutableStorage(
+        { small in small.setHostname(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) },
+        { large in large.setHostname(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) }
+      )
+    }
+    try newValue.withContiguousStorageIfAvailable { newHostnameBytes in
+      try storage.withUnwrappedMutableStorage(
+        { small in small.setHostname(to: newHostnameBytes.boundsChecked) },
+        { large in large.setHostname(to: newHostnameBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setHostname(to: newValue) },
+        { large in large.setHostname(to: newValue) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `port`, if present.
@@ -325,10 +367,16 @@ extension WebURL.UTF8View {
   public mutating func setPath<UTF8Bytes>(
     _ newPath: UTF8Bytes
   ) throws where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setPath(to: newPath) },
-      { large in large.setPath(to: newPath) }
-    )
+    try newPath.withContiguousStorageIfAvailable { newPathBytes in
+      try storage.withUnwrappedMutableStorage(
+        { small in small.setPath(to: newPathBytes.boundsChecked) },
+        { large in large.setPath(to: newPathBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setPath(to: newPath) },
+        { large in large.setPath(to: newPath) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `query`, if present.
@@ -350,10 +398,22 @@ extension WebURL.UTF8View {
   public mutating func setQuery<UTF8Bytes>(
     _ newQuery: UTF8Bytes?
   ) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
-    storage.withUnwrappedMutableStorage(
-      { small in small.setQuery(to: newQuery) },
-      { large in large.setQuery(to: newQuery) }
-    )
+    guard let newValue = newQuery else {
+      return storage.withUnwrappedMutableStorage(
+        { small in small.setQuery(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) },
+        { large in large.setQuery(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) }
+      )
+    }
+    newValue.withContiguousStorageIfAvailable { newQueryBytes in
+      storage.withUnwrappedMutableStorage(
+        { small in small.setQuery(to: newQueryBytes.boundsChecked) },
+        { large in large.setQuery(to: newQueryBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setQuery(to: newValue) },
+        { large in large.setQuery(to: newValue) }
+      )
   }
 
   /// The UTF-8 code-units containing this URL's `fragment`, if present.
@@ -374,9 +434,21 @@ extension WebURL.UTF8View {
   public mutating func setFragment<UTF8Bytes>(
     _ newFragment: UTF8Bytes?
   ) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
-    storage.withUnwrappedMutableStorage(
-      { small in small.setFragment(to: newFragment) },
-      { large in large.setFragment(to: newFragment) }
-    )
+    guard let newValue = newFragment else {
+      return storage.withUnwrappedMutableStorage(
+        { small in small.setFragment(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) },
+        { large in large.setFragment(to: UnsafeBoundsCheckedBufferPointer<UInt8>?.none) }
+      )
+    }
+    newValue.withContiguousStorageIfAvailable { newFragmentBytes in
+      storage.withUnwrappedMutableStorage(
+        { small in small.setFragment(to: newFragmentBytes.boundsChecked) },
+        { large in large.setFragment(to: newFragmentBytes.boundsChecked) }
+      )
+    }
+      ?? storage.withUnwrappedMutableStorage(
+        { small in small.setFragment(to: newValue) },
+        { large in large.setFragment(to: newValue) }
+      )
   }
 }


### PR DESCRIPTION
The improved performance comes mainly from 2 places:

- Not percent encoding values which we have checked don't need percent encoding (🤦‍♂️ - my bad)
- Using a fixed-capacity stack rather than an Array for ReplaceSubrangeOperations
- Using `withContiguousStorageIfAvailable` in the UTF8 views

The latter increases code-size dramatically because it generates more generic specialisations, especially on Darwin platforms where types like `String` might not have contiguous UTF8 code-units. I'm keeping a close eye on the code-size issue, and it will be reduced substantially by another PR which removes the header size variants (which comes with another performance boost).