### PR TITLE
Fix occasional compiler confusion resolving UTF8View.Indices

### DIFF
--- a/Sources/WebURL/WebURL+UTF8View.swift
+++ b/Sources/WebURL/WebURL+UTF8View.swift
@@ -71,6 +71,7 @@ extension URLStorage {
 extension WebURL.UTF8View: RandomAccessCollection {
 
   public typealias Index = Int
+  public typealias Indices = Range<Index>
   public typealias Element = UInt8
 
   @inlinable
@@ -81,6 +82,11 @@ extension WebURL.UTF8View: RandomAccessCollection {
   @inlinable
   public var endIndex: Index {
     storage.codeUnits.count
+  }
+
+  @inlinable
+  public var indices: Range<Index> {
+    Range(uncheckedBounds: (startIndex, endIndex))
   }
 
   @inlinable


### PR DESCRIPTION
On some rare occasions, the project fails to compile, and swift returns a bunch of errors about `UTF8View`, saying that `Collection.SubSequence.SubSequence.Subsequence.Indices` (and so on) are not the same as `Collection.Indices`. It only happens on incremental builds (a clean build clears it right up).

It's pretty weird, especially since we never defined an `Indices` type on `UTF8View` so were using the default. It seems to be a canonicalisation bug; hopefully something the compiler's new requirement-machine will eliminate.

For now, work around it by defining the `Indices` type.