### PR TITLE
Additions to pathComponents to better handle percent-encoded data

### DIFF
--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -1382,11 +1382,6 @@ extension _StaticMember where Base: PercentEncodeSet {
   ///
   @inlinable
   public static var formEncoding: _StaticMember<URLEncodeSet.FormEncoding> { .init(.init()) }
-
-  /// An internal percent-encode set for manipulating path components.
-  ///
-  @inlinable
-  internal static var pathComponentSet: _StaticMember<URLEncodeSet._PathComponent> { .init(.init()) }
 }
 
 // URL encode-set implementations.
@@ -1665,34 +1660,6 @@ extension URLEncodeSet {
 
     @inlinable @inline(__always)
     public var substitutions: Substitutions { .init() }
-  }
-}
-
-// Non-standard encode-sets.
-
-extension URLEncodeSet {
-
-  /// An encode-set used for escaping the contents path components. **Not defined by the URL standard.**
-  ///
-  /// The URL 'path' encode-set, as defined in the standard, does not include the forward-slash character, as the URL parser won't ever see them in a path component.
-  /// This is problematic for APIs which allow the user to insert path-components, as they might insert content which would be re-parsed as multiple components,
-  /// possibly including hidden "." or ".." components and leading to non-idempotent URL strings.
-  ///
-  /// A solution with true minimal-escaping would be split this encode-set for special/non-special URLs, with only the former including the forwardSlash character.
-  /// For simplicity, we include them both, which means that we will unnecessarily escape forwardSlashes in the path components of non-special URLs.
-  ///
-  @usableFromInline
-  internal struct _PathComponent: PercentEncodeSet {
-
-    @inlinable
-    internal init() {}
-
-    @inlinable @inline(__always)
-    internal func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
-      __shouldPercentEncode(URLEncodeSet.Path.self, ascii: codePoint)
-        || codePoint == ASCII.forwardSlash.codePoint
-        || codePoint == ASCII.backslash.codePoint
-    }
   }
 }
 

--- a/Tests/WebURLTests/FilePathTests.swift
+++ b/Tests/WebURLTests/FilePathTests.swift
@@ -160,7 +160,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.startIndex], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.first, "caf��")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
@@ -181,7 +181,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.startIndex], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.first, "hi���")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
@@ -301,7 +301,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.last, "caf��")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
@@ -323,7 +323,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.last, "hi���")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
@@ -483,7 +483,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.last, "caf��")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
@@ -506,7 +506,7 @@ extension FilePathTests {
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
 
-      // FIXME: Perhaps don't automatically percent-decode path components?
+      XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.last, "hi���")
 
       let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)

--- a/Tests/WebURLTests/OtherURLTests.swift
+++ b/Tests/WebURLTests/OtherURLTests.swift
@@ -1,0 +1,68 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import WebURL
+
+final class OtherURLTests: XCTestCase {}
+
+// This file contains tests which document "questionable behaviour" in the URL Standard.
+// Web compatibility means these things might never change, but it may also be worth raising them
+// with the WHATWG at some point. In any case, it's worth adding a test so we don't forget about them
+// and don't mistakenly think they are bugs with WebURL.
+
+extension OtherURLTests {
+
+  func testPathSetterBackslash() {
+
+    // Backslashes are not percent-encoded in non-special URLs,
+    // so copying the path to a special URL can cause it to be interpreted differently.
+    do {
+      var specialURL = WebURL("https://example.com/")!
+      XCTAssertEqual(specialURL.serialized, "https://example.com/")
+      XCTAssertEqual(specialURL.path, "/")
+      XCTAssertEqual(specialURL.pathComponents.count, 1)
+
+      let nonSpecialURL = WebURL(#"foo://example.com/baz\qux"#)!
+      XCTAssertEqual(nonSpecialURL.serialized, #"foo://example.com/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.path, #"/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.pathComponents.count, 1)
+
+      specialURL.path = nonSpecialURL.path
+      XCTAssertEqual(specialURL.serialized, "https://example.com/baz/qux")
+      XCTAssertEqual(specialURL.path, "/baz/qux")
+      XCTAssertEqual(specialURL.pathComponents.count, 2)
+    }
+
+    // Our pathComponents view happens to work around this.
+    // (covered already in PathComponentsTests.testReplaceSubrange_Slashes, .testAppendContents, etc)
+    do {
+      var specialURL = WebURL("https://example.com/")!
+      XCTAssertEqual(specialURL.serialized, "https://example.com/")
+      XCTAssertEqual(specialURL.path, "/")
+      XCTAssertEqual(specialURL.pathComponents.count, 1)
+
+      let nonSpecialURL = WebURL(#"foo://example.com/baz\qux"#)!
+      XCTAssertEqual(nonSpecialURL.serialized, #"foo://example.com/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.path, #"/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.pathComponents.count, 1)
+
+      specialURL.pathComponents.append(contentsOf: nonSpecialURL.pathComponents)
+      XCTAssertEqual(specialURL.serialized, "https://example.com/baz%5Cqux")
+      XCTAssertEqual(specialURL.path, "/baz%5Cqux")
+      XCTAssertEqual(specialURL.pathComponents.count, 1)
+    }
+  }
+}


### PR DESCRIPTION
- "%" added to pathComponents encode-set
- added raw subscript for reading without percent-decoding
- added replaceSubrange(_:withPercentEncodedComponents:) for writing percent-encoded components