### PR TITLE
Simplify the path parser

### DIFF
--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -378,7 +378,7 @@ extension LazilyPercentEncodedUTF8 {
   /// The latter point means that writers should still be wary - even an invalid collection which yields different values every time must
   /// never cause memory safety to be violated.
   ///
-  @inlinable
+  @inlinable @inline(never)
   internal var unsafeEncodedLength: (count: UInt, needsEncoding: Bool) {
     var count: UInt = 0
     let needsEncoding = write { count &+= UInt($0.count) }

--- a/Sources/WebURL/Util/BidirectionalCollection+suffix.swift
+++ b/Sources/WebURL/Util/BidirectionalCollection+suffix.swift
@@ -29,3 +29,21 @@ extension BidirectionalCollection {
     return self[startIndex..<endIndex]
   }
 }
+
+extension BidirectionalCollection {
+
+  /// Returns the index closest to `endIndex` where the element at the returned index matches the given predicate.
+  ///
+  /// The difference between this implementation and the one in the standard library is that this uses  `>` and `<` rather than `==` and `!=`
+  /// to compare indexes, which allows bounds-checking to be more throughly eliminated.
+  ///
+  @inlinable
+  internal func fastLastIndex(where predicate: (Element) -> Bool) -> Index? {
+    var i = endIndex
+    while i > startIndex {
+      formIndex(before: &i)
+      if i < endIndex, predicate(self[i]) { return i }
+    }
+    return nil
+  }
+}

--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -128,6 +128,15 @@ extension UnsafeMutableRawBufferPointer {
 // Arity 2:
 
 @inlinable @inline(__always)
+internal func withUnsafeBufferPointerToElements<T, Result>(
+  tuple: (T, T), _ body: (UnsafeBufferPointer<T>) -> Result
+) -> Result {
+  return withUnsafeBytes(of: tuple) {
+    return body($0._assumingMemoryBound(to: T.self))
+  }
+}
+
+@inlinable @inline(__always)
 internal func withUnsafeMutableBufferPointerToElements<T, Result>(
   tuple: inout (T, T), _ body: (inout UnsafeMutableBufferPointer<T>) -> Result
 ) -> Result {

--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -738,9 +738,7 @@ extension URLStorage {
     precondition(structure.isHierarchical, "Cannot replace components of a non-hierarchical URL")
 
     // If 'firstGivenComponentLength' is nil, we infer that the components are empty (i.e. removal operation).
-    let components = components.lazy.filter { utf8 in
-      !PathComponentParser.isSingleDotPathSegment(utf8) && !PathComponentParser.isDoubleDotPathSegment(utf8)
-    }
+    let components = components.lazy.filter { utf8 in PathComponentParser.parseDotPathComponent(utf8) == nil }
     let firstGivenComponentLength = components.first.map { 1 + $0.lazy.percentEncoded(as: \.pathComponent).count }
 
     // If the URL's path ends with a trailing slash and we're inserting elements at the end,


### PR DESCRIPTION
No longer defers empty components, deferred drive letters are stored as tuples rather than slices.

That allows a pretty major simplification of the parsing logic, and smaller, faster, more maintainable code.