### PR TITLE
[Tests] Refactor tuple utilities, improve diagnostics for IP address tests

### DIFF
--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -27,6 +27,7 @@ extension UnsafeRawPointer {
   ///
   @inlinable @inline(__always)
   internal func loadUnaligned<T>(fromByteOffset offset: Int = 0, as: T.Type) -> T where T: FixedWidthInteger {
+    assert(_isPOD(T.self))
     var val: T = 0
     withUnsafeMutableBytes(of: &val) {
       $0.copyMemory(from: UnsafeRawBufferPointer(start: self + offset, count: MemoryLayout<T>.stride))

--- a/Tests/WebURLTests/IPv6AddressTests.swift
+++ b/Tests/WebURLTests/IPv6AddressTests.swift
@@ -17,53 +17,40 @@ import XCTest
 
 @testable import WebURL
 
-extension Array {
-  fileprivate init(ipv6Octets addr: IPv6Address.Octets) where Element == UInt8 {
-    self = [
-      addr.0, addr.1, addr.2, addr.3, addr.4, addr.5, addr.6, addr.7,
-      addr.8, addr.9, addr.10, addr.11, addr.12, addr.13, addr.14, addr.15,
-    ]
-  }
-
-  fileprivate init(ipv6Pieces addr: IPv6Address.Pieces) where Element == UInt16 {
-    self = [addr.0, addr.1, addr.2, addr.3, addr.4, addr.5, addr.6, addr.7]
-  }
-}
-
 final class IPv6AddressTests: XCTestCase {
 
   func testBasic() {
 
-    let testData: [(String, String, [UInt8], [UInt16])] = [
+    let testData: [(String, String, IPv6Address.Octets, IPv6Address.Pieces)] = [
       // Canonical
       (
         "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:db8:85a3::8a2e:370:7334",
-        [0x20, 0x01, 0x0d, 0x0b8, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34],
-        [0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334]
+        (0x20, 0x01, 0x0d, 0x0b8, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34),
+        (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334)
       ),
       // Teredo
       (
         "2001::ce49:7601:e866:efff:62c3:fffe", "2001:0:ce49:7601:e866:efff:62c3:fffe",
-        [0x20, 0x01, 0x00, 0x00, 0xce, 0x49, 0x76, 0x01, 0xe8, 0x66, 0xef, 0xff, 0x62, 0xc3, 0xff, 0xfe],
-        [0x2001, 0x0000, 0xce49, 0x7601, 0xe866, 0xefff, 0x62c3, 0xfffe]
+        (0x20, 0x01, 0x00, 0x00, 0xce, 0x49, 0x76, 0x01, 0xe8, 0x66, 0xef, 0xff, 0x62, 0xc3, 0xff, 0xfe),
+        (0x2001, 0x0000, 0xce49, 0x7601, 0xe866, 0xefff, 0x62c3, 0xfffe)
       ),
       // Compact
       (
         "2608::3:5", "2608::3:5",
-        [0x26, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x05],
-        [0x2608, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0003, 0x0005]
+        (0x26, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x05),
+        (0x2608, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0003, 0x0005)
       ),
       // Empty
       (
         "::", "::",
-        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000]
+        (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
+        (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
       ),
       // IPv4
       (
         "::ffff:192.168.0.1", "::ffff:c0a8:1",
-        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01],
-        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xffff, 0xc0a8, 0x0001]
+        (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01),
+        (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xffff, 0xc0a8, 0x0001)
       ),
     ]
 
@@ -73,45 +60,47 @@ final class IPv6AddressTests: XCTestCase {
         continue
       }
 
-      XCTAssertEqual(Array(ipv6Octets: addr.octets), expectedOctets)
+      XCTAssertEqual(addr.octets, expectedOctets)
       XCTAssertEqual(addr.serialized, expectedDescription)
-      XCTAssertEqual(Array(ipv6Pieces: addr[pieces: .numeric]), expectedNumericPieces)
-      XCTAssertEqual(Array(ipv6Pieces: addr[pieces: .binary]), expectedNumericPieces.map { UInt16(bigEndian: $0) })
+      XCTAssertEqual(addr[pieces: .numeric], expectedNumericPieces)
+      XCTAssertEqual(
+        Array(elements: addr[pieces: .binary]), Array(elements: expectedNumericPieces).map { UInt16(bigEndian: $0) }
+      )
 
       guard let reparsedAddr = IPv6Address(addr.serialized) else {
         XCTFail("Failed to reparse. Original: '\(string)'. Parsed: '\(addr.serialized)'")
         continue
       }
-      XCTAssertEqual(Array(ipv6Octets: addr.octets), Array(ipv6Octets: reparsedAddr.octets))
+      XCTAssertEqual(addr.octets, reparsedAddr.octets)
       XCTAssertEqual(addr.serialized, reparsedAddr.serialized)
     }
   }
 
   func testCompression() {
 
-    let testData: [(String, String, [UInt8], [UInt16])] = [
+    let testData: [(String, String, IPv6Address.Octets, IPv6Address.Pieces)] = [
       // Leading
       (
         "::1234:F088", "::1234:f088",
-        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0xf0, 0x88],
-        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x1234, 0xf088]
+        (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0xf0, 0x88),
+        (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x1234, 0xf088)
       ),
       (
         "0:0::0:192.168.0.2", "::c0a8:2",
-        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0xa8, 0x00, 0x02],
-        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xc0a8, 0x0002]
+        (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0xa8, 0x00, 0x02),
+        (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xc0a8, 0x0002)
       ),
       // Middle
       (
         "1212:F0F0::3434:D0D0", "1212:f0f0::3434:d0d0",
-        [0x12, 0x12, 0xf0, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x34, 0xd0, 0xd0],
-        [0x1212, 0xf0f0, 0x0000, 0x0000, 0x0000, 0x0000, 0x3434, 0xd0d0]
+        (0x12, 0x12, 0xf0, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x34, 0xd0, 0xd0),
+        (0x1212, 0xf0f0, 0x0000, 0x0000, 0x0000, 0x0000, 0x3434, 0xd0d0)
       ),
       // Trailing
       (
         "1234:F088::", "1234:f088::",
-        [0x12, 0x34, 0xf0, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-        [0x1234, 0xf088, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000]
+        (0x12, 0x34, 0xf0, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
+        (0x1234, 0xf088, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
       ),
     ]
 
@@ -121,16 +110,18 @@ final class IPv6AddressTests: XCTestCase {
         continue
       }
 
-      XCTAssertEqual(Array(ipv6Octets: addr.octets), expectedOctets)
+      XCTAssertEqual(addr.octets, expectedOctets)
       XCTAssertEqual(addr.serialized, expectedDescription)
-      XCTAssertEqual(Array(ipv6Pieces: addr[pieces: .numeric]), expectedNumericPieces)
-      XCTAssertEqual(Array(ipv6Pieces: addr[pieces: .binary]), expectedNumericPieces.map { UInt16(bigEndian: $0) })
+      XCTAssertEqual(addr[pieces: .numeric], expectedNumericPieces)
+      XCTAssertEqual(
+        Array(elements: addr[pieces: .binary]), Array(elements: expectedNumericPieces).map { UInt16(bigEndian: $0) }
+      )
 
       guard let reparsedAddr = IPv6Address(addr.serialized) else {
         XCTFail("Failed to reparse. Original: '\(string)'. Parsed: '\(addr.serialized)'")
         continue
       }
-      XCTAssertEqual(Array(ipv6Octets: addr.octets), Array(ipv6Octets: reparsedAddr.octets))
+      XCTAssertEqual(addr.octets, reparsedAddr.octets)
       XCTAssertEqual(addr.serialized, reparsedAddr.serialized)
     }
   }
@@ -193,76 +184,43 @@ final class IPv6AddressTests: XCTestCase {
 
   #if canImport(Glibc)
     import Glibc
-    let in6_addr_octets = \in6_addr.__in6_u.__u6_addr8
+    // let in6_addr_octets = \in6_addr.__in6_u.__u6_addr8
     let in6_addr_pieces = \in6_addr.__in6_u.__u6_addr16
-  #elseif canImport(WinSDK)
-    import WinSDK
-    let in6_addr_octets = \in6_addr.u.Byte
-    let in6_addr_pieces = \in6_addr.u.Word
   #elseif canImport(Darwin)
     import Darwin
-    let in6_addr_octets = \in6_addr.__u6_addr.__u6_addr8
+    // let in6_addr_octets = \in6_addr.__u6_addr.__u6_addr8
     let in6_addr_pieces = \in6_addr.__u6_addr.__u6_addr16
+  #elseif canImport(WinSDK)
+    import WinSDK
+    // let in6_addr_octets = \in6_addr.u.Byte
+    let in6_addr_pieces = \in6_addr.u.Word
   #endif
 
-  fileprivate func pton_octets(_ input: String) -> [UInt8]? {
-    var result = in6_addr()
-
-    guard inet_pton(AF_INET6, input, &result) != 0 else { return nil }
-    return withUnsafeBytes(of: &result[keyPath: in6_addr_octets]) { ptr in
-      let u16 = ptr.bindMemory(to: UInt8.self)
-      return Array(u16)
-    }
-  }
-
-  fileprivate func pton_pieces(_ input: String) -> [UInt16]? {
+  fileprivate func libc_pton(_ input: String) -> IPv6Address.Pieces? {
     var result = in6_addr()
     guard inet_pton(AF_INET6, input, &result) != 0 else { return nil }
-    return withUnsafeBytes(of: &result[keyPath: in6_addr_pieces]) { ptr in
-      let u16 = ptr.bindMemory(to: UInt16.self)
-      return Array(u16)
-    }
+    return (
+      result[keyPath: in6_addr_pieces].0,
+      result[keyPath: in6_addr_pieces].1,
+      result[keyPath: in6_addr_pieces].2,
+      result[keyPath: in6_addr_pieces].3,
+      result[keyPath: in6_addr_pieces].4,
+      result[keyPath: in6_addr_pieces].5,
+      result[keyPath: in6_addr_pieces].6,
+      result[keyPath: in6_addr_pieces].7
+    )
   }
 
-  fileprivate func ntop_octets(_ input: [UInt8]) -> String? {
+  fileprivate func libc_ntop(_ input: IPv6Address.Pieces) -> String? {
     var src = in6_addr()
-    src[keyPath: in6_addr_octets].0 = input[0]
-    src[keyPath: in6_addr_octets].1 = input[1]
-    src[keyPath: in6_addr_octets].2 = input[2]
-    src[keyPath: in6_addr_octets].3 = input[3]
-    src[keyPath: in6_addr_octets].4 = input[4]
-    src[keyPath: in6_addr_octets].5 = input[5]
-    src[keyPath: in6_addr_octets].6 = input[6]
-    src[keyPath: in6_addr_octets].7 = input[7]
-    src[keyPath: in6_addr_octets].8 = input[8]
-    src[keyPath: in6_addr_octets].9 = input[9]
-    src[keyPath: in6_addr_octets].10 = input[10]
-    src[keyPath: in6_addr_octets].11 = input[11]
-    src[keyPath: in6_addr_octets].12 = input[12]
-    src[keyPath: in6_addr_octets].13 = input[13]
-    src[keyPath: in6_addr_octets].14 = input[14]
-    src[keyPath: in6_addr_octets].15 = input[15]
-    let bytes = [CChar](unsafeUninitializedCapacity: Int(INET6_ADDRSTRLEN)) { buffer, count in
-      #if canImport(WinSDK)
-        let p = inet_ntop(AF_INET6, &src, buffer.baseAddress, buffer.count)
-      #else
-        let p = inet_ntop(AF_INET6, &src, buffer.baseAddress, socklen_t(buffer.count))
-      #endif
-      count = (p == nil) ? 0 : strlen(buffer.baseAddress!)
-    }
-    return bytes.isEmpty ? nil : String(cString: bytes)
-  }
-
-  fileprivate func ntop_pieces(_ input: [UInt16]) -> String? {
-    var src = in6_addr()
-    src[keyPath: in6_addr_pieces].0 = input[0]
-    src[keyPath: in6_addr_pieces].1 = input[1]
-    src[keyPath: in6_addr_pieces].2 = input[2]
-    src[keyPath: in6_addr_pieces].3 = input[3]
-    src[keyPath: in6_addr_pieces].4 = input[4]
-    src[keyPath: in6_addr_pieces].5 = input[5]
-    src[keyPath: in6_addr_pieces].6 = input[6]
-    src[keyPath: in6_addr_pieces].7 = input[7]
+    src[keyPath: in6_addr_pieces].0 = input.0
+    src[keyPath: in6_addr_pieces].1 = input.1
+    src[keyPath: in6_addr_pieces].2 = input.2
+    src[keyPath: in6_addr_pieces].3 = input.3
+    src[keyPath: in6_addr_pieces].4 = input.4
+    src[keyPath: in6_addr_pieces].5 = input.5
+    src[keyPath: in6_addr_pieces].6 = input.6
+    src[keyPath: in6_addr_pieces].7 = input.7
     let bytes = [CChar](unsafeUninitializedCapacity: Int(INET6_ADDRSTRLEN)) { buffer, count in
       #if canImport(WinSDK)
         let p = inet_ntop(AF_INET6, &src, buffer.baseAddress, buffer.count)
@@ -276,48 +234,84 @@ final class IPv6AddressTests: XCTestCase {
 
   extension IPv6AddressTests {
 
-    /// Generate 1000 random IP addresses, serialize them via IPAddress.
-    /// Then serialize the same addresss via `ntop`, and ensure it returns the same string.
-    /// Then parse our serialized version back via `pton`, and ensure it returns the same address.
+    /// Tests IPv6Address serialization with random addresses, and compares the results to the system's libc implementations.
+    ///
+    /// - Generate a random IP address, serialize it via IPv6Address.
+    /// - Serialize the same addresss via `ntop`, and ensure it returns the same serialized string.
+    ///   - If there is a difference, make sure we know what it happening and why there is a difference.
+    /// - Parse our serialization via `pton`, and ensure it returns the same address.
+    /// - Parse our serialization again using IPv6Address, to ensure that the parser and serializer round-trip.
     ///
     func testRandom_Serialization() {
       for _ in 0..<1000 {
-        let expected = IPv6Address.Utils.randomAddress()
-        let address = IPv6Address(pieces: expected, .binary)
-        if address.serialized.contains("::") {
-          XCTAssertTrue(Array(ipv6Pieces: expected)._longestSubrange(equalTo: 0).length > 0)
-        }
+        let expectedPieces = IPv6Address.Utils.randomAddress()
+        let address = IPv6Address(pieces: expectedPieces, .binary)
 
-        // Serialize with libc. It should return the same String.
-        let libcStr = ntop_pieces(Array(ipv6Pieces: expected))
+        // Serialize the address with libc.
+        // Both implementations should return the same serialization.
+        let libcStr = libc_ntop(expectedPieces)
         if libcStr?.contains(".") == true {
-          // Exception: if the address <= UInt32.max, libc may print this as an embedded IPv4 address on some platforms
-          // (e.g. it prints "::198.135.80.188", we print "::c687:50bc").
-          XCTAssertTrue(Array(ipv6Pieces: expected).dropLast(2).allSatisfy { $0 == 0 })
+          // Some implementations of ntop serialize addresses which are <= UInt32.max as embedded IPv4 addresses.
+          // (e.g. ntop might print "::198.135.80.188", we print "::c687:50bc").
+          XCTAssertTrue(
+            Array(elements: expectedPieces).dropLast(2).allSatisfy { $0 == 0 },
+            "ntop produced unexpected serialization '\(libcStr!)' for address \(expectedPieces)"
+          )
         } else {
-          XCTAssertEqual(libcStr, address.serialized)
+          XCTAssertEqual(
+            libcStr, address.serialized,
+            "Serialization mismatch for address \(expectedPieces)"
+          )
         }
 
-        // Parse our serialized output with libc. It should return the same address.
-        XCTAssertEqual(pton_octets(address.serialized), Array(ipv6Octets: address.octets))
-        XCTAssertEqual(pton_pieces(address.serialized), Array(ipv6Pieces: address[pieces: .binary]))
+        // Parse our serialized output with libc.
+        // It should be able to parse our serialization and return the same address.
+        XCTAssertEqual(
+          libc_pton(address.serialized), address[pieces: .binary],
+          "pton returned a different address for string: \(address.serialized)"
+        )
+
+        // Parse our serialized output with IPv6Address.
+        // We should be able to re-parse our serialization and return the same address.
+        if let reparsed = IPv6Address(address.serialized) {
+          XCTAssertEqual(
+            address.octets, reparsed.octets,
+            "\(address.serialized) reparsed as \(reparsed.serialized)"
+          )
+        } else {
+          XCTFail("Address failed to re-parse: \(address.serialized)")
+        }
       }
     }
 
-    /// Generate 1000 random IP Address Strings, parse them via IPAddress,
-    /// check that the numerical value matches the expected network address,
-    /// and that `pton` gets the same result when parsing the same random String.
+    /// Tests IPv6Address parsing with random addresses, and compares the results to the system's libc implementations.
+    ///
+    /// - Generate a random IP Address and serialization, including quirks such as embedded IPv4 addresses, compressed pieces, etc.
+    /// - Parse the serialization via IPv6Address.
+    /// - Check that the parsed address matches the expected network address.
+    /// - Check that `pton` gets the same result when parsing the same serialization.
     ///
     func testRandom_Parsing() {
       for _ in 0..<1000 {
-        let (randomPieces, randomAddressString) = IPv6Address.Utils.randomString()
+        let (expectedPieces, randomAddressString) = IPv6Address.Utils.randomString()
+
         guard let parsedAddress = IPv6Address(randomAddressString) else {
-          XCTFail("Failed to parse address: \(randomAddressString); expected pieces: \(randomPieces)")
+          XCTFail("Failed to parse serialization '\(randomAddressString)' of address: \(expectedPieces)")
           continue
         }
-        XCTAssertEqual(Array(ipv6Octets: parsedAddress.octets), pton_octets(randomAddressString))
-        XCTAssertEqual(Array(ipv6Pieces: parsedAddress[pieces: .binary]), Array(ipv6Pieces: randomPieces))
-        XCTAssertEqual(Array(ipv6Pieces: parsedAddress[pieces: .binary]), pton_pieces(randomAddressString))
+
+        // Check the value is correct.
+        XCTAssertEqual(
+          parsedAddress[pieces: .binary], expectedPieces,
+          "Incorrect address for string: \(randomAddressString)"
+        )
+
+        // Parse the same string with libc.
+        // Both implementations should return the same address.
+        XCTAssertEqual(
+          parsedAddress[pieces: .binary], libc_pton(randomAddressString),
+          "pton returned a different address for string: \(randomAddressString)"
+        )
       }
     }
   }

--- a/Tests/WebURLTests/Utils.swift
+++ b/Tests/WebURLTests/Utils.swift
@@ -50,6 +50,102 @@ let stringWithEveryASCIICharacter: String = {
 
 
 // --------------------------------------------
+// MARK: - Tuples
+// --------------------------------------------
+
+
+typealias Tuple4<T> = (T, T, T, T)
+typealias Tuple8<T> = (T, T, T, T, T, T, T, T)
+typealias Tuple16<T> = (T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T)
+
+extension Array {
+
+  init(elements tuple: Tuple4<Element>) {
+    self = [tuple.0, tuple.1, tuple.2, tuple.3]
+  }
+
+  init(elements tuple: Tuple8<Element>) {
+    self = [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7]
+  }
+
+  init(elements tuple: Tuple16<Element>) {
+    self = [
+      tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7,
+      tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15,
+    ]
+  }
+}
+
+// One day, when tuples are Equatable, we won't need these.
+// https://github.com/apple/swift-evolution/blob/main/proposals/0283-tuples-are-equatable-comparable-hashable.md
+func XCTAssertEqual<T>(
+  _ expression1: @autoclosure () throws -> Tuple4<T>?,
+  _ expression2: @autoclosure () throws -> Tuple4<T>?,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) rethrows where T: Equatable {
+  let left = try expression1()
+  let right = try expression2()
+  switch (left, right) {
+  case (.none, .none):
+    return
+  case (.some, .none), (.none, .some):
+    XCTFail(
+      "XCTAssertEqual failed. \(String(describing: left)) is not equal to \(String(describing: right)). \(message())",
+      file: file, line: line
+    )
+  case (.some(let left), .some(let right)):
+    XCTAssertEqual(Array(elements: left), Array(elements: right), message(), file: file, line: line)
+  }
+}
+
+func XCTAssertEqual<T>(
+  _ expression1: @autoclosure () throws -> Tuple8<T>?,
+  _ expression2: @autoclosure () throws -> Tuple8<T>?,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) rethrows where T: Equatable {
+  let left = try expression1()
+  let right = try expression2()
+  switch (left, right) {
+  case (.none, .none):
+    return
+  case (.some, .none), (.none, .some):
+    XCTFail(
+      "XCTAssertEqual failed. \(String(describing: left)) is not equal to \(String(describing: right)). \(message())",
+      file: file, line: line
+    )
+  case (.some(let left), .some(let right)):
+    XCTAssertEqual(Array(elements: left), Array(elements: right), message(), file: file, line: line)
+  }
+}
+
+func XCTAssertEqual<T>(
+  _ expression1: @autoclosure () throws -> Tuple16<T>?,
+  _ expression2: @autoclosure () throws -> Tuple16<T>?,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) rethrows where T: Equatable {
+  let left = try expression1()
+  let right = try expression2()
+  switch (left, right) {
+  case (.none, .none):
+    return
+  case (.some, .none), (.none, .some):
+    XCTFail(
+      "XCTAssertEqual failed. \(String(describing: left)) is not equal to \(String(describing: right)). \(message())",
+      file: file, line: line
+    )
+  case (.some(let left), .some(let right)):
+    XCTAssertEqual(Array(elements: left), Array(elements: right), message(), file: file, line: line)
+  }
+}
+
+
+// --------------------------------------------
 // MARK: - WebURL test utilities
 // --------------------------------------------
 


### PR DESCRIPTION
Recently, a randomised IP address test failed on Windows.

That's good (kinda) - that's what they're there for. To uncover and notify about differences between the platform's IP address parser/serializer and ours. Unfortunately, the emitted diagnostics weren't helpful at all, so I don't know which string ultimately lead to the test failure, so I can't reproduce and investigate it 😞 

So improve those diagnostics. And while I'm here, refactor some of the tuple utilities which make these tests so awkward in the first place, improve the implementation of the randomised address generation, etc. Just generally make them better and clearer.