### PR TITLE
Flatten lazy percent-encoding, improve string creation, etc

### DIFF
--- a/Sources/WebURL/IPAddress.swift
+++ b/Sources/WebURL/IPAddress.swift
@@ -286,12 +286,12 @@ extension IPv6Address {
       var idx = utf8.startIndex
 
       if utf8[idx] == ASCII.colon.codePoint {
-        idx = utf8.index(after: idx)
+        utf8.formIndex(after: &idx)
         guard idx < utf8.endIndex, utf8[idx] == ASCII.colon.codePoint else {
           callback.validationError(ipv6: .unexpectedLeadingColon)
           return nil
         }
-        idx = utf8.index(after: idx)
+        utf8.formIndex(after: &idx)
         pieceIndex &+= 1
         expandFrom = pieceIndex
       }
@@ -306,7 +306,7 @@ extension IPv6Address {
             callback.validationError(ipv6: .multipleCompressedPieces)
             return nil
           }
-          idx = utf8.index(after: idx)
+          utf8.formIndex(after: &idx)
           pieceIndex &+= 1
           expandFrom = pieceIndex
           continue parseloop
@@ -320,7 +320,7 @@ extension IPv6Address {
           value <<= 4
           value &+= UInt16(numberValue)
           length &+= 1
-          idx = utf8.index(after: idx)
+          utf8.formIndex(after: &idx)
         }
         value = value.bigEndian
         // After the numeric value.
@@ -335,7 +335,7 @@ extension IPv6Address {
         guard utf8[idx] != ASCII.colon.codePoint else {
           parsedPieces[pieceIndex] = value
           pieceIndex &+= 1
-          idx = utf8.index(after: idx)
+          utf8.formIndex(after: &idx)
           guard idx < utf8.endIndex else {
             callback.validationError(ipv6: .unexpectedTrailingColon)
             return nil
@@ -718,11 +718,11 @@ extension IPv4Address {
           return nil
         }
         if firstCharInPiece == ASCII.n0 {
-          idx = utf8.index(after: idx)
+          utf8.formIndex(after: &idx)
           if idx < utf8.endIndex {
             if ASCII(utf8[idx])?.lowercased == .x {
               radix = 16
-              idx = utf8.index(after: idx)
+              utf8.formIndex(after: &idx)
             } else {
               radix = 8
             }
@@ -741,7 +741,7 @@ extension IPv4Address {
             callback.validationError(ipv4: .pieceOverflows)
             return nil
           }
-          idx = utf8.index(after: idx)
+          utf8.formIndex(after: &idx)
         }
         // Set the piece to its numeric value.
         guard pieceIndex < 4 else {
@@ -755,7 +755,7 @@ extension IPv4Address {
         guard idx < utf8.endIndex, utf8[idx] == ASCII.period.codePoint else {
           break
         }
-        idx = utf8.index(after: idx)
+        utf8.formIndex(after: &idx)
       }
 
       guard idx == utf8.endIndex else {
@@ -875,7 +875,7 @@ extension IPv4Address {
         guard numbersSeen < 4 else {
           return nil  // too many pieces.
         }
-        idx = utf8.index(after: idx)
+        utf8.formIndex(after: &idx)
       }
       var ipv4Piece = -1  // -1 means "no digits parsed".
       while idx < utf8.endIndex, let digit = ASCII(utf8[idx])?.decimalNumberValue {
@@ -891,7 +891,7 @@ extension IPv4Address {
         guard ipv4Piece < 256 else {
           return nil  // piece overflow.
         }
-        idx = utf8.index(after: idx)
+        utf8.formIndex(after: &idx)
       }
       guard ipv4Piece > -1 else {
         return nil  // piece does not begin with a decimal digit.

--- a/Sources/WebURL/Parser/Parser+Host.swift
+++ b/Sources/WebURL/Parser/Parser+Host.swift
@@ -170,7 +170,7 @@ extension ParsedHost {
           callback.validationError(.domainToASCIIFailure)
           return .containsUnicodeOrIDNA
         }
-        if i != domain.endIndex {
+        if i < domain.endIndex {
           startOfLastLabel = i
         }
       }

--- a/Sources/WebURL/Parser/Parser+Host.swift
+++ b/Sources/WebURL/Parser/Parser+Host.swift
@@ -283,7 +283,7 @@ extension ParsedHost {
     case .opaque(let hostnameInfo):
       if hostnameInfo.needsPercentEncoding {
         writer.writeHostname(lengthIfKnown: hostnameInfo.encodedCount) { writePiece in
-          _ = bytes.lazy.percentEncodedGroups(as: \.c0Control).write(to: writePiece)
+          _ = bytes.lazy.percentEncoded(as: \.c0Control).write(to: writePiece)
         }
       } else {
         writer.writeHostname(lengthIfKnown: hostnameInfo.encodedCount) { writePiece in

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -384,7 +384,7 @@ extension ParsedURLString.ProcessedMapping {
         } else {
           var wasEncoded = false
           writer.writeUsernameContents { writer in
-            wasEncoded = inputString[username].lazy.percentEncodedGroups(as: \.userInfo).write(to: writer)
+            wasEncoded = inputString[username].lazy.percentEncoded(as: \.userInfo).write(to: writer)
           }
           writer.writeHint(.username, maySkipPercentEncoding: !wasEncoded)
         }
@@ -396,7 +396,7 @@ extension ParsedURLString.ProcessedMapping {
         } else {
           var wasEncoded = false
           writer.writePasswordContents { writer in
-            wasEncoded = inputString[password].lazy.percentEncodedGroups(as: \.userInfo).write(to: writer)
+            wasEncoded = inputString[password].lazy.percentEncoded(as: \.userInfo).write(to: writer)
           }
           writer.writeHint(.password, maySkipPercentEncoding: !wasEncoded)
         }
@@ -433,7 +433,7 @@ extension ParsedURLString.ProcessedMapping {
       } else {
         var wasEncoded = false
         writer.writePath(firstComponentLength: 0) { writer in
-          wasEncoded = inputString[path].lazy.percentEncodedGroups(as: \.c0Control).write(to: writer)
+          wasEncoded = inputString[path].lazy.percentEncoded(as: \.c0Control).write(to: writer)
         }
         writer.writeHint(.path, maySkipPercentEncoding: !wasEncoded)
       }
@@ -493,11 +493,11 @@ extension ParsedURLString.ProcessedMapping {
         writer.writeQueryContents { writer in writer(inputString[query]) }
       } else {
         var wasEncoded = false
-        writer.writeQueryContents { (writer: (_PercentEncodedByte) -> Void) in
+        writer.writeQueryContents { (writer: (UnsafeBufferPointer<UInt8>) -> Void) in
           if schemeKind.isSpecial {
-            wasEncoded = inputString[query].lazy.percentEncodedGroups(as: \.query_special).write(to: writer)
+            wasEncoded = inputString[query].lazy.percentEncoded(as: \.query_special).write(to: writer)
           } else {
-            wasEncoded = inputString[query].lazy.percentEncodedGroups(as: \.query_notSpecial).write(to: writer)
+            wasEncoded = inputString[query].lazy.percentEncoded(as: \.query_notSpecial).write(to: writer)
           }
         }
         writer.writeHint(.query, maySkipPercentEncoding: !wasEncoded)
@@ -518,7 +518,7 @@ extension ParsedURLString.ProcessedMapping {
       } else {
         var wasEncoded = false
         writer.writeFragmentContents { writer in
-          wasEncoded = inputString[fragment].lazy.percentEncodedGroups(as: \.fragment).write(to: writer)
+          wasEncoded = inputString[fragment].lazy.percentEncoded(as: \.fragment).write(to: writer)
         }
         writer.writeHint(.fragment, maySkipPercentEncoding: !wasEncoded)
       }

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -417,8 +417,8 @@ extension Collection where Element == UInt8 {
     as encodeSet: KeyPath<PercentEncodeSet, EncodeSet.Type>
   ) -> String {
     withContiguousStorageIfAvailable {
-      String(decoding: $0.boundsChecked.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
-    } ?? String(decoding: self.lazy.percentEncoded(as: encodeSet), as: UTF8.self)
+      String(discontiguousUTF8: $0.boundsChecked.lazy.percentEncoded(as: encodeSet))
+    } ?? String(discontiguousUTF8: self.lazy.percentEncoded(as: encodeSet))
   }
 
   /// Interpets this collection's elements as UTF-8 code-units, and returns a `String` formed by encoding them using the `\.component` encoding-set.
@@ -772,8 +772,8 @@ extension Collection where Element == UInt8 {
     from decodeSet: KeyPath<PercentDecodeSet, EncodeSet.Type>
   ) -> String where EncodeSet: PercentEncodeSetProtocol {
     withContiguousStorageIfAvailable {
-      String(decoding: $0.boundsChecked.lazy.percentDecodedUTF8(from: decodeSet), as: UTF8.self)
-    } ?? String(decoding: self.lazy.percentDecodedUTF8(from: decodeSet), as: UTF8.self)
+      String(discontiguousUTF8: $0.boundsChecked.lazy.percentDecodedUTF8(from: decodeSet))
+    } ?? String(discontiguousUTF8: self.lazy.percentDecodedUTF8(from: decodeSet))
   }
 
   /// Interprets this collection's elements as UTF-8 code-units, and returns a string formed by decoding all percent-encoded code-unit sequences.

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -111,7 +111,7 @@ extension URLStorage {
       return .success
     }
 
-    let (_newValueLength, needsEncoding) = newValue.lazy.percentEncodedGroups(as: \.userInfo).encodedLength
+    let (_newValueLength, needsEncoding) = newValue.lazy.percentEncoded(as: \.userInfo).unsafeEncodedLength
     guard let newValueLength = URLStorage.SizeType(exactly: _newValueLength) else {
       return .failure(.exceedsMaximumSize)
     }
@@ -168,7 +168,7 @@ extension URLStorage {
       return .success
     }
 
-    let (_newValueLength, needsEncoding) = newValue.lazy.percentEncodedGroups(as: \.userInfo).encodedLength
+    let (_newValueLength, needsEncoding) = newValue.lazy.percentEncoded(as: \.userInfo).unsafeEncodedLength
     guard let newValueLength = URLStorage.SizeType(exactly: _newValueLength) else {
       return .failure(.exceedsMaximumSize)
     }
@@ -890,7 +890,7 @@ extension URLStorage {
       return .success
     }
 
-    let (_newValueLength, needsEncoding) = newBytes.lazy.percentEncodedGroups(as: encodeSet).encodedLength
+    let (_newValueLength, needsEncoding) = newBytes.lazy.percentEncoded(as: encodeSet).unsafeEncodedLength
     guard let newValueLength = URLStorage.SizeType(exactly: _newValueLength) else {
       return .failure(.exceedsMaximumSize)
     }

--- a/Sources/WebURL/Util/ASCII.swift
+++ b/Sources/WebURL/Util/ASCII.swift
@@ -287,9 +287,9 @@ extension ASCII {
 // --------------------------------------------
 
 
-@usableFromInline internal let DC: UInt8 = 99
+@usableFromInline internal let DC: Int8 = -1
 // swift-format-ignore
-@usableFromInline internal let _parseHex_table: [UInt8] = [
+@usableFromInline internal let _parseHex_table: [Int8] = [
     DC, DC, DC, DC, DC, DC, DC, DC, DC, DC, // 48 invalid chars.
     DC, DC, DC, DC, DC, DC, DC, DC, DC, DC,
     DC, DC, DC, DC, DC, DC, DC, DC, DC, DC,
@@ -313,9 +313,8 @@ extension ASCII {
   ///
   @inlinable
   internal var hexNumberValue: UInt8? {
-    assert(_parseHex_table.count == 128)
     let numericValue = _parseHex_table.withUnsafeBufferPointer { $0[Int(codePoint)] }
-    return numericValue == DC ? nil : numericValue
+    return numericValue < 0 ? nil : UInt8(bitPattern: numericValue)
   }
 
   /// If this character is a decimal digit, returns the digit's numeric value.

--- a/Sources/WebURL/Util/ASCII.swift
+++ b/Sources/WebURL/Util/ASCII.swift
@@ -483,7 +483,7 @@ extension ASCII {
       if overflowM || overflowA {
         return nil
       }
-      idx = utf8.index(after: idx)
+      utf8.formIndex(after: &idx)
     }
     return idx < utf8.endIndex ? nil : value
   }

--- a/Sources/WebURL/Util/BidirectionalCollection+trim.swift
+++ b/Sources/WebURL/Util/BidirectionalCollection+trim.swift
@@ -27,11 +27,11 @@ extension BidirectionalCollection {
     var sliceStart = startIndex
     var sliceEnd = endIndex
     // Consume elements from the front.
-    while sliceStart != sliceEnd, try predicate(self[sliceStart]) {
-      sliceStart = index(after: sliceStart)
+    while sliceStart < sliceEnd, try predicate(self[sliceStart]) {
+      formIndex(after: &sliceStart)
     }
     // Consume elements from the back only if the element at the "before" index matches the predicate.
-    while sliceStart != sliceEnd {
+    while sliceStart < sliceEnd {
       let idxBeforeSliceEnd = index(before: sliceEnd)
       guard try predicate(self[idxBeforeSliceEnd]) else {
         return self[sliceStart..<sliceEnd]

--- a/Sources/WebURL/Util/Collection+longestRange.swift
+++ b/Sources/WebURL/Util/Collection+longestRange.swift
@@ -40,7 +40,7 @@ extension Collection {
         if current.length > longest.length { longest = (current.start..<idx, current.length) }
         current.length = 0
       }
-      idx = index(after: idx)
+      formIndex(after: &idx)
     }
     if current.length > longest.length {
       longest = (current.start..<endIndex, current.length)

--- a/Sources/WebURL/Util/MutableCollection+pathUtils.swift
+++ b/Sources/WebURL/Util/MutableCollection+pathUtils.swift
@@ -157,7 +157,7 @@ extension MutableCollection {
     // If the content begins with a separator, advance past it.
     // The segment's contents extend from after the separator until the next separator.
     if readHead < endIndex, isSeparator(self[readHead]) {
-      readHead = index(after: readHead)
+      formIndex(after: &readHead)
     }
 
     var writeHead = readHead

--- a/Sources/WebURL/Util/StringAdditions.swift
+++ b/Sources/WebURL/Util/StringAdditions.swift
@@ -1,0 +1,89 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension String {
+
+  /// Creates a String from the given collection of UTF-8 code-units, in a way that is optimized for discontiguous collections.
+  ///
+  /// The standard library's `String(decoding:as:)` initializer simply copies discontiguous collections to an `Array`, and uses
+  /// the array's contiguous storage to initialize the `String`. This initializer bypasses the `Array`, copying the given code-units
+  /// in to `String`'s internal storage in the most direct way available, with optimizations for small-medium length collections which avoids
+  /// heap allocations.
+  ///
+  /// On percent-encoding/decoding benchmarks, this can improve performance by 60-75% (i.e. taking about _one quarter_ of the time).
+  ///
+  @inlinable
+  internal init<C>(discontiguousUTF8 utf8: C) where C: Collection, C.Element == UInt8 {
+
+    // We don't care if this overflows; it is just used to size the allocation.
+    // If the collection doesn't initialize this many elements, we'll fatalError anyway.
+    var _count: UInt = 0
+    for _ in utf8.indices { _count &+= 1 }
+    let count = Int(truncatingIfNeeded: _count)
+
+    self = String(_unsafeUninitializedCapacity: count) { buffer in
+      guard var ptr = buffer.baseAddress else { return 0 }
+      let end = ptr + buffer.count
+      var i = utf8.startIndex
+      while i < utf8.endIndex, ptr < end {
+        ptr.initialize(to: utf8[i])
+        ptr += 1
+        utf8.formIndex(after: &i)
+      }
+      precondition(i == utf8.endIndex, "Collection does not contain 'count' elements")
+      return ptr - buffer.baseAddress!
+    }
+  }
+
+  @inlinable
+  internal init(
+    _unsafeUninitializedCapacity capacity: Int,
+    initializingUTF8With initializer: (UnsafeMutableBufferPointer<UInt8>) -> Int
+  ) {
+    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      self = String(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+      return
+    }
+    if capacity > 64 {
+      self = String(decoding: [UInt8](unsafeUninitializedCapacity: capacity) { $1 = initializer($0) }, as: UTF8.self)
+      return
+    }
+    var sixtyFourBytes:
+      (
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+      ) = (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0
+      )
+    let _ = sixtyFourBytes.63  // Check that there are 64 elements. This wouldn't compile otherwise.
+    self = withUnsafeMutableBytes(of: &sixtyFourBytes) { rawBuffer in
+      let buffer = rawBuffer._assumingMemoryBound(to: UInt8.self)
+      let initializedCount = initializer(buffer)
+      return String(decoding: UnsafeBufferPointer(rebasing: buffer.prefix(initializedCount)), as: UTF8.self)
+    }
+  }
+}

--- a/Sources/WebURL/WebURL+FormParameters.swift
+++ b/Sources/WebURL/WebURL+FormParameters.swift
@@ -470,8 +470,8 @@ extension URLStorage {
     let combinedLength: Int
     let needsEscaping: Bool
     (combinedLength, needsEscaping) = keyValuePairs.reduce(into: (0, false)) { metrics, kvp in
-      let (keyLength, encodeKey) = kvp.0.lazy.percentEncodedGroups(as: \.form).encodedLength
-      let (valLength, encodeVal) = kvp.1.lazy.percentEncodedGroups(as: \.form).encodedLength
+      let (keyLength, encodeKey) = kvp.0.lazy.percentEncoded(as: \.form).unsafeEncodedLength
+      let (valLength, encodeVal) = kvp.1.lazy.percentEncoded(as: \.form).unsafeEncodedLength
       metrics.0 += keyLength + valLength
       metrics.1 = metrics.1 || encodeKey || encodeVal
     }

--- a/Tests/WebURLTests/ASCIITests.swift
+++ b/Tests/WebURLTests/ASCIITests.swift
@@ -19,6 +19,10 @@ import XCTest
 
 final class ASCIITests: XCTestCase {
 
+  func testASCIIHexParseTable() {
+    XCTAssertEqual(_parseHex_table.count, 128)
+  }
+
   func testASCIIHexValue() {
     // Test that hex digits have the appropriate character classes,
     // that we can get the numeric value of a character and the character of a numeric value.

--- a/Tests/WebURLTests/PercentEncodingTests.swift
+++ b/Tests/WebURLTests/PercentEncodingTests.swift
@@ -128,15 +128,12 @@ extension PercentEncodingTests {
       // Check the contents and Collection conformance.
       let lazilyEncoded = original.utf8.lazy.percentEncoded(as: encodeSet)
       XCTAssertEqualElements(lazilyEncoded, encoded.utf8)
-      // Due to https://bugs.swift.org/browse/SR-13874 we can only check conformance for percentEncodedGroups.
-      // CollectionChecker.check(lazilyEncoded)
-      CollectionChecker.check(original.utf8.lazy.percentEncodedGroups(as: encodeSet))
+      CollectionChecker.check(lazilyEncoded)
 
       // Check the contents and Collection conformance in reverse.
-      // Again, limited to awkward hacks via percentEncodedGroups due to stdlib bugs.
-      let lazilyEncodedGroups = original.utf8.lazy.percentEncodedGroups(as: encodeSet)
-      XCTAssertEqualElements(lazilyEncodedGroups.reversed().flatMap { $0.reversed() }, encoded.utf8.reversed())
-      CollectionChecker.check(lazilyEncodedGroups.reversed() as ReversedCollection)
+      let lazilyEncodedReversed = lazilyEncoded.reversed() as ReversedCollection
+      XCTAssertEqualElements(lazilyEncodedReversed, encoded.utf8.reversed())
+      CollectionChecker.check(lazilyEncodedReversed)
     }
 
     _testLazilyEncoded("hello, world!", as: \.userInfo, to: "hello,%20world!")
@@ -180,13 +177,12 @@ extension PercentEncodingTests {
     ) {
       let lazilyDecoded = encoded.utf8.lazy.percentDecodedUTF8(from: decodeSet)
       // Check the contents and Collection conformance.
-      // This should also check BidirectionalCollection conformance, but the tests are a bit limited right now.
       XCTAssertEqualElements(lazilyDecoded, decoded.utf8)
       CollectionChecker.check(lazilyDecoded)
       // Check the contents and Collection conformance in reverse.
-      // This tends to be quite a good double-check, especially as BidirectionalCollection tests are a bit limited.
-      XCTAssertEqualElements(lazilyDecoded.reversed() as ReversedCollection, decoded.utf8.reversed())
-      CollectionChecker.check(lazilyDecoded.reversed() as ReversedCollection)
+      let lazilyDecodedReversed = lazilyDecoded.reversed() as ReversedCollection
+      XCTAssertEqualElements(lazilyDecodedReversed, decoded.utf8.reversed())
+      CollectionChecker.check(lazilyDecodedReversed)
     }
 
     _testLazilyDecoded("hello%2C%20world!", from: \.percentEncodedOnly, to: "hello, world!")

--- a/docs-excluded-symbols
+++ b/docs-excluded-symbols
@@ -1,7 +1,4 @@
-LazilyPercentEncodedGroups
-LazilyPercentEncodedGroups.index(before:)
-LazilyPercentEncodedGroups.formIndex(before:)
-_PercentEncodedByte
+LazilyPercentEncodedUTF8.Index
 LazilyPercentDecodedUTF8.Index
 PercentEncodeSet.C0Control
 PercentEncodeSet.Fragment


### PR DESCRIPTION
- Flatten the lazy percent-encoding types. 

  The stdlib's `FlattenSequence` really wasn't a good fit for the previous design. For one thing, it assumes subscripting the outer collection with a given index was cheap. In the previous design, the outer collection just wrapped the source collection (using the same index type, even), and created `_PercentEncodedByte`s on-demand in the subscript operation, which is kinda not really cheap. Additionally, there are weird [performance traps](https://bugs.swift.org/browse/SR-15173) which make me a bit uneasy about using it.

  The new design uses opaque indexes consisting of the source index, the `_EncodedByte`, and an offset within that encoded byte. Percent-encoding happens on index traversal, not on subscripting.

  Additionally, I've added a lookup table of all percent-encoded bytes. It's _a bit heavy_... at 769 bytes, but I think it's worth it.

- Improve String creation

  The stdlib's `String(decoding:as:)` initializer copies all non-contiguous collections in to an Array, and creates the String from that contiguous copy. The Array copying code ends up calling `_copyToContiguousArray`, which will call `count` on the Collection, create a buffer, and write the contents. We can simplify that work by calling `count` ourselves, and using the `String(unsafeUninializedCapacity:)` to write the contents in to String-owned storage directly.

- Other tweaks

  Includes some other minor improvements, including using `formIndex` more often, using -1 as the "nil" value for the hex table so we can use the processor's jump-if-signed instruction rather than comparing against an arbitrary value, and fixes a weird issue with `withContiguousStorageIfAvailable`, where the compiler couldn't tell that `UnsafeBoundsCheckedBufferPointer` never returned nil, so it would also include the non-contiguous branch 😵.

  Also, I experimented with making the hex-parsing table cover the full 256 byte range and eliminating the branch from the ASCII check, but it seemed to have a negligible impact on performance on percent-decoding, IP address parsing, and domain parsing. Really, margin-of-error stuff, can't even tell if it helped. So yeah, I rolled it back. I just wanted to make the point that it was explored.