### PR TITLE
[File paths] Allow percent-encoded Windows drive letters

### DIFF
--- a/Sources/WebURL/WebURL+FilePaths.swift
+++ b/Sources/WebURL/WebURL+FilePaths.swift
@@ -796,12 +796,11 @@ internal func _filePathFromURL_windows(
 
   if !isUNC {
     // For DOS-style paths, the first component must be a drive letter and be followed by another component.
-    // (e.g. "/C:/" is okay, "/C:" is not). Furthermore, we require the drive letter not be percent-encoded.
+    // (e.g. "/C:/" is okay, "/C:" is not). Furthermore, we allow the drive letter to be percent-encoded.
 
-    // This may be too strict - people sometimes over-escape characters in URLs, and generally standards favour
-    // treating percent-encoded characters as equivalent to their decoded versions.
     let drive = url.utf8.pathComponent(url.pathComponents.startIndex)
-    guard PathComponentParser.isNormalizedWindowsDriveLetter(drive), drive.endIndex < urlPath.endIndex else {
+    let decodedDrive = drive.lazy.percentDecoded()
+    guard PathComponentParser.isNormalizedWindowsDriveLetter(decodedDrive), drive.endIndex < urlPath.endIndex else {
       return .failure(.windowsPathIsNotFullyQualified)
     }
     // Drop the leading slash from the path.

--- a/Tests/WebURLTests/Resources/file_url_path_tests.json
+++ b/Tests/WebURLTests/Resources/file_url_path_tests.json
@@ -3595,16 +3595,16 @@
             "file_path_windows": { "failure-reason": "relative-path" }
         },
         {
-            "comment": "URL path with an escaped drive-letter [no hostname, with trailing]. This is an interesting case - since the path component is escaped, there's an argument that it intentionally does not want to be interpreted as a drive letter. Indeed, the Windows API 'PathCreateFromUrl' treats this as a relative path, and IE won't resolve it. Chrome/Edge will, though.",
+            "comment": "URL path with an escaped drive-letter [no hostname, with trailing]",
             "URL": "file:///c%3A/",
             "file_path_posix": "/c:/",
-            "file_path_windows": { "failure-reason": "relative-path" }
+            "file_path_windows": "c:\\"
         },
         {
             "comment": "URL with an escaped drive letter [no hostname] (2)",
             "URL": "file:///C%3A/foo/BAR/baZ.txt",
             "file_path_posix": "/C:/foo/BAR/baZ.txt",
-            "file_path_windows": { "failure-reason": "relative-path" }
+            "file_path_windows": "C:\\foo\\BAR\\baZ.txt"
         },
         {
             "comment": "URL path with a percent-encoded Windows drive-relative path [no hostname, no trailing].",


### PR DESCRIPTION
I just think disallowing them is too strict. They still have to abide by a bunch of format restrictions (e.g. must have a trailing slash), so this is just a good move for compatibility.

Percent-encode sets are far from universal. Just because the WHATWG URL Standard doesn't require `:` to be encoded, doesn't mean other systems won't produce these URLs.