### PR TITLE
Simplify URLStorage

### DIFF
--- a/Sources/WebURL/Parser/Parser+Path.swift
+++ b/Sources/WebURL/Parser/Parser+Path.swift
@@ -311,7 +311,7 @@ extension _PathParser {
       visitEmptyPathComponent()
       if isFileScheme, let base = baseURL {
         let _baseDrive = PathComponentParser._normalizedWindowsDrive(
-          in: base.utf8.path, firstCmptLength: base.storage.structure.firstPathComponentLength
+          in: base.utf8.path, firstCmptLength: Int(base.storage.structure.firstPathComponentLength)
         )
         if let baseDrive = _baseDrive {
           visitBasePathComponent(baseDrive)
@@ -434,7 +434,9 @@ extension _PathParser {
     if isFileScheme {
       if let basePath = _basePath {
         let baseURLFirstCmptLength = baseURL.unsafelyUnwrapped.storage.structure.firstPathComponentLength
-        baseDrive = PathComponentParser._normalizedWindowsDrive(in: basePath, firstCmptLength: baseURLFirstCmptLength)
+        baseDrive = PathComponentParser._normalizedWindowsDrive(
+          in: basePath, firstCmptLength: Int(baseURLFirstCmptLength)
+        )
       }
       // If the first written component of the input string is a Windows drive letter, the path is never relative -
       // even if it normally would be. [URL Standard: "file" state, "file slash" state]

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -475,7 +475,7 @@ extension ParsedURLString.ProcessedMapping {
       if baseURL.storage.structure.pathRequiresSigil, hasAuthority == false {
         writer.writePathSigil()
       }
-      writer.writePath(firstComponentLength: baseURL.storage.structure.firstPathComponentLength) { writer in
+      writer.writePath(firstComponentLength: Int(baseURL.storage.structure.firstPathComponentLength)) { writer in
         writer(baseURL.utf8.path)
       }
 

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -139,10 +139,10 @@ internal struct ParsedURLString<InputString> where InputString: BidirectionalCol
   internal func constructURLObject() -> WebURL? {
     var info = StructureAndMetricsCollector()
     write(to: &info)
-    guard info.requiredCapacity <= URLStorage.SizeType.max else {
+    guard let requiredCapacity = URLStorage.SizeType(exactly: info.requiredCapacity) else {
       return nil
     }
-    let storage = URLStorage(count: info.requiredCapacity, structure: info.structure) { buffer in
+    let storage = URLStorage(count: requiredCapacity, structure: URLStructure(copying: info.structure)) { buffer in
       var writer = UnsafePresizedBufferWriter(buffer: buffer, hints: info.hints)
       write(to: &writer)
       return writer.bytesWritten

--- a/Sources/WebURL/Parser/URLWriter.swift
+++ b/Sources/WebURL/Parser/URLWriter.swift
@@ -298,14 +298,14 @@ internal struct StructureAndMetricsCollector: URLWriter {
   internal mutating func writeAuthoritySigil() {
     assert(structure.sigil == .none)
     structure.sigil = .authority
-    requiredCapacity += Sigil.authority.length
+    requiredCapacity += Int(Sigil.authority.length)
   }
 
   @inlinable
   internal mutating func writePathSigil() {
     assert(structure.sigil == .none)
     structure.sigil = .path
-    requiredCapacity += Sigil.path.length
+    requiredCapacity += Int(Sigil.path.length)
   }
 
   @inlinable

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -37,7 +37,7 @@ extension URLStorage {
 
     // Check that the operation is semantically valid for the existing structure.
     let newSchemeBytes = newValue[..<idx]
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     if newSchemeKind.isSpecial != oldStructure.schemeKind.isSpecial {
       return .failure(.changeOfSchemeSpecialness)
@@ -92,7 +92,7 @@ extension URLStorage {
     to newValue: UTF8Bytes?
   ) -> Result<Void, URLSetterError> where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     // Check that the operation is semantically valid for the existing structure.
     if oldStructure.cannotHaveCredentialsOrPort {
@@ -151,7 +151,7 @@ extension URLStorage {
     to newValue: UTF8Bytes?
   ) -> Result<Void, URLSetterError> where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     // Check that the operation is semantically valid for the existing structure.
     if oldStructure.cannotHaveCredentialsOrPort {
@@ -223,7 +223,7 @@ extension URLStorage {
     to newValue: UTF8Bytes?
   ) -> Result<Void, URLSetterError> where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     // Check that the operation is semantically valid for the existing structure.
     guard oldStructure.isHierarchical else {
@@ -349,7 +349,7 @@ extension URLStorage {
   ) -> Result<Void, URLSetterError> {
 
     var newValue = newValue
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     // Check that the operation is semantically valid for the existing structure.
     guard !oldStructure.cannotHaveCredentialsOrPort else {
@@ -396,7 +396,7 @@ extension URLStorage {
     to newPath: UTF8Bytes
   ) -> Result<Void, URLSetterError> where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     // Check that the operation is semantically valid for the existing structure.
     guard oldStructure.isHierarchical else {
@@ -475,7 +475,7 @@ extension URLStorage {
     to newValue: UTF8Bytes?
   ) -> Result<Void, URLSetterError> where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
-    if self.header.structure.schemeKind.isSpecial {
+    if structure.schemeKind.isSpecial {
       return setSimpleComponent(
         .query,
         to: newValue,
@@ -748,7 +748,7 @@ extension URLStorage {
     codeUnits.unsafeReplaceSubrange(
       subrange.toCodeUnitsIndices(), withUninitializedCapacity: newElementCount, initializingWith: initializer
     )
-    header.structure = newStructure
+    structure = newStructure
     return .success
   }
 
@@ -764,7 +764,7 @@ extension URLStorage {
   ) {
     newStructure.checkInvariants()
     codeUnits.removeSubrange(subrange.toCodeUnitsIndices())
-    header.structure = newStructure
+    structure = newStructure
   }
 
   /// Performs a series of code-unit replacements and a URL structure replacement.
@@ -817,7 +817,7 @@ extension URLStorage {
           )
         }
       }
-      header.structure = newStructure
+      structure = newStructure
     } else {
       self = URLStorage(count: newCount, structure: newStructure) { dest in
         codeUnits.withUnsafeBufferPointer { src in
@@ -887,7 +887,7 @@ extension URLStorage {
   ) -> Result<Void, URLSetterError>
   where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8, EncodeSet: PercentEncodeSetProtocol {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     guard let newBytes = newValue else {
       guard let existingFragment = oldStructure.range(of: component) else {

--- a/Sources/WebURL/URLStorage.swift
+++ b/Sources/WebURL/URLStorage.swift
@@ -686,20 +686,27 @@ internal struct URLStorage {
 
 extension URLStorage {
 
-  // TODO: Change this to URLStructure<URLStorage.SizeType>
   @inlinable
-  internal var structure: URLStructure<Int> {
-    URLStructure<Int>(copying: header.structure)
+  internal var structure: URLStructure<URLStorage.SizeType> {
+    get {
+      header.structure
+    }
+    _modify {
+      yield &header.structure
+    }
+    set {
+      header.structure = newValue
+    }
   }
 
   @inlinable
   internal var schemeKind: WebURL.SchemeKind {
-    header.structure.schemeKind
+    structure.schemeKind
   }
 
   @inlinable
   internal var isHierarchical: Bool {
-    header.structure.isHierarchical
+    structure.isHierarchical
   }
 
   @inlinable
@@ -712,7 +719,6 @@ extension URLStorage {
       _ portLength: Int
     ) -> T
   ) -> T {
-    let structure = header.structure
     guard let range = structure.rangeOfAuthorityString else { return body(nil, 0, 0, 0, 0) }
     // Note: ManagedArrayBuffer.withUnsafeBufferPointer(range:) is bounds-checked.
     return codeUnits.withUnsafeBufferPointer(range: range.toCodeUnitsIndices()) { buffer in

--- a/Sources/WebURL/URLStorage.swift
+++ b/Sources/WebURL/URLStorage.swift
@@ -588,13 +588,13 @@ internal struct URLHeader<SizeType: FixedWidthInteger> {
   internal var _capacity: SizeType
 
   @usableFromInline
-  internal var structure: URLStructure<SizeType>
+  internal var _structure: URLStructure<SizeType>
 
   @inlinable
   internal init(_count: SizeType, _capacity: SizeType, _structure: URLStructure<SizeType>) {
     self._count = _count
     self._capacity = _capacity
-    self.structure = _structure
+    self._structure = _structure
   }
 
   @inlinable
@@ -622,7 +622,7 @@ extension URLHeader: ManagedBufferHeader {
     guard newCapacity >= minimumCapacity else {
       return nil
     }
-    return Self(_count: _count, _capacity: newCapacity, _structure: structure)
+    return Self(_count: _count, _capacity: newCapacity, _structure: _structure)
   }
 }
 
@@ -689,13 +689,13 @@ extension URLStorage {
   @inlinable
   internal var structure: URLStructure<URLStorage.SizeType> {
     get {
-      header.structure
+      header._structure
     }
     _modify {
-      yield &header.structure
+      yield &header._structure
     }
     set {
-      header.structure = newValue
+      header._structure = newValue
     }
   }
 

--- a/Sources/WebURL/Util/Errors.swift
+++ b/Sources/WebURL/Util/Errors.swift
@@ -1,0 +1,21 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension Result where Success == Void {
+
+  @inlinable
+  internal static var success: Self {
+    .success(())
+  }
+}

--- a/Sources/WebURL/WebURL+FilePaths.swift
+++ b/Sources/WebURL/WebURL+FilePaths.swift
@@ -894,18 +894,17 @@ internal func _filePathFromURL_windows(
 @inlinable
 internal var _emptyFileURL: WebURL {
   WebURL(
-    storage: AnyURLStorage(
-      URLStorage<BasicURLHeader<UInt8>>(
-        count: 8,
-        structure: URLStructure(
-          schemeLength: 5, usernameLength: 0, passwordLength: 0, hostnameLength: 0,
-          portLength: 0, pathLength: 1, queryLength: 0, fragmentLength: 0, firstPathComponentLength: 1,
-          sigil: .authority, schemeKind: .file, isHierarchical: true, queryIsKnownFormEncoded: true),
-        initializingCodeUnitsWith: { buffer in
-          ("file:///" as StaticString).withUTF8Buffer { buffer.fastInitialize(from: $0) }
-        }
-      )
-    ))
+    storage: URLStorage(
+      count: 8,
+      structure: URLStructure(
+        schemeLength: 5, usernameLength: 0, passwordLength: 0, hostnameLength: 0,
+        portLength: 0, pathLength: 1, queryLength: 0, fragmentLength: 0, firstPathComponentLength: 1,
+        sigil: .authority, schemeKind: .file, isHierarchical: true, queryIsKnownFormEncoded: true),
+      initializingCodeUnitsWith: { buffer in
+        ("file:///" as StaticString).withUTF8Buffer { buffer.fastInitialize(from: $0) }
+      }
+    )
+  )
 }
 
 extension PercentEncodeSet {

--- a/Sources/WebURL/WebURL+FormParameters.swift
+++ b/Sources/WebURL/WebURL+FormParameters.swift
@@ -498,7 +498,7 @@ extension URLStorage {
     fromEncoded keyValuePairs: C, lengthIfKnown: Int? = nil
   ) where C: Collection, C.Element == (UTF8Bytes, UTF8Bytes), UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
 
     let encodedKVPsLength: Int
     if let knownLength = lengthIfKnown {
@@ -570,7 +570,7 @@ extension URLStorage {
   ) where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
     assert(structure.queryIsKnownFormEncoded)
-    let oldQueryRange = header.structure.rangeForReplacingCodeUnits(of: .query).dropFirst().toCodeUnitsIndices()
+    let oldQueryRange = structure.rangeForReplacingCodeUnits(of: .query).dropFirst().toCodeUnitsIndices()
 
     // Find the first KVP to match the key. If no keys match, and we have a value to set, append the new value.
     let formParams = WebURL.FormEncodedQueryParameters.RawKeyValuePairs(utf8: codeUnits[oldQueryRange])
@@ -622,7 +622,7 @@ extension URLStorage {
 
     // Now that all subsequent KVPs have been removed, replace the value in the first match.
     // Since it already exists as part of a KVP, it already has the required separators around it.
-    var newStructure = header.structure
+    var newStructure = structure
     newStructure.queryLength -= URLStorage.SizeType(totalRemovedBytes)
 
     if let encodedValue = encodedValue, let rangeOfFirstValue = rangeToInsertNewValue {
@@ -647,7 +647,7 @@ extension URLStorage {
         newStructure.queryLength = 0
         removeSubrange(newStructure.queryStart..<newStructure.queryStart + 1, newStructure: newStructure)
       } else {
-        header.structure = newStructure
+        structure = newStructure
       }
     }
   }

--- a/Sources/WebURL/WebURL+JSModel.swift
+++ b/Sources/WebURL/WebURL+JSModel.swift
@@ -73,9 +73,9 @@ extension WebURL {
   ///
   public struct JSModel {
 
-    internal var storage: AnyURLStorage
+    internal var storage: URLStorage
 
-    init(storage: AnyURLStorage) {
+    init(storage: URLStorage) {
       self.storage = storage
     }
 
@@ -334,7 +334,7 @@ extension WebURL.JSModel {
       if newValue.first?.asciiValue == ASCII.questionMark.codePoint {
         newQuery = newValue.dropFirst()
       }
-      swiftModel.utf8.setQuery(ASCII.NewlineAndTabFiltered(newQuery.utf8))
+      try? swiftModel.utf8.setQuery(ASCII.NewlineAndTabFiltered(newQuery.utf8))
     }
   }
 
@@ -357,7 +357,7 @@ extension WebURL.JSModel {
       if newValue.first?.asciiValue == ASCII.numberSign.codePoint {
         newFragment = newValue.dropFirst()
       }
-      swiftModel.utf8.setFragment(ASCII.NewlineAndTabFiltered(newFragment.utf8))
+      try? swiftModel.utf8.setFragment(ASCII.NewlineAndTabFiltered(newFragment.utf8))
     }
   }
 }

--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -637,13 +637,13 @@ extension URLStorage {
 
   @inlinable
   internal var pathComponentsStartIndex: WebURL.PathComponents.Index {
-    let pathStart = header.structure.rangeForReplacingCodeUnits(of: .path).lowerBound
-    return WebURL.PathComponents.Index(codeUnitRange: pathStart..<pathStart + header.structure.firstPathComponentLength)
+    let pathStart = structure.rangeForReplacingCodeUnits(of: .path).lowerBound
+    return WebURL.PathComponents.Index(codeUnitRange: pathStart..<pathStart + structure.firstPathComponentLength)
   }
 
   @inlinable
   internal var pathComponentsEndIndex: WebURL.PathComponents.Index {
-    let pathEnd = header.structure.rangeForReplacingCodeUnits(of: .path).upperBound
+    let pathEnd = structure.rangeForReplacingCodeUnits(of: .path).upperBound
     return WebURL.PathComponents.Index(codeUnitRange: pathEnd..<pathEnd)
   }
 
@@ -653,7 +653,7 @@ extension URLStorage {
   ///
   @inlinable
   internal func endOfPathComponent(startingAt componentStartOffset: Int) -> Int? {
-    let pathRange = header.structure.rangeForReplacingCodeUnits(of: .path).toCodeUnitsIndices()
+    let pathRange = structure.rangeForReplacingCodeUnits(of: .path).toCodeUnitsIndices()
     guard pathRange.contains(componentStartOffset) else { return nil }
     assert(codeUnits[componentStartOffset] == ASCII.forwardSlash.codePoint, "UTF8 position not aligned to a component")
     return codeUnits[componentStartOffset + 1..<pathRange.upperBound].firstIndex(of: ASCII.forwardSlash.codePoint)
@@ -669,7 +669,7 @@ extension URLStorage {
   ///
   @inlinable
   internal func startOfPathComponent(endingAt componentEndOffset: Int) -> Int? {
-    let pathRange = header.structure.rangeForReplacingCodeUnits(of: .path).toCodeUnitsIndices()
+    let pathRange = structure.rangeForReplacingCodeUnits(of: .path).toCodeUnitsIndices()
     guard componentEndOffset > pathRange.lowerBound, componentEndOffset <= pathRange.upperBound else { return nil }
     assert(
       componentEndOffset == pathRange.upperBound || codeUnits[componentEndOffset] == ASCII.forwardSlash.codePoint,
@@ -689,7 +689,7 @@ extension URLStorage {
   @inlinable
   internal mutating func _clearPath() -> Range<WebURL.PathComponents.Index> {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
     let oldPathRange = oldStructure.rangeForReplacingCodeUnits(of: .path)
     precondition(oldStructure.isHierarchical, "Cannot replace components of a non-hierarchical URL")
 
@@ -716,8 +716,8 @@ extension URLStorage {
         try! multiReplaceSubrange(commands, newStructure: newStructure).get()
       }
     }
-    let newPathStart = header.structure.pathStart
-    let newPathEnd = header.structure.pathStart &+ header.structure.pathLength
+    let newPathStart = structure.pathStart
+    let newPathEnd = structure.pathStart &+ structure.pathLength
     let newLowerBound = WebURL.PathComponents.Index(codeUnitRange: newPathStart..<newPathEnd)
     let newUpperBound = WebURL.PathComponents.Index(codeUnitRange: newPathEnd..<newPathEnd)
     return Range(uncheckedBounds: (newLowerBound, newUpperBound))
@@ -735,7 +735,7 @@ extension URLStorage {
   ) -> Range<WebURL.PathComponents.Index>
   where Components: Collection, Components.Element: Collection, Components.Element.Element == UInt8 {
 
-    let oldStructure = header.structure
+    let oldStructure = structure
     let oldPathRange = oldStructure.rangeForReplacingCodeUnits(of: .path).toCodeUnitsIndices()
     precondition(oldStructure.isHierarchical, "Cannot replace components of a non-hierarchical URL")
 
@@ -863,7 +863,7 @@ extension URLStorage {
 
     // Post-replacement normalization of Windows drive letters.
     // This is necessary to preserve idempotence, but doesn't modify the URLStructure.
-    if case .file = header.structure.schemeKind {
+    if case .file = structure.schemeKind {
       _normalizeWindowsDriveLetterIfPresent()
     }
 
@@ -892,7 +892,7 @@ extension URLStorage {
 
   @inlinable
   internal mutating func _normalizeWindowsDriveLetterIfPresent() {
-    guard case .file = header.structure.schemeKind, header.structure.firstPathComponentLength == 3 else { return }
+    guard case .file = structure.schemeKind, structure.firstPathComponentLength == 3 else { return }
     let firstComponent = utf8.path.dropFirst().prefix(2)
     if PathComponentParser.isWindowsDriveLetter(firstComponent) {
       codeUnits[firstComponent.startIndex + 1] = ASCII.colon.codePoint

--- a/Sources/WebURL/WebURL+UTF8View.swift
+++ b/Sources/WebURL/WebURL+UTF8View.swift
@@ -90,6 +90,11 @@ extension WebURL.UTF8View: RandomAccessCollection {
   }
 
   @inlinable
+  public subscript(bounds: Range<Index>) -> Slice<Self> {
+    Slice(base: self, bounds: bounds)
+  }
+
+  @inlinable
   public func index(after i: Index) -> Index {
     i &+ 1
   }
@@ -412,5 +417,10 @@ extension WebURL.UTF8View {
       storage.setQuery(toKnownFormEncoded: $0.boundsChecked)
     } ?? storage.setQuery(toKnownFormEncoded: newValue)
     try result.get()
+  }
+
+  @inlinable @inline(__always)
+  internal subscript(bounds: Range<URLStorage.SizeType>) -> Slice<WebURL.UTF8View> {
+    self[bounds.toCodeUnitsIndices()]
   }
 }

--- a/Sources/WebURL/WebURL.swift
+++ b/Sources/WebURL/WebURL.swift
@@ -27,10 +27,10 @@
 public struct WebURL {
 
   @usableFromInline
-  internal var storage: AnyURLStorage
+  internal var storage: URLStorage
 
   @inlinable
-  internal init(storage: AnyURLStorage) {
+  internal init(storage: URLStorage) {
     self.storage = storage
   }
 
@@ -259,7 +259,7 @@ extension WebURL {
   ///
   public var query: String? {
     get { utf8.query.map { String(decoding: $0, as: UTF8.self) } }
-    set { setQuery(newValue) }
+    set { try? setQuery(newValue) }
   }
 
   /// The fragment of this URL, if present, as a percent-encoded string.
@@ -271,7 +271,7 @@ extension WebURL {
   ///
   public var fragment: String? {
     get { utf8.fragment.map { String(decoding: $0, as: UTF8.self) } }
-    set { setFragment(newValue) }
+    set { try? setFragment(newValue) }
   }
 
   /// Whether this is a hierarchical URL.
@@ -363,19 +363,12 @@ extension WebURL {
   ///
   public mutating func setPort(_ newPort: Int?) throws {
     guard let newPort = newPort else {
-      try storage.withUnwrappedMutableStorage(
-        { small in small.setPort(to: nil) },
-        { large in large.setPort(to: nil) }
-      )
-      return
+      return try storage.setPort(to: nil).get()
     }
     guard let uint16Port = UInt16(exactly: newPort) else {
       throw URLSetterError.portValueOutOfBounds
     }
-    try storage.withUnwrappedMutableStorage(
-      { small in small.setPort(to: uint16Port) },
-      { large in large.setPort(to: uint16Port) }
-    )
+    try storage.setPort(to: uint16Port).get()
   }
 
   /// Replaces this URL's `path` with the given string.
@@ -398,8 +391,8 @@ extension WebURL {
   /// - seealso: `query`
   ///
   @inlinable
-  public mutating func setQuery<S>(_ newQuery: S?) where S: StringProtocol {
-    utf8.setQuery(newQuery?.utf8)
+  public mutating func setQuery<S>(_ newQuery: S?) throws where S: StringProtocol {
+    try utf8.setQuery(newQuery?.utf8)
   }
 
   /// Replaces this URL's `fragment` with the given string.
@@ -409,7 +402,7 @@ extension WebURL {
   /// - seealso: `fragment`
   ///
   @inlinable
-  public mutating func setFragment<S>(_ newFragment: S?) where S: StringProtocol {
-    utf8.setFragment(newFragment?.utf8)
+  public mutating func setFragment<S>(_ newFragment: S?) throws where S: StringProtocol {
+    try utf8.setFragment(newFragment?.utf8)
   }
 }

--- a/Sources/WebURL/WebURL.swift
+++ b/Sources/WebURL/WebURL.swift
@@ -162,7 +162,7 @@ extension WebURL {
   /// The string representation of this URL, excluding the URL's fragment.
   ///
   public var serializedExcludingFragment: String {
-    utf8.withUnsafeBufferPointer { String(decoding: $0[..<storage.structure.fragmentStart], as: UTF8.self) }
+    utf8[0..<storage.structure.fragmentStart].withUnsafeBufferPointer { String(decoding: $0, as: UTF8.self) }
   }
 
   /// The scheme of this URL, for example `https` or `file`.

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -851,32 +851,6 @@ extension WebURLTests {
       XCTAssertEqual(x.href, "sc://x?hello")
       XCTAssertEqual(x.pathname, "")
     }
-
-
-    // TODO [testing]: This test needs to be more comprehensive, and we need tests like this exercising all major
-    // paths in all setters.
-
-    // Checks what happens when a scheme change requires the port to be removed, and the resulting URL
-    // has a different optimal storage type to the original (i.e. suddenly becomes less than 255 bytes).
-    // It's such a niche case that we'd otherwise never see it.
-    do {
-      var url = WebURL(
-        "ws://hostnamewhichtakesustotheedge:443?hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellop"
-      )!.jsModel
-      switch url.storage {
-      case .large(_): break
-      default: XCTFail("Unexpected storage type")
-      }
-      url.scheme = "wss"
-      switch url.storage {
-      case .small(_): break
-      default: XCTFail("Unexpected storage type")
-      }
-      XCTAssertEqual(
-        url.description,
-        "wss://hostnamewhichtakesustotheedge/?hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellop"
-      )
-    }
   }
 }
 


### PR DESCRIPTION
Rather than having 2 header types, one with `UInt8` values and another with `Int` values, use a single header type with a compromise of `UInt32` values. This means the maximum size a `URLStorage` can address is 4GB. Which should be plenty. It also means that small URLs require slightly larger allocations, which is unfortunate but I think it's worth the trade-off.

This change basically doesn't affect the parser at all, but it does help manipulate URL objects after they have been parsed. The code can be cleaner and more direct, because we don't need to be so cautious about, say, the path you set spilling over the 255 character limit and having to allocate new storage with a different header type. It also means less generic specialisations, less branching, more comprehensive testing, etc.

Benchmarking against `main` (with the recent component setter optimisations) shows a ~15-20% improvement in performance, with a ~10% decrease in code-size at -O.

```
benchmark                                          column     results/main_opt results/simple-storage       %
-------------------------------------------------------------------------------------------------------------
ComponentSetters.Unique.Scheme                     std                  126.34                 277.73 -119.82
ComponentSetters.Unique.Scheme                     warmup             77893.00               53176.00   31.73
ComponentSetters.Unique.Scheme                     iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Scheme                     time                 959.00                 785.00   18.14
ComponentSetters.Unique.Scheme.Long                std                  114.69                 117.09   -2.09
ComponentSetters.Unique.Scheme.Long                warmup             71283.00               71370.00   -0.12
ComponentSetters.Unique.Scheme.Long                iterations        990592.00             1000000.00   -0.95
ComponentSetters.Unique.Scheme.Long                time                1224.00                1194.00    2.45
ComponentSetters.Unique.Username                   std                  190.72                  74.79   60.78
ComponentSetters.Unique.Username                   warmup             47554.00               37304.00   21.55
ComponentSetters.Unique.Username                   iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Username                   time                 645.00                 434.00   32.71
ComponentSetters.Unique.Username.PercentEncoding   std                  220.69                 116.41   47.25
ComponentSetters.Unique.Username.PercentEncoding   warmup             66663.00               64993.00    2.51
ComponentSetters.Unique.Username.PercentEncoding   iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Username.PercentEncoding   time                1094.00                 945.00   13.62
ComponentSetters.Unique.Username.Long              std                  252.36                 172.54   31.63
ComponentSetters.Unique.Username.Long              warmup             50917.00               44703.00   12.20
ComponentSetters.Unique.Username.Long              iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Username.Long              time                 918.00                 784.00   14.60
ComponentSetters.Unique.Password                   std                  368.14                  96.12   73.89
ComponentSetters.Unique.Password                   warmup             42366.00               24884.00   41.26
ComponentSetters.Unique.Password                   iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Password                   time                 633.00                 443.00   30.02
ComponentSetters.Unique.Password.PercentEncoding   std                  271.71                 102.83   62.16
ComponentSetters.Unique.Password.PercentEncoding   warmup             98584.00               84665.00   14.12
ComponentSetters.Unique.Password.PercentEncoding   iterations        761237.00              843153.00  -10.76
ComponentSetters.Unique.Password.PercentEncoding   time                1681.00                1449.00   13.80
ComponentSetters.Unique.Password.Long              std                   65.97                 170.16 -157.91
ComponentSetters.Unique.Password.Long              warmup             57499.00               52517.00    8.66
ComponentSetters.Unique.Password.Long              iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Password.Long              time                 906.00                 779.00   14.02
ComponentSetters.Unique.Hostname.Domain.ASCII      std                  131.09                 435.82 -232.46
ComponentSetters.Unique.Hostname.Domain.ASCII      warmup             88937.00               70678.00   20.53
ComponentSetters.Unique.Hostname.Domain.ASCII      iterations        896744.00             1000000.00  -11.51
ComponentSetters.Unique.Hostname.Domain.ASCII      time                1411.00                1032.00   26.86
ComponentSetters.Unique.Hostname.IPv4              std                  156.77                 274.79  -75.29
ComponentSetters.Unique.Hostname.IPv4              warmup            120610.00               85594.00   29.03
ComponentSetters.Unique.Hostname.IPv4              iterations        731965.00              979289.00  -33.79
ComponentSetters.Unique.Hostname.IPv4              time                1740.00                1289.00   25.92
ComponentSetters.Unique.Hostname.IPv6              std                   88.17                 215.56 -144.50
ComponentSetters.Unique.Hostname.IPv6              warmup            170662.00              115417.00   32.37
ComponentSetters.Unique.Hostname.IPv6              iterations        622189.00              795797.00  -27.90
ComponentSetters.Unique.Hostname.IPv6              time                1999.00                1588.00   20.56
ComponentSetters.Unique.Hostname.Opaque            std                  129.07                  82.37   36.18
ComponentSetters.Unique.Hostname.Opaque            warmup             81928.00               47131.00   42.47
ComponentSetters.Unique.Hostname.Opaque            iterations       1000000.00             1000000.00    0.00
ComponentSetters.Unique.Hostname.Opaque            time                1171.00                 869.00   25.79
ComponentSetters.Unique.Hostname.Domain.ASCII.Long std                  107.20                  63.11   41.13
ComponentSetters.Unique.Hostname.Domain.ASCII.Long warmup            100747.00               86286.00   14.35
ComponentSetters.Unique.Hostname.Domain.ASCII.Long iterations        685340.00              822041.00  -19.95
ComponentSetters.Unique.Hostname.Domain.ASCII.Long time                1813.00                1532.00   15.50
ComponentSetters.Unique.Hostname.Opaque.Long       std                  188.10                 136.92   27.21
ComponentSetters.Unique.Hostname.Opaque.Long       warmup             78353.00               59082.00   24.60
ComponentSetters.Unique.Hostname.Opaque.Long       iterations        950634.00             1000000.00   -5.19
ComponentSetters.Unique.Hostname.Opaque.Long       time                1337.00                1112.00   16.83
ComponentSetters.Unique.Path.Simple                std                   62.05                 159.52 -157.10
ComponentSetters.Unique.Path.Simple                warmup            252590.00              169195.00   33.02
ComponentSetters.Unique.Path.Simple                iterations        382291.00              422953.00  -10.64
ComponentSetters.Unique.Path.Simple                time                3340.00                2977.00   10.87
ComponentSetters.Unique.Path.DotDot                std                   50.20                  71.62  -42.67
ComponentSetters.Unique.Path.DotDot                warmup            216254.00              201177.00    6.97
ComponentSetters.Unique.Path.DotDot                iterations        365725.00              404258.00  -10.54
ComponentSetters.Unique.Path.DotDot                time                3456.00                3158.00    8.62
ComponentSetters.Unique.Path.PercentEncoding       std                  138.34                  57.74   58.26
ComponentSetters.Unique.Path.PercentEncoding       warmup            169474.00              147776.00   12.80
ComponentSetters.Unique.Path.PercentEncoding       iterations        430037.00              497423.00  -15.67
ComponentSetters.Unique.Path.PercentEncoding       time                2893.00                2583.00   10.72
ComponentSetters.Unique.Path.Simple.Long           std                   40.94                  47.97  -17.15
ComponentSetters.Unique.Path.Simple.Long           warmup            135256.00              158478.00  -17.17
ComponentSetters.Unique.Path.Simple.Long           iterations        502878.00              565492.00  -12.45
ComponentSetters.Unique.Path.Simple.Long           time                2538.00                2238.00   11.82
ComponentSetters.Unique.Path.PercentEncoding.Long  std                  164.41                 187.13  -13.82
ComponentSetters.Unique.Path.PercentEncoding.Long  warmup            330675.00              140240.00   57.59
ComponentSetters.Unique.Path.PercentEncoding.Long  iterations        488931.00              537271.00   -9.89
ComponentSetters.Unique.Path.PercentEncoding.Long  time                2602.00                2343.00    9.95
ComponentSetters.Unique.Query                      std                  205.57                  89.59   56.42
ComponentSetters.Unique.Query                      warmup            283500.00              214085.00   24.49
ComponentSetters.Unique.Query                      iterations        581346.00              699792.00  -20.37
ComponentSetters.Unique.Query                      time                2196.00                1760.00   19.85
ComponentSetters.Unique.Query.PercentEncoding      std                  178.99                 189.63   -5.94
ComponentSetters.Unique.Query.PercentEncoding      warmup            126083.00              110071.00   12.70
ComponentSetters.Unique.Query.PercentEncoding      iterations        637769.00              738812.00  -15.84
ComponentSetters.Unique.Query.PercentEncoding      time                2044.00                1734.00   15.17
ComponentSetters.Unique.Query.Long                 std                  224.85                 103.41   54.01
ComponentSetters.Unique.Query.Long                 warmup            188157.00              145062.00   22.90
ComponentSetters.Unique.Query.Long                 iterations        763665.00              737370.00    3.44
ComponentSetters.Unique.Query.Long                 time                1685.00                1731.00   -2.73
ComponentSetters.Unique.Fragment                   std                  259.55                  84.25   67.54
ComponentSetters.Unique.Fragment                   warmup            134979.00              117439.00   12.99
ComponentSetters.Unique.Fragment                   iterations        795093.00              973030.00  -22.38
ComponentSetters.Unique.Fragment                   time                1584.00                1267.00   20.01
ComponentSetters.Unique.Fragment.PercentEncoding   std                   64.19                  89.77  -39.85
ComponentSetters.Unique.Fragment.PercentEncoding   warmup            118858.00              103908.00   12.58
ComponentSetters.Unique.Fragment.PercentEncoding   iterations        638823.00              723466.00  -13.25
ComponentSetters.Unique.Fragment.PercentEncoding   time                1985.00                1723.00   13.20
PathComponents.Iteration.Small.Forwards            std                   51.47                 100.67  -95.59
PathComponents.Iteration.Small.Forwards            warmup            507725.00              354022.00   30.27
PathComponents.Iteration.Small.Forwards            iterations        247553.00              330262.00  -33.41
PathComponents.Iteration.Small.Forwards            time                5089.00                3830.00   24.74
PathComponents.Iteration.Small.Reverse             std                  174.53                 101.32   41.95
PathComponents.Iteration.Small.Reverse             warmup            261452.00              253243.00    3.14
PathComponents.Iteration.Small.Reverse             iterations        248104.00              334175.00  -34.69
PathComponents.Iteration.Small.Reverse             time                5041.00                3783.00   24.96
PathComponents.Iteration.Long.Forwards             std                   68.97                  48.32   29.94
PathComponents.Iteration.Long.Forwards             warmup           1543872.00             1131213.00   26.73
PathComponents.Iteration.Long.Forwards             iterations         52374.00               72860.00  -39.11
PathComponents.Iteration.Long.Forwards             time               23016.00               17171.00   25.40
PathComponents.Iteration.Long.Reverse              std                   65.82                  39.91   39.36
PathComponents.Iteration.Long.Reverse              warmup           1267713.00              865258.00   31.75
PathComponents.Iteration.Long.Reverse              iterations         54473.00               73700.00  -35.30
PathComponents.Iteration.Long.Reverse              time               22507.00               16933.00   24.77
PathComponents.Append.Single                       std                   68.08                 110.40  -62.15
PathComponents.Append.Single                       warmup            299586.00              249694.00   16.65
PathComponents.Append.Single                       iterations        683086.00              872569.00  -27.74
PathComponents.Append.Single                       time                1866.00                1476.00   20.90
PathComponents.Append.Multiple                     std                   78.97                 224.53 -184.33
PathComponents.Append.Multiple                     warmup            169893.00              119794.00   29.49
PathComponents.Append.Multiple                     iterations        451746.00              607592.00  -34.50
PathComponents.Append.Multiple                     time                2769.00                2083.00   24.77
PathComponents.RemoveLast.Single                   std                   91.27                  58.02   36.43
PathComponents.RemoveLast.Single                   warmup            128057.00               51531.00   59.76
PathComponents.RemoveLast.Single                   iterations        928213.00             1000000.00   -7.73
PathComponents.RemoveLast.Single                   time                1350.00                 696.00   48.44
PathComponents.RemoveLast.Multiple                 std                  208.07                 127.44   38.75
PathComponents.RemoveLast.Multiple                 warmup             83565.00               51525.00   38.34
PathComponents.RemoveLast.Multiple                 iterations        900737.00             1000000.00  -11.02
PathComponents.RemoveLast.Multiple                 time                1389.00                 750.00   46.00
PathComponents.ReplaceSubrange.Shrink              std                  248.84                 278.61  -11.96
PathComponents.ReplaceSubrange.Shrink              warmup            134051.00              103185.00   23.03
PathComponents.ReplaceSubrange.Shrink              iterations        547846.00              893743.00  -63.14
PathComponents.ReplaceSubrange.Shrink              time                2256.00                1413.00   37.37
PathComponents.ReplaceSubrange.Grow                std                  112.39                  96.76   13.91
PathComponents.ReplaceSubrange.Grow                warmup            217469.00              160290.00   26.29
PathComponents.ReplaceSubrange.Grow                iterations        348689.00              453680.00  -30.11
PathComponents.ReplaceSubrange.Grow                time                3613.00                2839.00   21.42
-------------------------------------------------------------------------------------------------------------
                                                   std                                                   8.34
                                                   warmup                                               24.03
                                                   iterations                                          -15.38
                                                   time                                                 20.98
```

```
karl@Karls-MBP Benchmarks % /Volumes/Code/swift-project/swift/utils/cmpcodesize/cmpcodesize.py ../../bench-build-mainopt/WebURL.build/**/*.o -- ./.build/release/WebURL.build/**/*.o -s
Title                              Section             Old             New  Percent
old-new                             __text:        1293995         1115987   -13.8%
```

```
karl@Karls-MBP Benchmarks % /Volumes/Code/swift-project/swift/utils/cmpcodesize/cmpcodesize.py ../../bench-build-mainopt/WebURLBenchmark -- ./.build/release/WebURLBenchmark       
Title                              Section             Old             New  Percent
WebURLBenchmark                     __text:        1871795         1689987    -9.7%
```