### PR TITLE
The sugar is salt. Stop using 'X?' notation for stored optionals.

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -43,7 +43,7 @@
     "ReturnVoidInsteadOfEmptyTuple" : true,
     "UseEnumForNamespacing" : true,
     "UseLetInEveryBoundCaseVariable" : true,
-    "UseShorthandTypeNames" : true,
+    "UseShorthandTypeNames" : false,
     "UseSingleLinePropertyGetter" : true,
     "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -95,7 +95,7 @@ internal struct ParsedURLString<InputString> where InputString: BidirectionalCol
   internal let inputString: InputString
 
   @usableFromInline
-  internal let baseURL: WebURL?
+  internal let baseURL: Optional<WebURL>
 
   @usableFromInline
   internal let mapping: ProcessedMapping
@@ -162,10 +162,10 @@ extension ParsedURLString {
     internal let info: ScannedRangesAndFlags<InputString>
 
     @usableFromInline
-    internal let parsedHost: ParsedHost?
+    internal let parsedHost: Optional<ParsedHost>
 
     @usableFromInline
-    internal let port: UInt16?
+    internal let port: Optional<UInt16>
   }
 }
 
@@ -178,46 +178,46 @@ internal struct ScannedRangesAndFlags<InputString> where InputString: Collection
 
   /// The position of the scheme's content, if present, without trailing separators.
   @usableFromInline
-  internal var schemeRange: Range<InputString.Index>?
+  internal var schemeRange: Optional<Range<InputString.Index>>
 
   /// The position of the authority section, if present, without leading or trailing separators.
   @usableFromInline
-  internal var authorityRange: Range<InputString.Index>?
+  internal var authorityRange: Optional<Range<InputString.Index>>
 
   /// The position of the username content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var usernameRange: Range<InputString.Index>?
+  internal var usernameRange: Optional<Range<InputString.Index>>
 
   /// The position of the password content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var passwordRange: Range<InputString.Index>?
+  internal var passwordRange: Optional<Range<InputString.Index>>
 
   /// The position of the hostname content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var hostnameRange: Range<InputString.Index>?
+  internal var hostnameRange: Optional<Range<InputString.Index>>
 
   /// The position of the port content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var portRange: Range<InputString.Index>?
+  internal var portRange: Optional<Range<InputString.Index>>
 
   /// The position of the path content, if present, without leading or trailing separators.
   /// Note that the path's initial "/", if present, is not considered a separator.
   @usableFromInline
-  internal var pathRange: Range<InputString.Index>?
+  internal var pathRange: Optional<Range<InputString.Index>>
 
   /// The position of the query content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var queryRange: Range<InputString.Index>?
+  internal var queryRange: Optional<Range<InputString.Index>>
 
   /// The position of the fragment content, if present, without leading or trailing separators.
   @usableFromInline
-  internal var fragmentRange: Range<InputString.Index>?
+  internal var fragmentRange: Optional<Range<InputString.Index>>
 
   // Flags.
 
   /// The kind of scheme contained in `schemeRange`, if it is not `nil`.
   @usableFromInline
-  internal var schemeKind: WebURL.SchemeKind?
+  internal var schemeKind: Optional<WebURL.SchemeKind>
 
   /// Whether this URL is hierarchical ("cannot-be-a-base" is false).
   @usableFromInline

--- a/Sources/WebURL/Parser/URLWriter.swift
+++ b/Sources/WebURL/Parser/URLWriter.swift
@@ -227,7 +227,7 @@ internal struct URLWriterHints {
   /// If not set, users may make no assumptions about the path.
   ///
   @usableFromInline
-  internal var pathMetrics: PathMetrics?
+  internal var pathMetrics: Optional<PathMetrics>
 
   /// Components which are known to not require percent-encoding.
   /// If a component is not in this set, users must assume that it requires percent-encoding.

--- a/Sources/WebURL/URLStorage.swift
+++ b/Sources/WebURL/URLStorage.swift
@@ -102,7 +102,7 @@ internal struct URLStructure<SizeType: FixedWidthInteger> {
   /// If `sigil == .path` or `sigil == nil`, the next component is a path/query/fragment and no username/password/hostname/port is present.
   ///
   @usableFromInline
-  internal var sigil: Sigil?
+  internal var sigil: Optional<Sigil>
 
   /// A summary of this URL's `scheme`.
   ///

--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -261,7 +261,7 @@ extension UnsafeBufferPointer {
 internal struct UnsafeBoundsCheckedBufferPointer<Element> {
 
   @usableFromInline
-  internal var baseAddress: UnsafePointer<Element>?
+  internal var baseAddress: Optional<UnsafePointer<Element>>
 
   @usableFromInline
   internal var bounds: Range<UInt>


### PR DESCRIPTION
See https://forums.swift.org/t/what-is-a-variable-initialization-expression/52132

You want to know why a project like this, which aims to meet-or-beat CFURL's performance, but using Swift, is so difficult?

Stuff like this. Stuff like this _everywhere_.