### PR TITLE
Move bounds-checking to the writing phase

### DIFF
--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -457,8 +457,8 @@ extension ParsedURLString.ProcessedMapping {
         writer.writePathSigil()
       }
       writer.writePresizedPathUnsafely(
-        length: pathMetrics.requiredCapacity,
-        firstComponentLength: pathMetrics.firstComponentLength
+        length: Int(bitPattern: pathMetrics.requiredCapacity),
+        firstComponentLength: Int(bitPattern: pathMetrics.firstComponentLength)
       ) { buffer in
         return buffer.writeNormalizedPath(
           parsing: inputString[path],

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -379,10 +379,10 @@ extension LazilyPercentEncodedUTF8 {
   /// never cause memory safety to be violated.
   ///
   @inlinable
-  internal var unsafeEncodedLength: (count: Int, needsEncoding: Bool) {
+  internal var unsafeEncodedLength: (count: UInt, needsEncoding: Bool) {
     var count: UInt = 0
     let needsEncoding = write { count &+= UInt($0.count) }
-    return (Int(truncatingIfNeeded: count), needsEncoding)
+    return (count, needsEncoding)
   }
 }
 

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -298,7 +298,7 @@ extension URLStorage {
 
     var newLengthCounter = HostnameLengthCounter()
     newHost.write(bytes: newHostnameBytes, using: &newLengthCounter)
-    guard let newValueLength = URLStorage.SizeType(exactly: newLengthCounter.length) else {
+    guard let newValueLength = URLStorage.SizeType(exactly: newLengthCounter.requiredCapacity) else {
       return .failure(.exceedsMaximumSize)
     }
 

--- a/Sources/WebURL/Util/ASCII.swift
+++ b/Sources/WebURL/Util/ASCII.swift
@@ -398,7 +398,7 @@ extension ASCII {
   }
 
   /// Prints the decimal representation of `number` to the memory location given by `stringBuffer`.
-  /// A maximum of 5 bytes will be written.
+  /// The amount of space required is given by `lengthOfDecimalString(for: UInt16)`, and is `1...5` bytes.
   ///
   /// - returns:  The number of bytes written to `stringBuffer`.
   ///
@@ -462,6 +462,20 @@ extension ASCII {
     )
     count += 1
     return count
+  }
+
+  /// Returns the number of bytes required to print the decimal representation of `number` (`1...5` bytes).
+  /// This value is guaranteed to be accurate, so it may be used to ensure memory safety.
+  ///
+  @usableFromInline
+  internal static func lengthOfDecimalString(for number: UInt16) -> UInt8 {
+    switch number {
+    case 10000...UInt16.max: return 5
+    case 1000..<10000: return 4
+    case 100..<1000: return 3
+    case 10..<100: return 2
+    default /* 0..<10 */: return 1
+    }
   }
 
   /// Parses a 16-bit unsigned integer from a decimal representation contained in the given UTF-8 code-units.

--- a/Sources/WebURL/WebURL+FormParameters.swift
+++ b/Sources/WebURL/WebURL+FormParameters.swift
@@ -467,7 +467,7 @@ extension URLStorage {
     fromUnencoded keyValuePairs: C
   ) where C: Collection, C.Element == (UTF8Bytes, UTF8Bytes), UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
 
-    let combinedLength: Int
+    let combinedLength: UInt
     let needsEscaping: Bool
     (combinedLength, needsEscaping) = keyValuePairs.reduce(into: (0, false)) { metrics, kvp in
       let (keyLength, encodeKey) = kvp.0.lazy.percentEncoded(as: \.form).unsafeEncodedLength
@@ -480,10 +480,10 @@ extension URLStorage {
         fromEncoded: keyValuePairs.lazy.map {
           ($0.0.lazy.percentEncoded(as: \.form), $0.1.lazy.percentEncoded(as: \.form))
         },
-        lengthIfKnown: combinedLength
+        lengthIfKnown: Int(combinedLength)
       )
     } else {
-      appendFormParamPairs(fromEncoded: keyValuePairs, lengthIfKnown: combinedLength)
+      appendFormParamPairs(fromEncoded: keyValuePairs, lengthIfKnown: Int(combinedLength))
     }
   }
 

--- a/Tests/WebURLTests/ASCIITests.swift
+++ b/Tests/WebURLTests/ASCIITests.swift
@@ -136,6 +136,7 @@ final class ASCIITests: XCTestCase {
       for num in (UInt16.min)...(UInt16.max) {
         let bufferContentsCount = ASCII.writeDecimalString(for: num, to: buffer.baseAddress!)
         XCTAssertEqualElements(buffer[..<Int(bufferContentsCount)], String(num, radix: 10).utf8)
+        XCTAssertEqual(bufferContentsCount, ASCII.lengthOfDecimalString(for: num))
       }
     }
   }


### PR DESCRIPTION
Better, faster bounds checking.

Previously, we were bounds-checking during the initial measuring phase, and then not doing it for the writing phase. I don't remember why; it seemed like a smart move at the time.

Anyway, this is backwards - the measuring doesn't matter, at least not for memory safety. Maybe the URL turns out to be super-long and we overflow, or the source collection is malicious and returns a different number of elements each time, and as a result we end up allocating too much/not enough memory, or having a broken structure. None of that actually matters. It's not _great_, but it's a garbage-in-garbage-out situation and it isn't unsafe.

The thing that we actually need to check is the writing phase - that once we have our allocation (mis-sized as it may be), that we don't write over the end of it because that would be a buffer overflow and is very much unsafe. Even if the source collection is malicious. So that's where we do our bounds-checks.

As a bonus - moving the checks here turns out to be a slight performance win. It means the `StructureAndMetricsCollector`, which never sees contiguous pieces, doesn't need to worry about overflow in its already branch-laden code. And it means the writers - which might see contiguous pieces if percent-encoding turned out not to be required - can perform the more meaningful check far more efficiently than `SAMC` was able to. 

So good stuff.