### PR TITLE
Switch from 'isHierarchical' -> 'hasOpaquePath'

### DIFF
--- a/Sources/WebURL/DeprecatedAPIs.swift
+++ b/Sources/WebURL/DeprecatedAPIs.swift
@@ -127,27 +127,25 @@ extension IPv4Address {
 
 extension WebURL {
 
-  /// Whether this URL cannot be a base.
+  /// Whether this URL has an opaque path.
   ///
-  /// **This API is deprecated and will be removed in a future version.**
+  /// **This API is deprecated and will be removed in a future version; use `hasOpaquePath` instead.**
   ///
-  /// 'Cannot be a base' URLs are non-hierarchical; they do not have authority components, or hierarchical paths.
-  /// URLs with special schemes (such as http or file) are never non-hierarchical.
-  /// Non-hierarchical URLs can be recognized by the lack of slashes immediately following their scheme.
-  ///
-  /// When parsing a relative URL string against such a URL, only replacing the fragment is allowed, and any modifications which would change
-  /// a URL's structure to become hierarchical (or non-hierarchical) will fail. This means the `username`, `password`, `hostname`, `port`, and
-  /// `path` setters always fail when performed on a non-hierarchical URL.
-  ///
-  /// Examples of non-hierarchical URLs are:
+  /// URLs with opaque paths are non-hierarchical: they do not have a hostname, and their paths are opaque strings which cannot be split in to components.
+  /// They can be recognized by the lack of slashes immediately following the scheme delimiter, for example:
   ///
   /// - `mailto:bob@example.com`
   /// - `javascript:alert("hello");`
   /// - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   ///
-  @available(*, deprecated, message: "Use `!isHierarchical` instead")
+  /// It is invalid to set any authority components, such as `username`, `password`, `hostname` or `port`, on these URLs.
+  /// Modifying the `path` or accessing the URL's `pathComponents` is also invalid, and they only support limited forms of relative references.
+  ///
+  /// URLs with special schemes (such as http/s and file) never have opaque paths.
+  ///
+  @available(*, deprecated, renamed: "hasOpaquePath")
   public var cannotBeABase: Bool {
-    !storage.isHierarchical
+    hasOpaquePath
   }
 }
 

--- a/Sources/WebURL/Parser/Parser+Path.swift
+++ b/Sources/WebURL/Parser/Parser+Path.swift
@@ -125,8 +125,8 @@ internal struct _PathParserState {
 
   /// Whether or not the parser has yielded any components.
   ///
-  /// A hierarchical URL requires either an authority segment or hierarchical path.
-  /// Therefore, it is usually required that the path parser yields at least _something_.
+  /// Most URLs require either an authority segment or non-opaque path,
+  /// therefore it is usually required that the path parser yields at least _something_.
   ///
   /// It is also important to track this flag when determining whether a path sigil is required.
   ///
@@ -239,7 +239,7 @@ extension _PathParser {
   /// This method yields the components `["", "c", "a"]`, and path construction by prepending proceeds as follows: `"/" -> "/c/" -> "/a/c/"`.
   ///
   /// - note: The parser produces a non-empty path for almost all inputs. The only case in which this function does not yield a path
-  ///         is when the input is empty, the scheme is not special, and the URL has an authority (and thus is already hierarchical).
+  ///         is when the input is empty, the scheme is not special, and the URL has an authority (as these URLs are allowed to have empty paths).
   ///
   /// - parameters:
   ///   - input:        The path string to parse, as a collection of UTF-8 code-units.
@@ -270,7 +270,7 @@ extension _PathParser {
     guard input.startIndex < input.endIndex else {
       // Special URLs have an implicit path.
       // Non-special URLs may only have an empty path if they have an authority
-      // (otherwise they would be non-hierarchical URLs).
+      // (otherwise they would be opaque-path URLs).
       if schemeKind.isSpecial || !hasAuthority {
         visitEmptyPathComponent()
       }

--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -1245,7 +1245,7 @@ extension URLScanner {
       case .fragment:
         nextLocation = scanFragment(remaining, &mapping, callback: &callback)
       case .pathStart, .path, .host, .port, .authority:
-        fatalError("Tried to scan invalid component for non-hierarchical URL")
+        fatalError("Tried to scan invalid component for URL with opaque path")
       }
     }
     return true

--- a/Sources/WebURL/Parser/URLWriter.swift
+++ b/Sources/WebURL/Parser/URLWriter.swift
@@ -289,7 +289,7 @@ internal struct StructureAndMetricsCollector: URLWriter {
   @inlinable
   internal mutating func writeFlags(schemeKind: WebURL.SchemeKind, hasOpaquePath: Bool) {
     structure.schemeKind = schemeKind
-    structure.isHierarchical = !hasOpaquePath
+    structure.hasOpaquePath = hasOpaquePath
   }
 
   @inlinable

--- a/Sources/WebURL/Parser/ValidationError.swift
+++ b/Sources/WebURL/Parser/ValidationError.swift
@@ -147,12 +147,12 @@ extension ValidationError: CustomStringConvertible {
       return #"""
         The input is missing a scheme, because it does not begin with an ASCII alpha,
         and either no base URL was provided or the base URL cannot be used as a base URL
-        because it is non-hierarchical.
+        because it has an opaque path.
 
         Example (Input’s scheme is missing and no base URL is given):
         (url, base) = ("💩", nil)
 
-        Example (Input’s scheme is missing, but the base URL is non-hierarchical):
+        Example (Input’s scheme is missing, but the base URL has an opaque path):
         (url, base) = ("💩", "mailto:user@example.org")
         """#
     case .relativeURLMissingBeginningSolidus:

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -1430,7 +1430,7 @@ extension URLEncodeSet {
     internal static func shouldEscape_binary(ascii codePoint: UInt8) -> Bool {
       // TODO: [performance]: Benchmark alternative:
       // `codePoint & 0b11100000 == 0 || codePoint == 0x7F`
-      // C0Control percent-encoding is used for non-hierarchical URL paths and opaque host names,
+      // C0Control percent-encoding is used for opaque paths and opaque host names,
       // which currently are not benchmarked.
 
       //                 FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210

--- a/Sources/WebURL/WebURL+FilePaths.swift
+++ b/Sources/WebURL/WebURL+FilePaths.swift
@@ -899,7 +899,7 @@ internal var _emptyFileURL: WebURL {
       structure: URLStructure(
         schemeLength: 5, usernameLength: 0, passwordLength: 0, hostnameLength: 0,
         portLength: 0, pathLength: 1, queryLength: 0, fragmentLength: 0, firstPathComponentLength: 1,
-        sigil: .authority, schemeKind: .file, isHierarchical: true, queryIsKnownFormEncoded: true),
+        sigil: .authority, schemeKind: .file, hasOpaquePath: false, queryIsKnownFormEncoded: true),
       initializingCodeUnitsWith: { buffer in
         ("file:///" as StaticString).withUTF8Buffer { buffer.fastInitialize(from: $0) }
       }

--- a/Sources/WebURL/WebURL+Origin.swift
+++ b/Sources/WebURL/WebURL+Origin.swift
@@ -23,7 +23,7 @@ extension WebURL {
   ///
   /// The only URLs for which meaningful origins may be computed are:
   /// - Those with the http, https, ftp, ws, or wss schemes (i.e. the "special" schemes, excluding file), and
-  /// - Those with the "blob" scheme, which are non-hierarchical, and whose path is another URL.
+  /// - Those with the "blob" scheme, which have an opaque path containing another URL.
   ///
   /// Computing an origin using any other URL results in an _opaque origin_, which is defined to be an "internal value, with no serialization it can be recreated from,
   /// [...] and for which the only meaningful operation is testing for equality." ([HTML Standard][HTML-origin]).
@@ -82,7 +82,7 @@ extension WebURL {
     case .http, .https, .ws, .wss, .ftp:
       let serializedTuple = "\(scheme)://\(hostname!)\(port.map { ":\($0)" } ?? "")"
       return Origin(kind: .tuple(serializedTuple))
-    case .other where !isHierarchical && utf8.scheme.elementsEqual("blob".utf8):
+    case .other where hasOpaquePath && utf8.scheme.elementsEqual("blob".utf8):
       return WebURL(path)?.origin ?? Origin(kind: .opaque)
     default:
       return Origin(kind: .opaque)

--- a/Sources/WebURL/WebURL.swift
+++ b/Sources/WebURL/WebURL.swift
@@ -237,11 +237,12 @@ extension WebURL {
 
   /// The string representation of this URL's path.
   ///
-  /// A URL's path is a list of zero or more ASCII strings, usually identifying a location in hierarchical form.
-  /// Hierarchical paths are those that begin with a "/". Empty paths are assumed to be hierarchical if the URL has a `hostname`.
+  /// A URL’s path is either an opaque ASCII string or a list of zero or more ASCII strings, usually identifying a location.
+  /// Paths which are lists begin with a forward-slash, and their components delimited by forward-slashes ("/").
+  /// Empty paths are lists if the URL has a `hostname`.
   ///
-  /// When setting this property, the given path string will be lexically simplified, and any code-points in the path's components that are not valid
-  /// for use will be percent-encoded. Setting this property may fail if the URL is non-hierarchical (see `WebURL.isHierarchical`).
+  /// When setting this property, the given path will be lexically simplified, and any code-points in the path's components that are not valid
+  /// for use will be percent-encoded. Setting this property will fail if the URL's path is opaque (see ``WebURL.hasOpaquePath``).
   ///
   public var path: String {
     get { String(decoding: utf8.path, as: UTF8.self) }
@@ -274,29 +275,22 @@ extension WebURL {
     set { try? setFragment(newValue) }
   }
 
-  /// Whether this is a hierarchical URL.
+  /// Whether this URL has an opaque path.
   ///
-  /// Hierarchical URLs have an authority component or hierarchical path.
-  /// URLs with special schemes (such as http or file) are always hierarchical.
-  ///
-  /// Non-hierarchical URLs can be recognized by the lack of slashes immediately following their scheme, and support only a very
-  /// limited subset of URL operations. Attempting to set any authority components, such as `username`, `password`, `hostname` or `port`,
-  /// will fail, as will attempts to set the `path`. Non-hierarchical URLs do not have path components, so accessing the `pathComponents` property
-  /// will trigger a runtime error. When resolving a relative URL string against a non-hierarchical URL, only replacing the fragment is allowed.
-  ///
-  /// Examples of non-hierarchical URLs are:
+  /// URLs with opaque paths are non-hierarchical: they do not have a hostname, and their paths are opaque strings which cannot be split in to components.
+  /// They can be recognized by the lack of slashes immediately following the scheme delimiter, for example:
   ///
   /// - `mailto:bob@example.com`
   /// - `javascript:alert("hello");`
   /// - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   ///
-  public var isHierarchical: Bool {
-    storage.isHierarchical
-  }
-
-  @usableFromInline
-  internal var hasOpaquePath: Bool {
-    !storage.isHierarchical
+  /// It is invalid to set any authority components, such as `username`, `password`, `hostname` or `port`, on these URLs.
+  /// Modifying the `path` or accessing the URL's `pathComponents` is also invalid, and they only support limited forms of relative references.
+  ///
+  /// URLs with special schemes (such as http/s and file) never have opaque paths.
+  ///
+  public var hasOpaquePath: Bool {
+    storage.hasOpaquePath
   }
 }
 
@@ -379,7 +373,7 @@ extension WebURL {
   /// Replaces this URL's `path` with the given string.
   ///
   /// When setting this component, the given path string will be lexically simplified, and any code-points in the path's components that are not valid
-  /// for use will be percent-encoded. Setting this component will fail if the URL is non-hierarchical (see `WebURL.isHierarchical` for more information).
+  /// for use will be percent-encoded. Setting this component will fail if the URL's path is opaque (see ``WebURL.hasOpaquePath``).
   ///
   /// - seealso: `path`
   ///

--- a/Tests/WebURLDeprecatedAPITests/WebURLAPITests.swift
+++ b/Tests/WebURLDeprecatedAPITests/WebURLAPITests.swift
@@ -20,28 +20,28 @@ import XCTest
 final class WebURLAPITests_Deprecated: XCTestCase {
 
   func testCannotBeABase() {
-    // Non-hierarchical URLs.
+    // URLs with opaque paths.
     if let url = WebURL("javascript:alert('hello');") {
-      XCTAssertFalse(url.isHierarchical)
+      XCTAssertTrue(url.hasOpaquePath)
       XCTAssertTrue(url.cannotBeABase)
     } else {
       XCTFail()
     }
     if let url = WebURL("mailto:jim@example.com") {
-      XCTAssertFalse(url.isHierarchical)
+      XCTAssertTrue(url.hasOpaquePath)
       XCTAssertTrue(url.cannotBeABase)
     } else {
       XCTFail()
     }
-    // Hierarchical URLs.
+    // URLs with non-opaque paths.
     if let url = WebURL("http://example.com") {
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
       XCTAssertFalse(url.cannotBeABase)
     } else {
       XCTFail()
     }
     if let url = WebURL("foo:/path/only") {
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
       XCTAssertFalse(url.cannotBeABase)
     } else {
       XCTFail()

--- a/Tests/WebURLTests/PathComponentsTests.swift
+++ b/Tests/WebURLTests/PathComponentsTests.swift
@@ -214,7 +214,7 @@ extension PathComponentsTests {
     let url = WebURL("foo://somehost?someQuery")!
     XCTAssertEqual(url.serialized, "foo://somehost?someQuery")
     XCTAssertEqual(url.path, "")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, [])
     XCTAssertEqual(url.pathComponents.count, 0)
@@ -227,7 +227,7 @@ extension PathComponentsTests {
     let url = WebURL("http://example.com/?someQuery")!
     XCTAssertEqual(url.serialized, "http://example.com/?someQuery")
     XCTAssertEqual(url.path, "/")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, [""])
     XCTAssertEqual(url.pathComponents.count, 1)
@@ -240,7 +240,7 @@ extension PathComponentsTests {
     let url = WebURL("foo:/a/b/c")!
     XCTAssertEqual(url.serialized, "foo:/a/b/c")
     XCTAssertEqual(url.path, "/a/b/c")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, ["a", "b", "c"])
     XCTAssertEqual(url.pathComponents.count, 3)
@@ -255,7 +255,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com//?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com//?someQuery")
       XCTAssertEqual(url.path, "//")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["", ""])
       XCTAssertEqual(url.pathComponents.count, 2)
@@ -267,7 +267,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com///?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com///?someQuery")
       XCTAssertEqual(url.path, "///")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["", "", ""])
       XCTAssertEqual(url.pathComponents.count, 3)
@@ -279,7 +279,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com////?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com////?someQuery")
       XCTAssertEqual(url.path, "////")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["", "", "", ""])
       XCTAssertEqual(url.pathComponents.count, 4)
@@ -291,7 +291,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com//p///?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com//p///?someQuery")
       XCTAssertEqual(url.path, "//p///")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["", "p", "", "", ""])
       XCTAssertEqual(url.pathComponents.count, 5)
@@ -307,7 +307,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com/a/b/c?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com/a/b/c?someQuery")
       XCTAssertEqual(url.path, "/a/b/c")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c"])
       XCTAssertEqual(url.pathComponents.count, 3)
@@ -319,7 +319,7 @@ extension PathComponentsTests {
       let url = WebURL("http://example.com/a/b/c/?someQuery")!
       XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
       XCTAssertEqual(url.path, "/a/b/c/")
-      XCTAssertTrue(url.isHierarchical)
+      XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", ""])
       XCTAssertEqual(url.pathComponents.count, 4)
@@ -333,7 +333,7 @@ extension PathComponentsTests {
     let url = WebURL("file:///C:/Windows/🦆/System 32/somefile.dll")!
     XCTAssertEqual(url.serialized, "file:///C:/Windows/%F0%9F%A6%86/System%2032/somefile.dll")
     XCTAssertEqual(url.path, "/C:/Windows/%F0%9F%A6%86/System%2032/somefile.dll")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, ["C:", "Windows", "🦆", "System 32", "somefile.dll"])
     XCTAssertEqual(url.pathComponents.count, 5)
@@ -357,7 +357,7 @@ extension PathComponentsTests {
     let url = WebURL("http://example.com/a/b/c/?someQuery")!
     XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
     XCTAssertEqual(url.path, "/a/b/c/")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", ""])
     XCTAssertEqual(url.pathComponents.count, 4)
@@ -382,7 +382,7 @@ extension PathComponentsTests {
     let url = WebURL("http://example.com/a/b/c/?someQuery")!
     XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
     XCTAssertEqual(url.path, "/a/b/c/")
-    XCTAssertTrue(url.isHierarchical)
+    XCTAssertFalse(url.hasOpaquePath)
 
     XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", ""])
     XCTAssertEqual(url.pathComponents.count, 4)
@@ -641,10 +641,11 @@ extension PathComponentsTests {
       XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
-    // We can add components to a hierarchical URL with an empty path.
+    // We can add components to a non-opaque, empty path.
     do {
       var url = WebURL("foo://somehost?someQuery")!
       XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertFalse(url.hasOpaquePath)
 
       let range = url.pathComponents.replaceSubrange(
         url.pathComponents.startIndex..<url.pathComponents.endIndex, with: ["a", "b", "c"]
@@ -1566,10 +1567,11 @@ extension PathComponentsTests {
       XCTAssertURLIsIdempotent(url)
     }
 
-    // Insert to a hierarchical URL with an empty path.
+    // Insert to a non-opaque, empty path.
     do {
       var url = WebURL("foo://example.com")!
       XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertFalse(url.hasOpaquePath)
 
       let range = url.pathComponents.insert(contentsOf: ["hello", "world"], at: url.pathComponents.endIndex)
       XCTAssertEqual(range.lowerBound, url.pathComponents.startIndex)
@@ -1705,10 +1707,11 @@ extension PathComponentsTests {
       XCTAssertURLIsIdempotent(url)
     }
 
-    // Appending to a hierarchical URL with an empty path.
+    // Appending to a non-opaque, empty path.
     do {
       var url = WebURL("foo://example.com")!
       XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertFalse(url.hasOpaquePath)
 
       let range = url.pathComponents.append(contentsOf: ["hello", "world"])
       XCTAssertEqual(range.lowerBound, url.pathComponents.startIndex)
@@ -1879,10 +1882,11 @@ extension PathComponentsTests {
       XCTAssertURLIsIdempotent(url)
     }
 
-    // Removal from a hierarchical URL with an empty path.
+    // Removal from a non-opaque, empty path.
     do {
       var url = WebURL("foo://example.com")!
       XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertFalse(url.hasOpaquePath)
 
       let idx = url.pathComponents.removeSubrange(url.pathComponents.startIndex..<url.pathComponents.endIndex)
       XCTAssertEqual(idx, url.pathComponents.startIndex)
@@ -2266,10 +2270,11 @@ extension PathComponentsTests {
       XCTAssertEqual(url.serialized, "file:///")
       XCTAssertURLIsIdempotent(url)
     }
-    // Appends an empty component if the URL is hierarchical and path is empty.
+    // Appends an empty component if the path is non-opaque and empty.
     do {
       var url = WebURL("foo://example")!
       XCTAssertEqualElements(url.pathComponents, [])
+      XCTAssertFalse(url.hasOpaquePath)
 
       url.pathComponents.ensureDirectoryPath()
       XCTAssertEqualElements(url.pathComponents, [""])


### PR DESCRIPTION
This is now an official term in the standard (See https://github.com/whatwg/url/issues/634)