### PR TITLE
Combine .serialized and .serializedExcludingFragment in to a single .serialized(excludingFragment:) function.

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -33,7 +33,7 @@ url.scheme // "https"
 url.hostname // "github.com"
 url.path // "/karwa/swift-url/"
 
-url.serialized // "https://github.com/karwa/swift-url/"
+url.serialized() // "https://github.com/karwa/swift-url/"
 ```
 
 Components are returned as they appear in the URL string, including any percent-encoding. The `WebURL` package includes a number of extensions to standard library types and protocols,
@@ -79,11 +79,11 @@ var url = WebURL("http://github.com/karwa/swift-url/")!
 
 // Upgrade to https:
 url.scheme = "https"
-url.serialized // "https://github.com/karwa/swift-url/"
+url.serialized() // "https://github.com/karwa/swift-url/"
 
 // Change the path:
 url.path = "/apple/swift/"
-url.serialized // "https://github.com/apple/swift/"
+url.serialized() // "https://github.com/apple/swift/"
 ```
 
 When you modify a component, the value you set will automatically be percent-encoded if it contains any illegal characters.
@@ -95,10 +95,10 @@ var url = WebURL("https://example.com/my_files/secrets.txt")!
 
 url.username = "my username"
 url.password = "🤫"
-url.serialized // "https://my%20username:%F0%9F%A4%AB@example.com/my_files/secrets.txt"
+url.serialized() // "https://my%20username:%F0%9F%A4%AB@example.com/my_files/secrets.txt"
 
 url.hostname = "👾" // Fails, does not modify.
-url.serialized // (unchanged)
+url.serialized() // (unchanged)
 ```
 
 In general, the setters are very permissive. However, if you do wish to detect and respond to failures to modify a component,

--- a/Sources/WebURL/WebURL+FormParameters.swift
+++ b/Sources/WebURL/WebURL+FormParameters.swift
@@ -46,13 +46,13 @@ extension WebURL {
   /// assert(url.formParams.from == "EUR")
   ///
   /// url.formParams.from = "GBP"
-  /// assert(url.serialized == "http://example.com/currency/convert?from=GBP&to=USD")
+  /// assert(url.serialized() == "http://example.com/currency/convert?from=GBP&to=USD")
   ///
   /// url.formParams.amount = "20"
-  /// assert(url.serialized == "http://example.com/currency/convert?from=GBP&to=USD&amount=20")
+  /// assert(url.serialized() == "http://example.com/currency/convert?from=GBP&to=USD&amount=20")
   ///
   /// url.formParams.to = "💵"
-  /// assert(url.serialized == "http://example.com/currency/convert?from=GBP&to=%F0%9F%92%B5&amount=20")
+  /// assert(url.serialized() == "http://example.com/currency/convert?from=GBP&to=%F0%9F%92%B5&amount=20")
   /// ```
   ///
   /// Additionally, you can iterate over all of the key-value pairs using the `.allKeyValuePairs` property:
@@ -73,7 +73,7 @@ extension WebURL {
   ///
   /// ```swift
   /// let url = WebURL("http://example.com?jalape\u{006E}\u{0303}os=2")!
-  /// url.serialized // "http://example.com/?jalapen%CC%83os=2"
+  /// url.serialized() // "http://example.com/?jalapen%CC%83os=2"
   /// url.formParams.get("jalape\u{006E}\u{0303}os") // "2"
   /// url.formParams.get("jalape\u{00F1}os") // nil
   /// url.formParams.allKeyValuePairs.first(where: { $0.0 == "jalape\u{00F1}os" }) // ("jalapeños", "2")

--- a/Sources/WebURL/WebURL+JSModel.swift
+++ b/Sources/WebURL/WebURL+JSModel.swift
@@ -152,7 +152,7 @@ extension WebURL.JSModel {
 extension WebURL.JSModel: CustomStringConvertible {
 
   public var description: String {
-    swiftModel.serialized
+    swiftModel.serialized()
   }
 }
 
@@ -188,7 +188,7 @@ extension WebURL.JSModel {
   ///
   public var href: String {
     get {
-      swiftModel.serialized
+      swiftModel.serialized()
     }
     set {
       if let newURL = WebURL(newValue) {

--- a/Sources/WebURL/WebURL.swift
+++ b/Sources/WebURL/WebURL.swift
@@ -116,7 +116,7 @@ extension WebURL: Equatable, Hashable, Comparable {
 extension WebURL: CustomStringConvertible, LosslessStringConvertible {
 
   public var description: String {
-    serialized
+    serialized()
   }
 }
 
@@ -132,7 +132,7 @@ extension WebURL: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(serialized)
+    try container.encode(serialized())
   }
 }
 
@@ -157,16 +157,15 @@ extension WebURL {
 
 extension WebURL {
 
-  /// The string representation of this URL.
+  /// Returns the string representation of this URL.
   ///
-  public var serialized: String {
-    String(decoding: utf8, as: UTF8.self)
-  }
-
-  /// The string representation of this URL, excluding the URL's fragment.
+  /// - parameters:
+  ///   - excludingFragment: Whether the fragment should be omitted from the result. The default is `false`.
   ///
-  public var serializedExcludingFragment: String {
-    utf8[0..<storage.structure.fragmentStart].withUnsafeBufferPointer { String(decoding: $0, as: UTF8.self) }
+  public func serialized(excludingFragment: Bool = false) -> String {
+    excludingFragment
+      ? String(decoding: utf8[0..<storage.structure.fragmentStart], as: UTF8.self)
+      : String(decoding: utf8, as: UTF8.self)
   }
 
   /// The scheme of this URL, for example `https` or `file`.

--- a/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
+++ b/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
@@ -37,7 +37,7 @@ extension FilePathToURLTests.WebURLReportHarness: FilePathToURLTests.Harness {
   public func filePathToURL(
     _ path: String, format: FilePathFormat
   ) -> Result<String, FilePathToURLTests.FailureReason> {
-    Result { try WebURL(filePath: path, format: format).serialized }
+    Result { try WebURL(filePath: path, format: format).serialized() }
       .mapError { Self.errorToFailureReason($0 as! URLFromFilePathError) }
   }
 
@@ -56,7 +56,7 @@ extension FilePathToURLTests.WebURLReportHarness: FilePathToURLTests.Harness {
   }
 
   public func parseSerializedURL(_ serializedURL: String) -> String? {
-    WebURL(serializedURL)?.serialized
+    WebURL(serializedURL)?.serialized()
   }
 
   public mutating func markSection(_ name: String) {

--- a/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
+++ b/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
@@ -49,7 +49,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create a file URL.
       let fileURL = try WebURL(filePath: filePath)
-      XCTAssertEqual(fileURL.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/foo/bar.txt")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
@@ -66,7 +66,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
       let fileURL2 = try WebURL(filePath: filePath2)
-      XCTAssertEqual(fileURL2.serialized, "file:///C:/foo/bar.txt")
+      XCTAssertEqual(fileURL2.serialized(), "file:///C:/foo/bar.txt")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/foo/bar.txt")
       XCTAssertEqual(fileURL, fileURL2)
@@ -91,7 +91,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create a file URL. Should be transcoded to UTF-8.
       let fileURL = try WebURL(filePath: filePath)
-      XCTAssertEqual(fileURL.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(
         fileURL, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
@@ -110,7 +110,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
       let fileURL2 = try WebURL(filePath: filePath2)
-      XCTAssertEqual(fileURL2.serialized, "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertEqual(fileURL2.serialized(), "file:///C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(
         fileURL2, scheme: "file", hostname: "", path: "/C:/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
@@ -129,7 +129,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes.
       let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
-      XCTAssertEqual(fileURL.serialized, "file:///C:/fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
@@ -173,7 +173,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes.
       let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
-      XCTAssertEqual(fileURL.serialized, "file:///C:/caf%E9%DD")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -199,7 +199,7 @@ final class SystemFilePathTests: XCTestCase {}
       // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
       // the contents should be transcoded to UTF-8.
       let fileURL2 = try WebURL(filePath: filePath)
-      XCTAssertEqual(fileURL2.serialized, "file:///C:/caf%C3%A9%C3%9D")
+      XCTAssertEqual(fileURL2.serialized(), "file:///C:/caf%C3%A9%C3%9D")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/caf%C3%A9%C3%9D")
       XCTAssertEqual(fileURL2.pathComponents.count, 2)
@@ -225,7 +225,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes.
       let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
-      XCTAssertEqual(fileURL.serialized, "file:///C:/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -252,7 +252,7 @@ final class SystemFilePathTests: XCTestCase {}
       // Since the FilePath contents are UTF-16 (rather than the ANSI bytes we started with),
       // the contents should be transcoded to UTF-8.
       let fileURL2 = try WebURL(filePath: filePath)
-      XCTAssertEqual(fileURL2.serialized, "file:///C:/hi%CE%B1%CE%B2%CE%B3")
+      XCTAssertEqual(fileURL2.serialized(), "file:///C:/hi%CE%B1%CE%B2%CE%B3")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/C:/hi%CE%B1%CE%B2%CE%B3")
       XCTAssertEqual(fileURL2.pathComponents.count, 2)
@@ -364,7 +364,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create a file URL.
       let fileURL = try filePath.toURL()
-      XCTAssertEqual(fileURL.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL.serialized(), "file:///tmp/foo/bar.txt")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
@@ -381,7 +381,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
       let fileURL2 = try filePath2.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///tmp/foo/bar.txt")
+      XCTAssertEqual(fileURL2.serialized(), "file:///tmp/foo/bar.txt")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/tmp/foo/bar.txt")
       XCTAssertEqual(fileURL, fileURL2)
@@ -407,7 +407,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create a file URL.
       let fileURL = try filePath.toURL()
-      XCTAssertEqual(fileURL.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertEqual(fileURL.serialized(), "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(
         fileURL, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
@@ -426,7 +426,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create another file URL which should exactly match the first one.
       let fileURL2 = try filePath2.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
+      XCTAssertEqual(fileURL2.serialized(), "file:///tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(
         fileURL2, scheme: "file", hostname: "", path: "/tmp/f%F0%9F%A6%86o/b%F0%9F%8F%86%F0%9F%8F%8Er.%F0%9F%92%A9"
@@ -444,7 +444,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
       let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
-      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.serialized(), "file:///fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -459,7 +459,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create another file URL from the path. Should exactly match the first one.
       let fileURL2 = try filePath.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL2.serialized(), "file:///fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL, fileURL2)
@@ -478,7 +478,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Use WebURL(filePath: FilePath) to create a file URL.
       let fileURL = try filePath.toURL()
-      XCTAssertEqual(fileURL.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL.serialized(), "file:///fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -495,7 +495,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create another file URL from the path. Should exactly match the first one.
       let fileURL2 = try filePath.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///fo%ED%A0%80o/bar")
+      XCTAssertEqual(fileURL2.serialized(), "file:///fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL, fileURL2)
@@ -510,7 +510,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
       let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
-      XCTAssertEqual(fileURL.serialized, "file:///caf%E9%DD")
+      XCTAssertEqual(fileURL.serialized(), "file:///caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
@@ -525,7 +525,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create another file URL from the path. Should exactly match the first one.
       let fileURL2 = try filePath.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///caf%E9%DD")
+      XCTAssertEqual(fileURL2.serialized(), "file:///caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/caf%E9%DD")
       XCTAssertEqual(fileURL, fileURL2)
@@ -540,7 +540,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
       let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
-      XCTAssertEqual(fileURL.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.serialized(), "file:///hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
@@ -555,7 +555,7 @@ final class SystemFilePathTests: XCTestCase {}
 
       // Create another file URL from the path. Should exactly match the first one.
       let fileURL2 = try filePath.toURL()
-      XCTAssertEqual(fileURL2.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertEqual(fileURL2.serialized(), "file:///hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL2)
       XCTAssertURLComponents(fileURL2, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
       XCTAssertEqual(fileURL, fileURL2)

--- a/Tests/WebURLSystemExtrasTests/Utils.swift
+++ b/Tests/WebURLSystemExtrasTests/Utils.swift
@@ -48,7 +48,7 @@ func XCTAssertThrowsSpecific<E>(
 /// Checks that the given URL returns precisely the same value when its serialized representation is re-parsed.
 ///
 func XCTAssertURLIsIdempotent(_ url: WebURL) {
-  var serialized = url.serialized
+  var serialized = url.serialized()
   serialized.makeContiguousUTF8()
   guard let reparsed = WebURL(serialized) else {
     XCTFail("Failed to reparse URL string: \(serialized)")
@@ -59,7 +59,7 @@ func XCTAssertURLIsIdempotent(_ url: WebURL) {
   // Check that the code-units are the same.
   XCTAssertEqualElements(url.utf8, reparsed.utf8)
   // Triple check: check that the serialized representations are the same.
-  XCTAssertEqual(serialized, reparsed.serialized)
+  XCTAssertEqual(serialized, reparsed.serialized())
 }
 
 /// Checks the component values of the given URL. Any components not specified are checked to have a `nil` value.

--- a/Tests/WebURLTests/FilePathTests.swift
+++ b/Tests/WebURLTests/FilePathTests.swift
@@ -67,7 +67,7 @@ extension FilePathTests {
 extension FilePathTests {
 
   func testEmptyFileURLIsValidURL() {
-    XCTAssertEqual(_emptyFileURL.serialized, "file:///")
+    XCTAssertEqual(_emptyFileURL.serialized(), "file:///")
     XCTAssertURLIsIdempotent(_emptyFileURL)
   }
 
@@ -83,7 +83,7 @@ extension FilePathTests {
       XCTFail()
       return
     }
-    XCTAssertEqual(fileURL.serialized, "file://example/foo/bar")
+    XCTAssertEqual(fileURL.serialized(), "file://example/foo/bar")
     XCTAssertURLIsIdempotent(fileURL)
     XCTAssertThrowsSpecific(URLSetterError.cannotHaveCredentialsOrPort) {
       try fileURL.setPort(99)
@@ -137,7 +137,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
 
-      XCTAssertEqual(fileURL.serialized, #"file:///fo%ED%A0%80o/bar"#)
+      XCTAssertEqual(fileURL.serialized(), #"file:///fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -155,7 +155,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
 
-      XCTAssertEqual(fileURL.serialized, "file:///caf%E9%DD")
+      XCTAssertEqual(fileURL.serialized(), "file:///caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
@@ -176,7 +176,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
 
-      XCTAssertEqual(fileURL.serialized, "file:///hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.serialized(), "file:///hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 1)
@@ -197,7 +197,7 @@ extension FilePathTests {
       let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .posix)
 
       XCTAssertEqual(
-        fileURL.serialized,
+        fileURL.serialized(),
         #"file:///fo%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F"#
           + #"%20!%22%23$%25&'()*+,-./0123456789%3A;%3C=%3E%3F@ABCDEFGHIJKLMNOPQRSTUVWXYZ[%5C]^_%60abcdefghijklm"#
           + #"nopqrstuvwxyz%7B%7C%7D~%7F%80%81%82%83%84%85%86%87%88%89%8A%8B%8C%8D%8E%8F%90%91%92%93%94%95%96%97"#
@@ -277,7 +277,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, #"file:///C:/fo%ED%A0%80o/bar"#)
+      XCTAssertEqual(fileURL.serialized(), #"file:///C:/fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
@@ -296,7 +296,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, "file:///C:/caf%E9%DD")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -318,7 +318,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, "file:///C:/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -339,7 +339,7 @@ extension FilePathTests {
       let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .windows)
 
       XCTAssertEqual(
-        fileURL.serialized,
+        fileURL.serialized(),
         #"file:///C:/fo%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F"#
           //      Dot at end of component is trimmed                Backslash turned to forward slash in URL
           //                        V                                                    V
@@ -458,7 +458,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, #"file:///C:/fo%ED%A0%80o/bar"#)
+      XCTAssertEqual(fileURL.serialized(), #"file:///C:/fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
@@ -478,7 +478,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, "file:///C:/caf%E9%DD")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -501,7 +501,7 @@ extension FilePathTests {
 
       let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
 
-      XCTAssertEqual(fileURL.serialized, "file:///C:/hi%E1%E2%E3")
+      XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
@@ -522,7 +522,7 @@ extension FilePathTests {
       let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .windows)
 
       XCTAssertEqual(
-        fileURL.serialized,
+        fileURL.serialized(),
         #"file:///C:/fo%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F"#
           //                                                        Backslash turned to forward slash in URL
           //                                                                             V

--- a/Tests/WebURLTests/FormParametersTests.swift
+++ b/Tests/WebURLTests/FormParametersTests.swift
@@ -27,13 +27,13 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
       url.formParams.from = "GBP"
-      XCTAssertEqual(url.serialized, "http://example.com/currency/convert?from=GBP&to=USD")
+      XCTAssertEqual(url.serialized(), "http://example.com/currency/convert?from=GBP&to=USD")
 
       url.formParams.amount = "20"
-      XCTAssertEqual(url.serialized, "http://example.com/currency/convert?from=GBP&to=USD&amount=20")
+      XCTAssertEqual(url.serialized(), "http://example.com/currency/convert?from=GBP&to=USD&amount=20")
 
       url.formParams.to = "💵"
-      XCTAssertEqual(url.serialized, "http://example.com/currency/convert?from=GBP&to=%F0%9F%92%B5&amount=20")
+      XCTAssertEqual(url.serialized(), "http://example.com/currency/convert?from=GBP&to=%F0%9F%92%B5&amount=20")
 
       XCTAssertURLIsIdempotent(url)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -51,7 +51,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // From documentation for 'contains', 'get':
     do {
       let url = WebURL("http://example.com?jalape\u{006E}\u{0303}os=2")!
-      XCTAssertEqual(url.serialized, "http://example.com/?jalapen%CC%83os=2")
+      XCTAssertEqual(url.serialized(), "http://example.com/?jalapen%CC%83os=2")
 
       XCTAssertTrue(url.formParams.contains("jalape\u{006E}\u{0303}os"))
       XCTAssertEqual(url.formParams.get("jalape\u{006E}\u{0303}os"), "2")
@@ -68,7 +68,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
   func testGet_Contains() {
 
     let url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
@@ -98,7 +98,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     XCTAssertEqual(url.formParams.getAll("doesNotExist"), [])
 
     // All of this is read-only; the URL's query string remains as it was.
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
   }
 
@@ -107,7 +107,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Both nil and empty query strings present as empty query parameters.
     do {
       var url = WebURL("http://example.com")!
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertNil(url.formParams.get(""))
       XCTAssertNil(url.formParams.get("?"))
@@ -117,7 +117,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
 
       url.query = ""
-      XCTAssertEqual(url.serialized, "http://example.com/?")
+      XCTAssertEqual(url.serialized(), "http://example.com/?")
       XCTAssertEqual(url.query, "")
       XCTAssertNil(url.formParams.get(""))
       XCTAssertNil(url.formParams.get("?"))
@@ -131,13 +131,13 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // When emptying the formParams, the URL's query gets set to nil rather than empty.
     do {
       var url = WebURL("http://example.com?a=b&c is the key=d&&e=&e&=foo&e=g&h=👀&e=f")!
-      XCTAssertEqual(url.serialized, "http://example.com/?a=b&c%20is%20the%20key=d&&e=&e&=foo&e=g&h=%F0%9F%91%80&e=f")
+      XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c%20is%20the%20key=d&&e=&e&=foo&e=g&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url.query, "a=b&c%20is%20the%20key=d&&e=&e&=foo&e=g&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url.formParams.h, "👀")
       XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
       url.formParams.removeAll()
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertNil(url.formParams.h)
       XCTAssertTrue(url.formParams.allKeyValuePairs.isEmpty)
@@ -150,12 +150,12 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // and are the equivalent of an empty query.
     do {
       var url = WebURL("http://example.com?&&&")!
-      XCTAssertEqual(url.serialized, "http://example.com/?&&&")
+      XCTAssertEqual(url.serialized(), "http://example.com/?&&&")
       XCTAssertEqual(url.query, "&&&")
       XCTAssertNil(url.formParams.get(""))
 
       url.formParams = url.formParams
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertNil(url.formParams.get(""))
       XCTAssertTrue(url.formParams.allKeyValuePairs.isEmpty)
@@ -170,7 +170,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Start with a URL without query, use 'append' to build one.
     do {
       var url = WebURL("http://example.com")!
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
 
@@ -179,7 +179,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       url.formParams.append("search query", value: "why are 🦆 so awesome?")  // both need escaping.
       url.formParams.append("`back`'tick'", value: "")  // U+0027 is encoded by forms, and only by forms.
       XCTAssertEqual(
-        url.serialized,
+        url.serialized(),
         "http://example.com/?non_escaped=true&spa+ce=&search+query=why+are+%F0%9F%A6%86+so+awesome%3F&%60back%60%27tick%27="
       )
       XCTAssertEqual(
@@ -195,7 +195,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       var storedParams = url.formParams
       url.query = nil
       url.hostname = "foobar.org"
-      XCTAssertEqual(url.serialized, "http://foobar.org/")
+      XCTAssertEqual(url.serialized(), "http://foobar.org/")
       XCTAssertNil(url.query)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
       XCTAssertFalse(url.formParams.contains("search query"))
@@ -208,7 +208,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       // Assign it to the URL.
       url.formParams = storedParams
       XCTAssertEqual(
-        url.serialized,
+        url.serialized(),
         "http://foobar.org/?non_escaped=true&spa+ce=&search+query=why+are+%F0%9F%A6%86+so+awesome%3F&%60back%60%27tick%27=&still+alive%3F=should+be%21&owned+and+mutable%3F=sure+thing%21"
       )
       XCTAssertEqual(url.formParams.get("still alive?"), "should be!")
@@ -219,12 +219,12 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Ensure that we can append to an empty (not 'nil') query.
     do {
       var url = WebURL("foo://bar?")!
-      XCTAssertEqual(url.serialized, "foo://bar?")
+      XCTAssertEqual(url.serialized(), "foo://bar?")
       XCTAssertEqual(url.query, "")
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
 
       url.formParams.append("test", value: "works!")
-      XCTAssertEqual(url.serialized, "foo://bar?test=works%21")
+      XCTAssertEqual(url.serialized(), "foo://bar?test=works%21")
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
       XCTAssertURLIsIdempotent(url)
     }
@@ -235,7 +235,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     do {
       // Start with a URL without query, use 'append' to build one.
       var url = WebURL("http://example.com")!
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
 
@@ -244,7 +244,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
         ("`back`'tick'", ""),  // U+0027 is encoded by forms, and only by forms.
       ]
       XCTAssertEqual(
-        url.serialized,
+        url.serialized(),
         "http://example.com/?search+query=why+are+%F0%9F%A6%86+so+awesome%3F&%60back%60%27tick%27="
       )
       XCTAssertEqual(url.query, "search+query=why+are+%F0%9F%A6%86+so+awesome%3F&%60back%60%27tick%27=")
@@ -257,7 +257,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       var storedParams = url.formParams
       url.query = nil
       url.hostname = "foobar.org"
-      XCTAssertEqual(url.serialized, "http://foobar.org/")
+      XCTAssertEqual(url.serialized(), "http://foobar.org/")
       XCTAssertNil(url.query)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
       XCTAssertFalse(url.formParams.contains("search query"))
@@ -272,7 +272,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       // Assign it to the URL.
       url.formParams = storedParams
       XCTAssertEqual(
-        url.serialized,
+        url.serialized(),
         "http://foobar.org/?search+query=why+are+%F0%9F%A6%86+so+awesome%3F&%60back%60%27tick%27=&still+alive%3F=should+be%21&owned+and+mutable%3F=sure+thing%21"
       )
       XCTAssertEqual(url.formParams.get("still alive?"), "should be!")
@@ -284,7 +284,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // so appending a dictionary always gives predictable results.
     do {
       var url = WebURL("http://example.com")!
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.query)
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
 
@@ -293,7 +293,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
         "key 2️⃣": "value %02",
       ]
       url.formParams += dictionary
-      XCTAssertEqual(url.serialized, "http://example.com/?key+2%EF%B8%8F%E2%83%A3=value+%2502&key+one=value+one")
+      XCTAssertEqual(url.serialized(), "http://example.com/?key+2%EF%B8%8F%E2%83%A3=value+%2502&key+one=value+one")
       XCTAssertEqual(url.query, "key+2%EF%B8%8F%E2%83%A3=value+%2502&key+one=value+one")
       XCTAssertEqual(url.formParams.get("key one"), "value one")
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -304,14 +304,14 @@ final class FormEncodedQueryParametersTests: XCTestCase {
   func testRemove() {
 
     var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
     // Removal from the front.
     XCTAssertEqual(url.formParams.a, "b")
     url.formParams.remove("a")
-    XCTAssertEqual(url.serialized, "http://example.com/?c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertNil(url.formParams.a)
@@ -321,7 +321,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     XCTAssertEqual(url.formParams.e, "")
     XCTAssertEqual(url.formParams.getAll("e"), ["", "g", "", "f"])
     url.formParams.remove("e")
-    XCTAssertEqual(url.serialized, "http://example.com/?c+is+the+key=d&=foo&h=%F0%9F%91%80")
+    XCTAssertEqual(url.serialized(), "http://example.com/?c+is+the+key=d&=foo&h=%F0%9F%91%80")
     XCTAssertEqual(url.query, "c+is+the+key=d&=foo&h=%F0%9F%91%80")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertNil(url.formParams.e)
@@ -330,7 +330,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Removal from the back.
     XCTAssertEqual(url.formParams.h, "👀")
     url.formParams.remove("h")
-    XCTAssertEqual(url.serialized, "http://example.com/?c+is+the+key=d&=foo")
+    XCTAssertEqual(url.serialized(), "http://example.com/?c+is+the+key=d&=foo")
     XCTAssertEqual(url.query, "c+is+the+key=d&=foo")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertNil(url.formParams.h)
@@ -341,7 +341,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     XCTAssertEqual(url.formParams.get(""), "foo")
     url.formParams.remove("c is the key")
     url.formParams.remove("")
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertNil(url.query)
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertNil(url.formParams.get("c is the key"))
@@ -352,14 +352,14 @@ final class FormEncodedQueryParametersTests: XCTestCase {
   func testRemoveAll() {
 
     var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertEqual(url.formParams.e, "")
     XCTAssertEqual(url.formParams.a, "b")
 
     url.formParams.removeAll()
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertNil(url.query)
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertNil(url.formParams.e)
@@ -370,14 +370,14 @@ final class FormEncodedQueryParametersTests: XCTestCase {
   func testSet() {
 
     var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
     // Set unique, pre-existing keys. Relative position of KVP within the string is maintained.
     XCTAssertEqual(url.formParams.a, "b")
     url.formParams.a = "THIS ONE"
-    XCTAssertEqual(url.serialized, "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.formParams.a, "THIS ONE")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -385,7 +385,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
     XCTAssertEqual(url.formParams.h, "👀")
     url.formParams.set("h", to: "ALSO THIS ONE")
-    XCTAssertEqual(url.serialized, "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=ALSO+THIS+ONE&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=ALSO+THIS+ONE&e=f")
     XCTAssertEqual(url.query, "a=THIS+ONE&c+is+the+key=d&e=&=foo&e=g&e=&h=ALSO+THIS+ONE&e=f")
     XCTAssertEqual(url.formParams.h, "ALSO THIS ONE")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -394,7 +394,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Set a key with multiple entries.
     XCTAssertEqual(url.formParams.e, "")
     url.formParams.e = "collapsed"
-    XCTAssertEqual(url.serialized, "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=THIS+ONE&c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
     XCTAssertEqual(url.query, "a=THIS+ONE&c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
     XCTAssertEqual(url.formParams.e, "collapsed")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -403,7 +403,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Setting to 'nil' removes the key.
     XCTAssertEqual(url.formParams.a, "THIS ONE")
     url.formParams.a = nil
-    XCTAssertEqual(url.serialized, "http://example.com/?c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
+    XCTAssertEqual(url.serialized(), "http://example.com/?c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
     XCTAssertEqual(url.query, "c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE")
     XCTAssertNil(url.formParams.a)
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -413,7 +413,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     XCTAssertNil(url.formParams.doesNotExist)
     url.formParams.doesNotExist = "Yes, it does!"
     XCTAssertEqual(
-      url.serialized,
+      url.serialized(),
       "http://example.com/?c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE&doesNotExist=Yes%2C+it+does%21")
     XCTAssertEqual(url.query, "c+is+the+key=d&e=collapsed&=foo&h=ALSO+THIS+ONE&doesNotExist=Yes%2C+it+does%21")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
@@ -430,13 +430,13 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
       // Value includes "%".
       url.formParams.doohickey = "folder-%61"
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar?doohickey=folder-%2561")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar?doohickey=folder-%2561")
       XCTAssertEqual(url.query, "doohickey=folder-%2561")
       XCTAssertEqual(url.formParams.doohickey, "folder-%61")
       XCTAssertURLIsIdempotent(url)
       // Key includes "%".
       url.formParams.set("%61bc", to: "baz")
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar?doohickey=folder-%2561&%2561bc=baz")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar?doohickey=folder-%2561&%2561bc=baz")
       XCTAssertEqual(url.query, "doohickey=folder-%2561&%2561bc=baz")
       XCTAssertEqual(url.formParams.get("%61bc"), "baz")
       XCTAssertURLIsIdempotent(url)
@@ -446,13 +446,13 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
       // Value includes "+".
       url.formParams.language = "c++"
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar?language=c%2B%2B")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar?language=c%2B%2B")
       XCTAssertEqual(url.query, "language=c%2B%2B")
       XCTAssertEqual(url.formParams.language, "c++")
       XCTAssertURLIsIdempotent(url)
       // Key includes "+".
       url.formParams.set("1 + 1", to: "2")
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar?language=c%2B%2B&1+%2B+1=2")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar?language=c%2B%2B&1+%2B+1=2")
       XCTAssertEqual(url.query, "language=c%2B%2B&1+%2B+1=2")
       XCTAssertEqual(url.formParams.get("1 + 1"), "2")
       XCTAssertURLIsIdempotent(url)
@@ -463,21 +463,21 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
     do {
       var url0 = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-      XCTAssertEqual(url0.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+      XCTAssertEqual(url0.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url0.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
       XCTAssertFalse(url0.storage.structure.queryIsKnownFormEncoded)
 
       var url1 = WebURL("foo://bar")!
-      XCTAssertEqual(url1.serialized, "foo://bar")
+      XCTAssertEqual(url1.serialized(), "foo://bar")
       XCTAssertNil(url1.query)
       XCTAssertTrue(url1.storage.structure.queryIsKnownFormEncoded)
 
       // Set url1's formParams from empty to url0's non-empty formParams.
       // url1's query string should be the form-encoded version version of url0's query, which itself remains unchanged.
       url1.formParams = url0.formParams
-      XCTAssertEqual(url1.serialized, "foo://bar?a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
+      XCTAssertEqual(url1.serialized(), "foo://bar?a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url1.query, "a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
-      XCTAssertEqual(url0.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+      XCTAssertEqual(url0.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url0.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
       XCTAssertFalse(url0.storage.structure.queryIsKnownFormEncoded)
       XCTAssertTrue(url1.storage.structure.queryIsKnownFormEncoded)
@@ -486,15 +486,15 @@ final class FormEncodedQueryParametersTests: XCTestCase {
       // Reset url1 to a nil query. Set url0's non-empty params to url1's empty params.
       // url0 should now have a nil query, and url1 remains unchanged.
       url1 = WebURL("foo://bar")!
-      XCTAssertEqual(url1.serialized, "foo://bar")
+      XCTAssertEqual(url1.serialized(), "foo://bar")
       XCTAssertNil(url1.query)
       XCTAssertTrue(url1.storage.structure.queryIsKnownFormEncoded)
 
       url0.formParams = url1.formParams
-      XCTAssertEqual(url0.serialized, "http://example.com/")
+      XCTAssertEqual(url0.serialized(), "http://example.com/")
       XCTAssertNil(url0.query)
       XCTAssertTrue(url0.storage.structure.queryIsKnownFormEncoded)
-      XCTAssertEqual(url1.serialized, "foo://bar")
+      XCTAssertEqual(url1.serialized(), "foo://bar")
       XCTAssertNil(url1.query)
       XCTAssertTrue(url1.storage.structure.queryIsKnownFormEncoded)
       XCTAssertURLIsIdempotent(url0)
@@ -503,12 +503,14 @@ final class FormEncodedQueryParametersTests: XCTestCase {
     // Assigning a URL's query parameters to itself causes the string to be re-encoded.
     do {
       var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f&&&")!
-      XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f&&&")
+      XCTAssertEqual(
+        url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f&&&"
+      )
       XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f&&&")
       XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
       url.formParams = url.formParams
-      XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
+      XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
       XCTAssertEqual(url.query, "a=b&c+is+the+key=d&e=&=foo&e=g&e=&h=%F0%9F%91%80&e=f")
       XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
       XCTAssertURLIsIdempotent(url)
@@ -518,7 +520,7 @@ final class FormEncodedQueryParametersTests: XCTestCase {
   func testKeyValuePairsSequence() {
 
     var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.formParams.allKeyValuePairs.isEmpty)
 
@@ -546,19 +548,19 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
     // 'isEmpty' property.
     url.formParams.removeAll()
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertNil(url.query)
     XCTAssertTrue(url.formParams.allKeyValuePairs.isEmpty)
     XCTAssertFalse(url.formParams.allKeyValuePairs.contains { _ in true })
 
     url.formParams.someKey = "someValue"
-    XCTAssertEqual(url.serialized, "http://example.com/?someKey=someValue")
+    XCTAssertEqual(url.serialized(), "http://example.com/?someKey=someValue")
     XCTAssertEqual(url.query, "someKey=someValue")
     XCTAssertFalse(url.formParams.allKeyValuePairs.isEmpty)
 
     // Empty KVPs are ignored by form encoding.
     url = WebURL("http://example.com/?&&&&")!
-    XCTAssertEqual(url.serialized, "http://example.com/?&&&&")
+    XCTAssertEqual(url.serialized(), "http://example.com/?&&&&")
     XCTAssertEqual(url.query, "&&&&")
     XCTAssertTrue(url.formParams.allKeyValuePairs.isEmpty)
     for _ in url.formParams.allKeyValuePairs {
@@ -570,34 +572,34 @@ final class FormEncodedQueryParametersTests: XCTestCase {
 
     // For a non-empty query, the flag should start at 'false'.
     var url = WebURL("http://example.com?a=b&c+is the key=d&&e=&=foo&e=g&e&h=👀&e=f")!
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertEqual(url.query, "a=b&c+is%20the%20key=d&&e=&=foo&e=g&e&h=%F0%9F%91%80&e=f")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
 
     // Modifying via 'formParams' sets the flag to true, as the query is re-encoded.
     url.formParams.h = nil
-    XCTAssertEqual(url.serialized, "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f")
+    XCTAssertEqual(url.serialized(), "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f")
     XCTAssertEqual(url.query, "a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertURLIsIdempotent(url)
 
     // Copying from a base URL maintains the flag.
     let joinedURL = url.resolve("#someFragment")!
-    XCTAssertEqual(joinedURL.serialized, "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f#someFragment")
+    XCTAssertEqual(joinedURL.serialized(), "http://example.com/?a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f#someFragment")
     XCTAssertEqual(joinedURL.query, "a=b&c+is+the+key=d&e=&=foo&e=g&e=&e=f")
     XCTAssertTrue(joinedURL.storage.structure.queryIsKnownFormEncoded)
     XCTAssertURLIsIdempotent(joinedURL)
 
     // Setting via '.query' to a non-empty value sets the flag back to false.
     url.query = "foobar"
-    XCTAssertEqual(url.serialized, "http://example.com/?foobar")
+    XCTAssertEqual(url.serialized(), "http://example.com/?foobar")
     XCTAssertEqual(url.query, "foobar")
     XCTAssertFalse(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertURLIsIdempotent(url)
 
     // Setting via '.query' to an empty/nil value sets the flag to true.
     url.query = ""
-    XCTAssertEqual(url.serialized, "http://example.com/?")
+    XCTAssertEqual(url.serialized(), "http://example.com/?")
     XCTAssertEqual(url.query, "")
     XCTAssertTrue(url.storage.structure.queryIsKnownFormEncoded)
     XCTAssertURLIsIdempotent(url)

--- a/Tests/WebURLTests/OtherURLTests.swift
+++ b/Tests/WebURLTests/OtherURLTests.swift
@@ -31,17 +31,17 @@ extension OtherURLTests {
     // so copying the path to a special URL can cause it to be interpreted differently.
     do {
       var specialURL = WebURL("https://example.com/")!
-      XCTAssertEqual(specialURL.serialized, "https://example.com/")
+      XCTAssertEqual(specialURL.serialized(), "https://example.com/")
       XCTAssertEqual(specialURL.path, "/")
       XCTAssertEqual(specialURL.pathComponents.count, 1)
 
       let nonSpecialURL = WebURL(#"foo://example.com/baz\qux"#)!
-      XCTAssertEqual(nonSpecialURL.serialized, #"foo://example.com/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.serialized(), #"foo://example.com/baz\qux"#)
       XCTAssertEqual(nonSpecialURL.path, #"/baz\qux"#)
       XCTAssertEqual(nonSpecialURL.pathComponents.count, 1)
 
       specialURL.path = nonSpecialURL.path
-      XCTAssertEqual(specialURL.serialized, "https://example.com/baz/qux")
+      XCTAssertEqual(specialURL.serialized(), "https://example.com/baz/qux")
       XCTAssertEqual(specialURL.path, "/baz/qux")
       XCTAssertEqual(specialURL.pathComponents.count, 2)
     }
@@ -50,17 +50,17 @@ extension OtherURLTests {
     // (covered already in PathComponentsTests.testReplaceSubrange_Slashes, .testAppendContents, etc)
     do {
       var specialURL = WebURL("https://example.com/")!
-      XCTAssertEqual(specialURL.serialized, "https://example.com/")
+      XCTAssertEqual(specialURL.serialized(), "https://example.com/")
       XCTAssertEqual(specialURL.path, "/")
       XCTAssertEqual(specialURL.pathComponents.count, 1)
 
       let nonSpecialURL = WebURL(#"foo://example.com/baz\qux"#)!
-      XCTAssertEqual(nonSpecialURL.serialized, #"foo://example.com/baz\qux"#)
+      XCTAssertEqual(nonSpecialURL.serialized(), #"foo://example.com/baz\qux"#)
       XCTAssertEqual(nonSpecialURL.path, #"/baz\qux"#)
       XCTAssertEqual(nonSpecialURL.pathComponents.count, 1)
 
       specialURL.pathComponents.append(contentsOf: nonSpecialURL.pathComponents)
-      XCTAssertEqual(specialURL.serialized, "https://example.com/baz%5Cqux")
+      XCTAssertEqual(specialURL.serialized(), "https://example.com/baz%5Cqux")
       XCTAssertEqual(specialURL.path, "/baz%5Cqux")
       XCTAssertEqual(specialURL.pathComponents.count, 1)
     }

--- a/Tests/WebURLTests/OtherUtilitiesTests.swift
+++ b/Tests/WebURLTests/OtherUtilitiesTests.swift
@@ -132,7 +132,7 @@ extension OtherUtilitiesTests {
 
   func testTempStorageIsValidURL() {
     let url = WebURL(storage: _tempStorage)
-    XCTAssertEqual(url.serialized, "a:")
+    XCTAssertEqual(url.serialized(), "a:")
     XCTAssertURLIsIdempotent(url)
   }
 }

--- a/Tests/WebURLTests/PathComponentsTests.swift
+++ b/Tests/WebURLTests/PathComponentsTests.swift
@@ -37,7 +37,7 @@ extension PathComponentsTests {
 
       url.pathComponents.removeLast()
       url.pathComponents.append("swift-url")
-      XCTAssertEqual(url.serialized, "http://example.com/swift/packages/swift-url")
+      XCTAssertEqual(url.serialized(), "http://example.com/swift/packages/swift-url")
     }
     do {
       var url = WebURL("file:///")!
@@ -45,16 +45,16 @@ extension PathComponentsTests {
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append("usr")
-      XCTAssertEqual(url.serialized, "file:///usr")
+      XCTAssertEqual(url.serialized(), "file:///usr")
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents += ["bin", "swift"]
-      XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/bin/swift")
       XCTAssertEqual(url.pathComponents.last, "swift")
       XCTAssertEqual(url.pathComponents.count, 3)
 
       url.pathComponents.ensureDirectoryPath()
-      XCTAssertEqual(url.serialized, "file:///usr/bin/swift/")
+      XCTAssertEqual(url.serialized(), "file:///usr/bin/swift/")
       XCTAssertEqual(url.pathComponents.last, "")
       XCTAssertEqual(url.pathComponents.count, 4)
     }
@@ -76,7 +76,7 @@ extension PathComponentsTests {
           "linux",
           "libswiftCore.so",
         ])
-      XCTAssertEqual(url.serialized, "file:///usr/lib/swift/linux/libswiftCore.so")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/swift/linux/libswiftCore.so")
     }
     do {
       var url = WebURL("file:///usr/")!
@@ -85,7 +85,7 @@ extension PathComponentsTests {
       url.pathComponents.replaceSubrange(
         url.pathComponents.endIndex..<url.pathComponents.endIndex, with: ["bin", "swift"]
       )
-      XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/bin/swift")
       XCTAssertEqual(url.pathComponents.last, "swift")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
@@ -96,7 +96,7 @@ extension PathComponentsTests {
       url.pathComponents.replaceSubrange(
         url.pathComponents.startIndex..<url.pathComponents.endIndex, with: [] as [String]
       )
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertEqual(url.pathComponents.first, "")
       XCTAssertEqual(url.pathComponents.count, 1)
     }
@@ -109,14 +109,14 @@ extension PathComponentsTests {
         urlA.pathComponents.endIndex..<urlA.pathComponents.endIndex,
         with: ["The%20Beatles"]
       )
-      XCTAssertEqual(urlA.serialized, "http://example.com/music/bands/The%2520Beatles")
+      XCTAssertEqual(urlA.serialized(), "http://example.com/music/bands/The%2520Beatles")
       //---
       var urlB = url
       urlB.pathComponents.replaceSubrange(
         urlB.pathComponents.endIndex..<urlB.pathComponents.endIndex,
         withPercentEncodedComponents: ["The%20Beatles"]
       )
-      XCTAssertEqual(urlB.serialized, "http://example.com/music/bands/The%20Beatles")
+      XCTAssertEqual(urlB.serialized(), "http://example.com/music/bands/The%20Beatles")
     }
     // WebURL.PathComponents.insert(contentsOf:at:)
     do {
@@ -124,7 +124,7 @@ extension PathComponentsTests {
       url.pathComponents.insert(
         contentsOf: ["local", "bin"], at: url.pathComponents.index(after: url.pathComponents.startIndex)
       )
-      XCTAssertEqual(url.serialized, "file:///usr/local/bin/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/local/bin/swift")
     }
     // WebURL.PathComponents.append(contentsOf:)
     do {
@@ -137,7 +137,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append(contentsOf: ["my_app", "data.json"])
-      XCTAssertEqual(url.serialized, "file:///tmp/my_app/data.json")
+      XCTAssertEqual(url.serialized(), "file:///tmp/my_app/data.json")
       XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
@@ -152,7 +152,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents += ["my_app", "data.json"]
-      XCTAssertEqual(url.serialized, "file:///tmp/my_app/data.json")
+      XCTAssertEqual(url.serialized(), "file:///tmp/my_app/data.json")
       XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 3)
     }
@@ -162,14 +162,14 @@ extension PathComponentsTests {
       url.pathComponents.removeSubrange(
         url.pathComponents.index(after: url.pathComponents.startIndex)..<url.pathComponents.endIndex
       )
-      XCTAssertEqual(url.serialized, "http://example.com/projects")
+      XCTAssertEqual(url.serialized(), "http://example.com/projects")
     }
     do {
       var url = WebURL("http://example.com/awesome_product/index.html")!
       url.pathComponents.removeSubrange(
         url.pathComponents.startIndex..<url.pathComponents.endIndex
       )
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
     }
     // WebURL.PathComponents.replaceComponent(at:with:)
     do {
@@ -178,13 +178,13 @@ extension PathComponentsTests {
         at: url.pathComponents.index(after: url.pathComponents.startIndex),
         with: "lib"
       )
-      XCTAssertEqual(url.serialized, "file:///usr/lib/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/swift")
     }
     // WebURL.PathComponents.insert(_:at:)
     do {
       var url = WebURL("file:///usr/swift")!
       url.pathComponents.insert("bin", at: url.pathComponents.index(after: url.pathComponents.startIndex))
-      XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/bin/swift")
     }
     // WebURL.PathComponents.append(_:)
     do {
@@ -197,7 +197,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.pathComponents.count, 1)
 
       url.pathComponents.append("data.json")
-      XCTAssertEqual(url.serialized, "file:///tmp/data.json")
+      XCTAssertEqual(url.serialized(), "file:///tmp/data.json")
       XCTAssertEqual(url.pathComponents.last, "data.json")
       XCTAssertEqual(url.pathComponents.count, 2)
     }
@@ -205,38 +205,38 @@ extension PathComponentsTests {
     do {
       var url = WebURL("http://example.com/projects/swift/swift-url/Sources/")!
       url.pathComponents.remove(at: url.pathComponents.index(after: url.pathComponents.startIndex))
-      XCTAssertEqual(url.serialized, "http://example.com/projects/swift-url/Sources/")
+      XCTAssertEqual(url.serialized(), "http://example.com/projects/swift-url/Sources/")
     }
     do {
       var url = WebURL("http://example.com/foo")!
       url.pathComponents.remove(at: url.pathComponents.startIndex)
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
     }
     // WebURL.PathComponents.removeLast(_:)
     do {
       var url = WebURL("http://example.com/foo/bar")!
       url.pathComponents.removeLast()
-      XCTAssertEqual(url.serialized, "http://example.com/foo")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo")
 
       url.pathComponents.removeLast()
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
     }
     // WebURL.PathComponents.ensureDirectoryPath()
     do {
       var url = WebURL("file:///")!
 
       url.pathComponents += ["Users", "karl", "Desktop"]
-      XCTAssertEqual(url.serialized, "file:///Users/karl/Desktop")
+      XCTAssertEqual(url.serialized(), "file:///Users/karl/Desktop")
 
       url.pathComponents.ensureDirectoryPath()
-      XCTAssertEqual(url.serialized, "file:///Users/karl/Desktop/")
+      XCTAssertEqual(url.serialized(), "file:///Users/karl/Desktop/")
     }
   }
 
   func testURLWithNoPath() {
 
     let url = WebURL("foo://somehost?someQuery")!
-    XCTAssertEqual(url.serialized, "foo://somehost?someQuery")
+    XCTAssertEqual(url.serialized(), "foo://somehost?someQuery")
     XCTAssertEqual(url.path, "")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -249,7 +249,7 @@ extension PathComponentsTests {
   func testURLWithRootPath() {
 
     let url = WebURL("http://example.com/?someQuery")!
-    XCTAssertEqual(url.serialized, "http://example.com/?someQuery")
+    XCTAssertEqual(url.serialized(), "http://example.com/?someQuery")
     XCTAssertEqual(url.path, "/")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -262,7 +262,7 @@ extension PathComponentsTests {
   func testPathOnlyURL() {
 
     let url = WebURL("foo:/a/b/c")!
-    XCTAssertEqual(url.serialized, "foo:/a/b/c")
+    XCTAssertEqual(url.serialized(), "foo:/a/b/c")
     XCTAssertEqual(url.path, "/a/b/c")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -277,7 +277,7 @@ extension PathComponentsTests {
     // 2 empty components.
     do {
       let url = WebURL("http://example.com//?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com//?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com//?someQuery")
       XCTAssertEqual(url.path, "//")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -289,7 +289,7 @@ extension PathComponentsTests {
     // 3 empty components.
     do {
       let url = WebURL("http://example.com///?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com///?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com///?someQuery")
       XCTAssertEqual(url.path, "///")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -301,7 +301,7 @@ extension PathComponentsTests {
     // 4 empty components.
     do {
       let url = WebURL("http://example.com////?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com////?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com////?someQuery")
       XCTAssertEqual(url.path, "////")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -313,7 +313,7 @@ extension PathComponentsTests {
     // 1 empty + 1 non-empty + 3 empty.
     do {
       let url = WebURL("http://example.com//p///?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com//p///?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com//p///?someQuery")
       XCTAssertEqual(url.path, "//p///")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -329,7 +329,7 @@ extension PathComponentsTests {
     // File paths (i.e. without trailing slash).
     do {
       let url = WebURL("http://example.com/a/b/c?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/c?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/c?someQuery")
       XCTAssertEqual(url.path, "/a/b/c")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -341,7 +341,7 @@ extension PathComponentsTests {
     // Directory paths (i.e. with trailing slash) have an empty final component.
     do {
       let url = WebURL("http://example.com/a/b/c/?someQuery")!
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/?someQuery")
       XCTAssertEqual(url.path, "/a/b/c/")
       XCTAssertFalse(url.hasOpaquePath)
 
@@ -355,7 +355,7 @@ extension PathComponentsTests {
   func testComponentEscaping() {
     // Check that components are unescaped when reading.
     let url = WebURL("file:///C:/Windows/🦆/System 32/somefile.dll")!
-    XCTAssertEqual(url.serialized, "file:///C:/Windows/%F0%9F%A6%86/System%2032/somefile.dll")
+    XCTAssertEqual(url.serialized(), "file:///C:/Windows/%F0%9F%A6%86/System%2032/somefile.dll")
     XCTAssertEqual(url.path, "/C:/Windows/%F0%9F%A6%86/System%2032/somefile.dll")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -379,7 +379,7 @@ extension PathComponentsTests {
   func testPassingBounds() {
 
     let url = WebURL("http://example.com/a/b/c/?someQuery")!
-    XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
+    XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/?someQuery")
     XCTAssertEqual(url.path, "/a/b/c/")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -404,7 +404,7 @@ extension PathComponentsTests {
   func testCollectionDistance() {
 
     let url = WebURL("http://example.com/a/b/c/?someQuery")!
-    XCTAssertEqual(url.serialized, "http://example.com/a/b/c/?someQuery")
+    XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/?someQuery")
     XCTAssertEqual(url.path, "/a/b/c/")
     XCTAssertFalse(url.hasOpaquePath)
 
@@ -441,7 +441,7 @@ extension PathComponentsTests {
 
     XCTAssertEqualElements(url.pathComponents, ["a", "MAKE", "S O M E", "🔊", "d"])
     XCTAssertEqualElements(url.pathComponents[range], ["MAKE", "S O M E", "🔊"])
-    XCTAssertEqual(url.serialized, "http://example.com/a/MAKE/S%20O%20M%20E/%F0%9F%94%8A/d")
+    XCTAssertEqual(url.serialized(), "http://example.com/a/MAKE/S%20O%20M%20E/%F0%9F%94%8A/d")
     XCTAssertURLIsIdempotent(url)
 
     // Check that COW still happens if the storage is not uniquely-referenced.
@@ -450,11 +450,11 @@ extension PathComponentsTests {
       url.pathComponents.startIndex..<url.pathComponents.endIndex, with: ["hello", "world"]
     )
     XCTAssertEqualElements(url.pathComponents, ["hello", "world"])
-    XCTAssertEqual(url.serialized, "http://example.com/hello/world")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello/world")
     XCTAssertURLIsIdempotent(url)
 
     XCTAssertEqualElements(copy.pathComponents, ["a", "MAKE", "S O M E", "🔊", "d"])
-    XCTAssertEqual(copy.serialized, "http://example.com/a/MAKE/S%20O%20M%20E/%F0%9F%94%8A/d")
+    XCTAssertEqual(copy.serialized(), "http://example.com/a/MAKE/S%20O%20M%20E/%F0%9F%94%8A/d")
     XCTAssertURLIsIdempotent(copy)
   }
 
@@ -464,14 +464,14 @@ extension PathComponentsTests {
     do {
       // Check that we can store a freestanding path components object and mutate it independently.
       var url = WebURL("http://example.com/a/b/c/d")!
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/c/d")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/d")
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", "d"])
 
       var freestandingComponents = url.pathComponents
       freestandingComponents.append("e")
       XCTAssertEqualElements(freestandingComponents, ["a", "b", "c", "d", "e"])
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", "d"])
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/c/d")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/d")
       XCTAssertURLIsIdempotent(url)
 
       url.path = ""
@@ -479,16 +479,16 @@ extension PathComponentsTests {
 
       XCTAssertEqualElements(freestandingComponents, ["a", "b", "c", "d", "e"])
       XCTAssertEqualElements(url.pathComponents, ["test"])
-      XCTAssertEqual(url.serialized, "http://example.com/test")
+      XCTAssertEqual(url.serialized(), "http://example.com/test")
       XCTAssertURLIsIdempotent(url)
 
       // Check that we can assign path components to a different URL.
       var otherURL = WebURL("file://my-pc/some/path/")!
-      XCTAssertEqual(otherURL.serialized, "file://my-pc/some/path/")
+      XCTAssertEqual(otherURL.serialized(), "file://my-pc/some/path/")
       XCTAssertEqualElements(otherURL.pathComponents, ["some", "path", ""])
 
       otherURL.pathComponents = freestandingComponents
-      XCTAssertEqual(otherURL.serialized, "file://my-pc/a/b/c/d/e")
+      XCTAssertEqual(otherURL.serialized(), "file://my-pc/a/b/c/d/e")
       XCTAssertEqualElements(otherURL.pathComponents, ["a", "b", "c", "d", "e"])
       XCTAssertURLIsIdempotent(otherURL)
     }
@@ -511,32 +511,32 @@ extension PathComponentsTests {
       // Sigil is added/removed based on the combination of components and surrounding context.
       do {
         var url = WebURL("foo:/")!
-        XCTAssertEqual(url.serialized, "foo:/")
+        XCTAssertEqual(url.serialized(), "foo:/")
         XCTAssertEqualElements(url.pathComponents, [""])
 
         url.pathComponents = componentsRequiringSigil
-        XCTAssertEqual(url.serialized, "foo:/.//test")
+        XCTAssertEqual(url.serialized(), "foo:/.//test")
         XCTAssertEqualElements(url.pathComponents, ["", "test"])
         XCTAssertURLIsIdempotent(url)
 
         url.pathComponents = componentsWithoutSigil
-        XCTAssertEqual(url.serialized, "foo:/boo")
+        XCTAssertEqual(url.serialized(), "foo:/boo")
         XCTAssertEqualElements(url.pathComponents, ["boo"])
         XCTAssertURLIsIdempotent(url)
       }
       // As above, but in a context where no sigil is required.
       do {
         var url = WebURL("foo://host")!
-        XCTAssertEqual(url.serialized, "foo://host")
+        XCTAssertEqual(url.serialized(), "foo://host")
         XCTAssertEqualElements(url.pathComponents, [])
 
         url.pathComponents = componentsRequiringSigil
-        XCTAssertEqual(url.serialized, "foo://host//test")
+        XCTAssertEqual(url.serialized(), "foo://host//test")
         XCTAssertEqualElements(url.pathComponents, ["", "test"])
         XCTAssertURLIsIdempotent(url)
 
         url.pathComponents = componentsWithoutSigil
-        XCTAssertEqual(url.serialized, "foo://host/boo")
+        XCTAssertEqual(url.serialized(), "foo://host/boo")
         XCTAssertEqualElements(url.pathComponents, ["boo"])
         XCTAssertURLIsIdempotent(url)
       }
@@ -549,33 +549,33 @@ extension PathComponentsTests {
       // Empty components allowed for non-special schemes with host.
       do {
         var url = WebURL("ssh://my-pc/some/path")!
-        XCTAssertEqual(url.serialized, "ssh://my-pc/some/path")
+        XCTAssertEqual(url.serialized(), "ssh://my-pc/some/path")
         XCTAssertEqualElements(url.pathComponents, ["some", "path"])
 
         url.pathComponents = emptyComponents
-        XCTAssertEqual(url.serialized, "ssh://my-pc")
+        XCTAssertEqual(url.serialized(), "ssh://my-pc")
         XCTAssertEqualElements(url.pathComponents, [])
         XCTAssertURLIsIdempotent(url)
       }
       // Empty components not allowed for non-special schemes without host.
       do {
         var url = WebURL("bar:/a/path")!
-        XCTAssertEqual(url.serialized, "bar:/a/path")
+        XCTAssertEqual(url.serialized(), "bar:/a/path")
         XCTAssertEqualElements(url.pathComponents, ["a", "path"])
 
         url.pathComponents = emptyComponents
-        XCTAssertEqual(url.serialized, "bar:/")
+        XCTAssertEqual(url.serialized(), "bar:/")
         XCTAssertEqualElements(url.pathComponents, [""])
         XCTAssertURLIsIdempotent(url)
       }
       // Empty components not allowed for special schemes.
       do {
         var url = WebURL("http://example.com/paul/john/george/ringo")!
-        XCTAssertEqual(url.serialized, "http://example.com/paul/john/george/ringo")
+        XCTAssertEqual(url.serialized(), "http://example.com/paul/john/george/ringo")
         XCTAssertEqualElements(url.pathComponents, ["paul", "john", "george", "ringo"])
 
         url.pathComponents = emptyComponents
-        XCTAssertEqual(url.serialized, "http://example.com/")
+        XCTAssertEqual(url.serialized(), "http://example.com/")
         XCTAssertEqualElements(url.pathComponents, [""])
         XCTAssertURLIsIdempotent(url)
       }
@@ -597,7 +597,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "http://example.com/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "http://example.com/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // "."/".." components are skipped and do not make a path non-empty.
@@ -613,7 +613,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "http://example.com/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "http://example.com/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // We cannot set an empty path on a non-special URL, unless it has an authority.
@@ -629,7 +629,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Non-special URLs with an authority support empty paths.
@@ -646,7 +646,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "foo://example.com?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // If the URL has a path sigil, it is removed when setting an empty path.
@@ -662,7 +662,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // We can add components to a non-opaque, empty path.
@@ -679,7 +679,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c"])
       XCTAssertEqualElements(url.pathComponents[range], ["a", "b", "c"])
 
-      XCTAssertEqual(url.serialized, "foo://somehost/a/b/c?someQuery")
+      XCTAssertEqual(url.serialized(), "foo://somehost/a/b/c?someQuery")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -700,7 +700,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", "swift"])
       XCTAssertEqualElements(url.pathComponents[range], ["swift"])
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/swift?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/swift?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Appending a single empty component to a directory path does not actually change the path.
@@ -717,26 +717,26 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // You can even append multiple times and they all result in no change.
       _ = url.pathComponents.replaceSubrange(
         url.pathComponents.endIndex..<url.pathComponents.endIndex, with: [""]
       )
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
 
       _ = url.pathComponents.replaceSubrange(
         url.pathComponents.endIndex..<url.pathComponents.endIndex, with: [""]
       )
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
 
       _ = url.pathComponents.replaceSubrange(
         url.pathComponents.endIndex..<url.pathComponents.endIndex, with: [""]
       )
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
       XCTAssertURLIsIdempotent(url)
     }
@@ -754,7 +754,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", "", "swift"])
       XCTAssertEqualElements(url.pathComponents[range], ["", "swift"])
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib//swift?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib//swift?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // A trailing empty can be ensured by appending an empty component to any path.
@@ -771,7 +771,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // As before, subsequent single-empty appends have no effect.
@@ -784,7 +784,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["usr", "lib", ""])
       XCTAssertEqualElements(url.pathComponents[range2], [""])
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -814,7 +814,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["test"])
       XCTAssertEqualElements(url.pathComponents[range], ["test"])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/test?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/test?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Appending an empty component to a root path does not actually change the path.
@@ -831,7 +831,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Appending 2 empty components to a root path results in 2 empty components.
@@ -848,7 +848,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", ""])
       XCTAssertEqualElements(url.pathComponents[range], ["", ""])
 
-      XCTAssertEqual(url.serialized, "foo://example.com//?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com//?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Removing the empty subrange from endIndex..<endIdex also does not change the path.
@@ -865,7 +865,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "foo://host/?query")
+      XCTAssertEqual(url.serialized(), "foo://host/?query")
       XCTAssertURLIsIdempotent(url)
     }
     // Inserting in the range startIndex..<startIndex works as it does for other paths.
@@ -882,7 +882,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["test", ""])
       XCTAssertEqualElements(url.pathComponents[range], ["test"])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/test/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/test/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -904,7 +904,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["C:", "Windows"])
       XCTAssertEqualElements(url.pathComponents[range], ["C:", "Windows"])
 
-      XCTAssertEqual(url.serialized, "file:///C:/Windows")
+      XCTAssertEqual(url.serialized(), "file:///C:/Windows")
       XCTAssertURLIsIdempotent(url)
     }
     // Does not apply to non-file URLs.
@@ -921,7 +921,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["C|", "Windows"])
       XCTAssertEqualElements(url.pathComponents[range], ["C|", "Windows"])
 
-      XCTAssertEqual(url.serialized, "http://example/C|/Windows")
+      XCTAssertEqual(url.serialized(), "http://example/C|/Windows")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -940,7 +940,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["C:", "foo", ""])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "file://host/C:/foo/")
+      XCTAssertEqual(url.serialized(), "file://host/C:/foo/")
       XCTAssertURLIsIdempotent(url)
     }
     // Does not apply to non-file URLs.
@@ -957,7 +957,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["C|", "foo", ""])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "http://host/C|/foo/")
+      XCTAssertEqual(url.serialized(), "http://host/C|/foo/")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -979,7 +979,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "//boo/"])
       XCTAssertEqualElements(url.pathComponents[range], ["//boo/"])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/a/b/%2F%2Fboo%2F?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/a/b/%2F%2Fboo%2F?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Slashes cannot be used to sneak a "." or ".." component through - at least,
@@ -997,7 +997,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "/.."])
       XCTAssertEqualElements(url.pathComponents[range], ["/.."])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/a/b/%2F..?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/a/b/%2F..?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
     // Backslashes are also encoded, as they are treated like regular slashes in special URLs.
@@ -1014,7 +1014,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "\\"])
       XCTAssertEqualElements(url.pathComponents[range], ["\\"])
 
-      XCTAssertEqual(url.serialized, "foo://example.com/a/b/%5C?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://example.com/a/b/%5C?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -1041,7 +1041,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "a", "b", "c", "d"])
       XCTAssertEqualElements(url.pathComponents[range], [""])
 
-      XCTAssertEqual(url.serialized, "foo:/.//a/b/c/d?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/.//a/b/c/d?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is not added/removed when inserting a non-empty component at the front of the path.
@@ -1054,7 +1054,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["not empty", "", "a", "b", "c", "d"])
       XCTAssertEqualElements(url.pathComponents[range2], ["not empty"])
 
-      XCTAssertEqual(url.serialized, "foo:/not%20empty//a/b/c/d?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/not%20empty//a/b/c/d?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is not added/is removed when replacing the empty component at the front of the path with a non-empty one.
@@ -1068,7 +1068,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["book", "a", "b", "c", "d"])
       XCTAssertEqualElements(url.pathComponents[range3], ["book"])
 
-      XCTAssertEqual(url.serialized, "foo:/book/a/b/c/d?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/book/a/b/c/d?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is _not_ added when inserting an empty component at the front of the path _if authority present_.
@@ -1083,7 +1083,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "a", "b", "c", "d"])
       XCTAssertEqualElements(url.pathComponents[range4], [""])
 
-      XCTAssertEqual(url.serialized, "foo://host//a/b/c/d?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo://host//a/b/c/d?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1102,7 +1102,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c", "d"])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "foo:/a/b/c/d?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/a/b/c/d?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is inserted when a removal at the front causes an empty component to become first.
@@ -1119,7 +1119,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "c"])
       XCTAssertEqualElements(url.pathComponents[range2], [])
 
-      XCTAssertEqual(url.serialized, "foo:/.//c")
+      XCTAssertEqual(url.serialized(), "foo:/.//c")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is _not_ inserted when a removal at the front causes an empty component to become first _if authority present_.
@@ -1136,7 +1136,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "c"])
       XCTAssertEqualElements(url.pathComponents[range3], [])
 
-      XCTAssertEqual(url.serialized, "foo://host//c")
+      XCTAssertEqual(url.serialized(), "foo://host//c")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1155,7 +1155,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "f"])
       XCTAssertEqualElements(url.pathComponents[range], ["", "f"])
 
-      XCTAssertEqual(url.serialized, "foo:/.//f?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/.//f?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is unaffected by appending a component to a root path, due to special-casing appends to root paths.
@@ -1171,7 +1171,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["f"])
       XCTAssertEqualElements(url.pathComponents[range2], ["f"])
 
-      XCTAssertEqual(url.serialized, "foo:/f?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/f?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is unaffected by appending components after the 2nd component.
@@ -1187,7 +1187,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "a", "b", "c"])
       XCTAssertEqualElements(url.pathComponents[range3], ["c"])
 
-      XCTAssertEqual(url.serialized, "foo:/.//a/b/c?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/.//a/b/c?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       url = WebURL("foo:/a/b?aQuery#someFragment")!
@@ -1202,7 +1202,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["a", "b", "c"])
       XCTAssertEqualElements(url.pathComponents[range4], ["c"])
 
-      XCTAssertEqual(url.serialized, "foo:/a/b/c?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/a/b/c?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1221,7 +1221,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, [""])
       XCTAssertEqualElements(url.pathComponents[range], [])
 
-      XCTAssertEqual(url.serialized, "foo:/?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
 
       // Sigil is unaffected when removing components after the 2nd one.
@@ -1238,7 +1238,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "a"])
       XCTAssertEqualElements(url.pathComponents[range2], [])
 
-      XCTAssertEqual(url.serialized, "foo:/.//a?aQuery#someFragment")
+      XCTAssertEqual(url.serialized(), "foo:/.//a?aQuery#someFragment")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1257,7 +1257,7 @@ extension PathComponentsTests {
       XCTAssertEqualElements(url.pathComponents, ["", "g"])
       XCTAssertEqualElements(url.pathComponents[range], ["", "g"])
 
-      XCTAssertEqual(url.serialized, "foo:/.//g")
+      XCTAssertEqual(url.serialized(), "foo:/.//g")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -1290,7 +1290,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a/3")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1311,7 +1311,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/a/4")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/a/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/a/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1330,7 +1330,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/a")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/a")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/a")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1350,7 +1350,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a/b/c/d/3")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/c/d/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/c/d/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1371,7 +1371,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/a/b/c/d/3")
       XCTAssertEqual(url.pathComponents.count, 6)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/a/b/c/d/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/a/b/c/d/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1391,7 +1391,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/a/b/c/d")
       XCTAssertEqual(url.pathComponents.count, 6)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/a/b/c/d")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/a/b/c/d")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1412,7 +1412,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/3/4")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/3/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/3/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1434,7 +1434,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/4")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1455,7 +1455,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1474,7 +1474,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a/b/1/2/3")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/1/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/1/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1492,7 +1492,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/a/b/3/4")
       XCTAssertEqual(url.pathComponents.count, 6)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/a/b/3/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/a/b/3/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1511,7 +1511,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/a/b")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/a/b")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/a/b")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -1522,7 +1522,7 @@ extension PathComponentsTests {
     // will percent encode "%XX" to "%25XX".
     do {
       var url = WebURL("http://example.com/%2561")!
-      XCTAssertEqual(url.serialized, "http://example.com/%2561")
+      XCTAssertEqual(url.serialized(), "http://example.com/%2561")
       XCTAssertEqual(url.path, "/%2561")
       XCTAssertEqualElements(url.pathComponents, ["%61"])
 
@@ -1532,7 +1532,7 @@ extension PathComponentsTests {
         with: [url.pathComponents.first!, "hello to%3A the world!"]
       )
 
-      XCTAssertEqual(url.serialized, "http://example.com/%2561/%2561/hello%20to%253A%20the%20world!")
+      XCTAssertEqual(url.serialized(), "http://example.com/%2561/%2561/hello%20to%253A%20the%20world!")
       XCTAssertEqual(url.path, "/%2561/%2561/hello%20to%253A%20the%20world!")
       XCTAssertEqualElements(url.pathComponents, ["%61", "%61", "hello to%3A the world!"])
       XCTAssertURLIsIdempotent(url)
@@ -1542,7 +1542,7 @@ extension PathComponentsTests {
     // will not double-encode "%XX".
     do {
       var url = WebURL("http://example.com/%2561")!
-      XCTAssertEqual(url.serialized, "http://example.com/%2561")
+      XCTAssertEqual(url.serialized(), "http://example.com/%2561")
       XCTAssertEqual(url.path, "/%2561")
       XCTAssertEqualElements(url.pathComponents, ["%61"])
 
@@ -1552,7 +1552,7 @@ extension PathComponentsTests {
         withPercentEncodedComponents: [url.pathComponents.first!, "hello to%3A the world!"]
       )
 
-      XCTAssertEqual(url.serialized, "http://example.com/%2561/%61/hello%20to%3A%20the%20world!")
+      XCTAssertEqual(url.serialized(), "http://example.com/%2561/%61/hello%20to%3A%20the%20world!")
       XCTAssertEqual(url.path, "/%2561/%61/hello%20to%3A%20the%20world!")
       XCTAssertEqualElements(url.pathComponents, ["%61", "a", "hello to: the world!"])
       XCTAssertURLIsIdempotent(url)
@@ -1563,7 +1563,7 @@ extension PathComponentsTests {
     // the implementation so fixing it is a low priority.
     do {
       var url = WebURL("http://example.com/foo/bar")!
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar")
       XCTAssertEqual(url.path, "/foo/bar")
       XCTAssertEqualElements(url.pathComponents, ["foo", "bar"])
 
@@ -1572,14 +1572,14 @@ extension PathComponentsTests {
         with: ["baz", "%2E%2E", "qux"]  // Should technically be encoded as "%252E%252E".
       )
 
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar/baz/qux")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar/baz/qux")
       XCTAssertEqual(url.path, "/foo/bar/baz/qux")
       XCTAssertEqualElements(url.pathComponents, ["foo", "bar", "baz", "qux"])
       XCTAssertURLIsIdempotent(url)
     }
     do {
       var url = WebURL("http://example.com/foo/bar")!
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar")
       XCTAssertEqual(url.path, "/foo/bar")
       XCTAssertEqualElements(url.pathComponents, ["foo", "bar"])
 
@@ -1588,7 +1588,7 @@ extension PathComponentsTests {
         withPercentEncodedComponents: ["baz", "%2E%2E", "qux"]
       )
 
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar/baz/qux")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar/baz/qux")
       XCTAssertEqual(url.path, "/foo/bar/baz/qux")
       XCTAssertEqualElements(url.pathComponents, ["foo", "bar", "baz", "qux"])
       XCTAssertURLIsIdempotent(url)
@@ -1614,7 +1614,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a/b/1/2/3")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a/b/1/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b/1/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1633,7 +1633,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/a/b/3/4")
       XCTAssertEqual(url.pathComponents.count, 6)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/a/b/3/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/a/b/3/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1650,7 +1650,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/a/b")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/a/b")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/a/b")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1667,7 +1667,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/hello/world")
+      XCTAssertEqual(url.serialized(), "http://example.com/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1685,7 +1685,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "foo://example.com/hello/world")
+      XCTAssertEqual(url.serialized(), "foo://example.com/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1702,7 +1702,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/foo/bar/hello/world")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar/hello/world")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1719,7 +1719,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "//1/2/3")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "foo:/.//1/2/3")
+      XCTAssertEqual(url.serialized(), "foo:/.//1/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1736,7 +1736,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/C:/Users/jim/")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "file:///C:/Users/jim/")
+      XCTAssertEqual(url.serialized(), "file:///C:/Users/jim/")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1753,7 +1753,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1770,7 +1770,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/%2Fa/%5Cb")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/%2Fa/%5Cb")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/%2Fa/%5Cb")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1787,7 +1787,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/folder-%2561/w%2561m")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/folder-%2561/w%2561m")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/folder-%2561/w%2561m")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -1807,7 +1807,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/a/b")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/a/b")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/a/b")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1824,7 +1824,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/hello/world")
+      XCTAssertEqual(url.serialized(), "http://example.com/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1842,7 +1842,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "foo://example.com/hello/world")
+      XCTAssertEqual(url.serialized(), "foo://example.com/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1859,7 +1859,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/foo/bar/hello/world")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "http://example.com/foo/bar/hello/world")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/bar/hello/world")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1876,7 +1876,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "//bar")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "foo:/.//bar")
+      XCTAssertEqual(url.serialized(), "foo:/.//bar")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1893,7 +1893,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/C:/Windows/System32/")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "file://host/C:/Windows/System32/")
+      XCTAssertEqual(url.serialized(), "file://host/C:/Windows/System32/")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1910,7 +1910,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1927,7 +1927,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/%2Fa/%5Cb")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/%2Fa/%5Cb")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/%2Fa/%5Cb")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1944,7 +1944,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/3/folder-%2561/w%2561m")
       XCTAssertEqual(url.pathComponents.count, 5)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/3/folder-%2561/w%2561m")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/3/folder-%2561/w%2561m")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -1965,7 +1965,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/2/3")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -1984,7 +1984,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/4")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2001,7 +2001,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1")
+      XCTAssertEqual(url.serialized(), "http://example.com/1")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2016,7 +2016,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2033,7 +2033,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "")
       XCTAssertEqual(url.pathComponents.count, 0)
 
-      XCTAssertEqual(url.serialized, "foo://example.com")
+      XCTAssertEqual(url.serialized(), "foo://example.com")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2051,7 +2051,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "//c/d")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "foo:/.//c/d")
+      XCTAssertEqual(url.serialized(), "foo:/.//c/d")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2069,7 +2069,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/C:/d")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "file:///C:/d")
+      XCTAssertEqual(url.serialized(), "file:///C:/d")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2085,7 +2085,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "")
       XCTAssertEqual(url.pathComponents.count, 0)
 
-      XCTAssertEqual(url.serialized, "foo://example.com")
+      XCTAssertEqual(url.serialized(), "foo://example.com")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2100,7 +2100,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "foo:/")
+      XCTAssertEqual(url.serialized(), "foo:/")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -2120,7 +2120,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a/2/3")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2139,7 +2139,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/a/3/4")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/a/3/4")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/a/3/4")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2158,7 +2158,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2/a")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2/a")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2/a")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2175,7 +2175,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/a")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "http://example.com/a")
+      XCTAssertEqual(url.serialized(), "http://example.com/a")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2194,7 +2194,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/foo/a/")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/foo/a/")
+      XCTAssertEqual(url.serialized(), "http://example.com/foo/a/")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2211,7 +2211,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "//b/c/d")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "foo:/.//b/c/d")
+      XCTAssertEqual(url.serialized(), "foo:/.//b/c/d")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2228,7 +2228,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/C:/b/c/d")
       XCTAssertEqual(url.pathComponents.count, 4)
 
-      XCTAssertEqual(url.serialized, "file:///C:/b/c/d")
+      XCTAssertEqual(url.serialized(), "file:///C:/b/c/d")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2245,7 +2245,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/2/3")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/2/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/2/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2264,7 +2264,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/%5Cb/3")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/%5Cb/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/%5Cb/3")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -2283,7 +2283,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/folder-%2561/3")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/folder-%2561/3")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/folder-%2561/3")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -2303,7 +2303,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1/2")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1/2")
+      XCTAssertEqual(url.serialized(), "http://example.com/1/2")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove 2, non-empty components.
@@ -2316,7 +2316,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/1")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "http://example.com/1")
+      XCTAssertEqual(url.serialized(), "http://example.com/1")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove all components, special URL.
@@ -2329,7 +2329,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove all components, non-special URL with hostname.
@@ -2342,7 +2342,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "")
       XCTAssertEqual(url.pathComponents.count, 0)
 
-      XCTAssertEqual(url.serialized, "foo://example.com")
+      XCTAssertEqual(url.serialized(), "foo://example.com")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove all components, non-special URL without hostname.
@@ -2355,7 +2355,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "foo:/")
+      XCTAssertEqual(url.serialized(), "foo:/")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove 1, empty component.
@@ -2368,7 +2368,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/usr/lib")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib")
       XCTAssertURLIsIdempotent(url)
     }
     // Remove 2 empty components.
@@ -2381,7 +2381,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/usr/lib")
       XCTAssertEqual(url.pathComponents.count, 2)
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -2398,7 +2398,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/usr/lib/")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/")
       XCTAssertURLIsIdempotent(url)
     }
     // Does not append an empty component if the last component is already empty.
@@ -2411,7 +2411,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/usr/lib/")
       XCTAssertEqual(url.pathComponents.count, 3)
 
-      XCTAssertEqual(url.serialized, "file:///usr/lib/")
+      XCTAssertEqual(url.serialized(), "file:///usr/lib/")
       XCTAssertURLIsIdempotent(url)
     }
     // Does not append an empty component to root paths.
@@ -2424,7 +2424,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "file:///")
+      XCTAssertEqual(url.serialized(), "file:///")
       XCTAssertURLIsIdempotent(url)
     }
     // Appends an empty component if the path is non-opaque and empty.
@@ -2438,7 +2438,7 @@ extension PathComponentsTests {
       XCTAssertEqual(url.path, "/")
       XCTAssertEqual(url.pathComponents.count, 1)
 
-      XCTAssertEqual(url.serialized, "foo://example/")
+      XCTAssertEqual(url.serialized(), "foo://example/")
       XCTAssertURLIsIdempotent(url)
     }
   }

--- a/Tests/WebURLTests/Utils.swift
+++ b/Tests/WebURLTests/Utils.swift
@@ -160,7 +160,7 @@ func checkDoesNotCopy(_ url: inout WebURL, _ body: (inout WebURL) -> Void) {
 /// Checks that the given URL returns precisely the same value when its serialized representation is re-parsed.
 ///
 func XCTAssertURLIsIdempotent(_ url: WebURL) {
-  var serialized = url.serialized
+  var serialized = url.serialized()
   serialized.makeContiguousUTF8()
   guard let reparsed = WebURL(serialized) else {
     XCTFail("Failed to reparse URL string: \(serialized)")
@@ -171,7 +171,7 @@ func XCTAssertURLIsIdempotent(_ url: WebURL) {
   // Check that the code-units are the same.
   XCTAssertEqualElements(url.utf8, reparsed.utf8)
   // Triple check: check that the serialized representations are the same.
-  XCTAssertEqual(serialized, reparsed.serialized)
+  XCTAssertEqual(serialized, reparsed.serialized())
 }
 
 /// Checks the component values of the given URL. Any components not specified are checked to have a `nil` value.

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -25,6 +25,22 @@ class WebURLTests: XCTestCase {}
 // --------------------------------------------
 
 
+extension WebURLTests {
+
+  func testCustomStringConvertible() {
+    // String.init(WebURL) should include the fragment. Is the same as calling .serialized()
+    do {
+      let url = WebURL("http://example.com/some/path?and&a&query#withAFragment")!
+      XCTAssertEqual(url.serialized(), "http://example.com/some/path?and&a&query#withAFragment")
+      XCTAssertEqual(String(url), url.serialized())
+      XCTAssertEqual(url.description, url.serialized())
+
+      XCTAssertEqual(url.serialized(excludingFragment: true), "http://example.com/some/path?and&a&query")
+      XCTAssertNotEqual(url.serialized(), url.serialized(excludingFragment: true))
+    }
+  }
+}
+
 #if swift(>=5.5) && canImport(_Concurrency)
 
   extension WebURLTests {

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -65,61 +65,61 @@ extension WebURLTests {
     let original = url
 
     func checkOriginalHasNotChanged() {
-      XCTAssertEqual(original.serialized, "http://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(original.serialized(), "http://example.com/a/b?c=d&e=f#gh")
       XCTAssertEqual(original.scheme, "http")
     }
     // Scheme.
     url.scheme = "https"
-    XCTAssertEqual(url.serialized, "https://example.com/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "https://example.com/a/b?c=d&e=f#gh")
     XCTAssertEqual(url.scheme, "https")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Username.
     url.username = "user"
-    XCTAssertEqual(url.serialized, "http://user@example.com/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "http://user@example.com/a/b?c=d&e=f#gh")
     XCTAssertEqual(url.username, "user")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Password.
     url.password = "pass"
-    XCTAssertEqual(url.serialized, "http://:pass@example.com/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "http://:pass@example.com/a/b?c=d&e=f#gh")
     XCTAssertEqual(url.password, "pass")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Hostname.
     url.hostname = "test.test"
-    XCTAssertEqual(url.serialized, "http://test.test/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "http://test.test/a/b?c=d&e=f#gh")
     XCTAssertEqual(url.hostname, "test.test")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Port.
     url.port = 8080
-    XCTAssertEqual(url.serialized, "http://example.com:8080/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "http://example.com:8080/a/b?c=d&e=f#gh")
     XCTAssertEqual(url.port, 8080)
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Path.
     url.path = "/foo/bar/baz"
-    XCTAssertEqual(url.serialized, "http://example.com/foo/bar/baz?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "http://example.com/foo/bar/baz?c=d&e=f#gh")
     XCTAssertEqual(url.path, "/foo/bar/baz")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Query
     url.query = "foo=bar&baz=qux"
-    XCTAssertEqual(url.serialized, "http://example.com/a/b?foo=bar&baz=qux#gh")
+    XCTAssertEqual(url.serialized(), "http://example.com/a/b?foo=bar&baz=qux#gh")
     XCTAssertEqual(url.query, "foo=bar&baz=qux")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
     url = original
     // Fragment
     url.fragment = "foo"
-    XCTAssertEqual(url.serialized, "http://example.com/a/b?c=d&e=f#foo")
+    XCTAssertEqual(url.serialized(), "http://example.com/a/b?c=d&e=f#foo")
     XCTAssertEqual(url.fragment, "foo")
     XCTAssertURLIsIdempotent(url)
     checkOriginalHasNotChanged()
@@ -133,7 +133,7 @@ extension WebURLTests {
   func testCopyOnWrite_unique() {
 
     var url = WebURL("wss://user:pass@example.com:90/a/b?c=d&e=f#gh")!
-    XCTAssertEqual(url.serialized, "wss://user:pass@example.com:90/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "wss://user:pass@example.com:90/a/b?c=d&e=f#gh")
 
     // All new values must be the same length, so we can be sure we have enough capacity.
 
@@ -141,55 +141,55 @@ extension WebURLTests {
     checkDoesNotCopy(&url) {
       $0.scheme = "ftp"
     }
-    XCTAssertEqual(url.serialized, "ftp://user:pass@example.com:90/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://user:pass@example.com:90/a/b?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Username.
     checkDoesNotCopy(&url) {
       $0.username = "resu"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:pass@example.com:90/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:pass@example.com:90/a/b?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Password.
     checkDoesNotCopy(&url) {
       $0.password = "ssap"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@example.com:90/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@example.com:90/a/b?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Hostname.
     checkDoesNotCopy(&url) {
       $0.hostname = "moc.elpmaxe"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:90/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:90/a/b?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Port.
     checkDoesNotCopy(&url) {
       $0.port = 42
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:42/a/b?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:42/a/b?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Path
     checkDoesNotCopy(&url) {
       $0.path = "/j/k"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:42/j/k?c=d&e=f#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:42/j/k?c=d&e=f#gh")
     XCTAssertURLIsIdempotent(url)
     // Query
     checkDoesNotCopy(&url) {
       $0.query = "m=n&o=p"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#gh")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#gh")
     XCTAssertURLIsIdempotent(url)
     // Fragment
     checkDoesNotCopy(&url) {
       $0.fragment = "zz"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#zz")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#zz")
     XCTAssertURLIsIdempotent(url)
     // Chained modifying wrappers.
     checkDoesNotCopy(&url) {
       $0.jsModel.swiftModel.jsModel.swiftModel.jsModel.swiftModel.fragment = "aa"
     }
-    XCTAssertEqual(url.serialized, "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#aa")
+    XCTAssertEqual(url.serialized(), "ftp://resu:ssap@moc.elpmaxe:42/j/k?m=n&o=p#aa")
     XCTAssertURLIsIdempotent(url)
   }
 }
@@ -217,37 +217,37 @@ extension WebURLTests {
       XCTAssertThrowsSpecific(URLSetterError.invalidScheme) {
         try url.setScheme("🤯")
       }
-      XCTAssertEqual(url.serialized, "http://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
 
       // [Throw] Change of special-ness.
       XCTAssertThrowsSpecific(URLSetterError.changeOfSchemeSpecialness) {
         try url.setScheme("foo")
       }
-      XCTAssertEqual(url.serialized, "http://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
 
       // [Deviation] If there is content after the ":", the operation fails. The JS model silently discards it.
       XCTAssertThrowsSpecific(URLSetterError.invalidScheme) {
         try url.setScheme("http://foo/")
       }
-      XCTAssertEqual(url.serialized, "http://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "http://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
 
       // ":" is allowed as the final character, but not required.
       XCTAssertNoThrow(try url.setScheme("ws"))
-      XCTAssertEqual(url.serialized, "ws://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "ws://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
 
       XCTAssertNoThrow(try url.setScheme("https:"))
-      XCTAssertEqual(url.serialized, "https://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "https://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
 
       // [Deviation] Tabs and newlines are not ignored, cause setter to fail. The JS model ignores them.
       XCTAssertThrowsSpecific(URLSetterError.invalidScheme) {
         try url.setScheme("\th\nttp:")
       }
-      XCTAssertEqual(url.serialized, "https://example.com/a/b?c=d&e=f#gh")
+      XCTAssertEqual(url.serialized(), "https://example.com/a/b?c=d&e=f#gh")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -258,7 +258,7 @@ extension WebURLTests {
         try url.setScheme("file")
       }
       XCTAssertNoThrow(try url.setScheme("https"))
-      XCTAssertEqual(url.serialized, "https://user:pass@somehost/")
+      XCTAssertEqual(url.serialized(), "https://user:pass@somehost/")
       XCTAssertURLIsIdempotent(url)
 
       url = WebURL("http://somehost:8080/")!
@@ -266,7 +266,7 @@ extension WebURLTests {
         try url.setScheme("file")
       }
       XCTAssertNoThrow(try url.setScheme("https"))
-      XCTAssertEqual(url.serialized, "https://somehost:8080/")
+      XCTAssertEqual(url.serialized(), "https://somehost:8080/")
       XCTAssertURLIsIdempotent(url)
     }
 
@@ -277,7 +277,7 @@ extension WebURLTests {
         try url.setScheme("http")
       }
       XCTAssertNoThrow(try url.setScheme("file"))
-      XCTAssertEqual(url.serialized, "file:///")
+      XCTAssertEqual(url.serialized(), "file:///")
       XCTAssertURLIsIdempotent(url)
     }
   }
@@ -292,37 +292,37 @@ extension WebURLTests {
     //             therefore the Swift model returns 'nil' to mean 'not present'.
     var url = WebURL("http://example.com/")!
     XCTAssertNil(url.username)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     url.username = "some username"
     XCTAssertEqual(url.username, "some%20username")
-    XCTAssertEqual(url.serialized, "http://some%20username@example.com/")
+    XCTAssertEqual(url.serialized(), "http://some%20username@example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Setting the empty string is the same as setting 'nil'.
     url.username = ""
     XCTAssertNil(url.username)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     url.username = "some username"
     XCTAssertEqual(url.username, "some%20username")
-    XCTAssertEqual(url.serialized, "http://some%20username@example.com/")
+    XCTAssertEqual(url.serialized(), "http://some%20username@example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Setting 'nil' is the same as setting the empty string.
     url.username = nil
     XCTAssertNil(url.username)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Setting credentials when the scheme does not allow them.
     url = WebURL("file://somehost/p1/p2")!
     XCTAssertNil(url.username)
-    XCTAssertEqual(url.serialized, "file://somehost/p1/p2")
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertThrowsSpecific(URLSetterError.cannotHaveCredentialsOrPort) { try url.setUsername("user") }
-    XCTAssertEqual(url.serialized, "file://somehost/p1/p2")
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertURLIsIdempotent(url)
   }
 
@@ -336,37 +336,37 @@ extension WebURLTests {
     //             therefore the Swift model returns 'nil' to mean 'not present'.
     var url = WebURL("http://example.com/")!
     XCTAssertNil(url.password)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     url.password = "🤫"
     XCTAssertEqual(url.password, "%F0%9F%A4%AB")
-    XCTAssertEqual(url.serialized, "http://:%F0%9F%A4%AB@example.com/")
+    XCTAssertEqual(url.serialized(), "http://:%F0%9F%A4%AB@example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Setting the empty string is the same as setting 'nil'.
     url.password = ""
     XCTAssertNil(url.password)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     url.password = "🤫"
     XCTAssertEqual(url.password, "%F0%9F%A4%AB")
-    XCTAssertEqual(url.serialized, "http://:%F0%9F%A4%AB@example.com/")
+    XCTAssertEqual(url.serialized(), "http://:%F0%9F%A4%AB@example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Setting the 'nil' is the same as setting the empty string.
     url.password = nil
     XCTAssertNil(url.password)
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw]: Setting credentials when the scheme does not allow them.
     url = WebURL("file://somehost/p1/p2")!
     XCTAssertNil(url.password)
-    XCTAssertEqual(url.serialized, "file://somehost/p1/p2")
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertThrowsSpecific(URLSetterError.cannotHaveCredentialsOrPort) { try url.setPassword("pass") }
-    XCTAssertEqual(url.serialized, "file://somehost/p1/p2")
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertURLIsIdempotent(url)
   }
 
@@ -380,20 +380,20 @@ extension WebURLTests {
     // [Deviation] Hostname is not trimmed; invalid host code points such as "?", "#", or ":" cause the setter to fail.
     var url = WebURL("http://example.com/")!
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("hello?") }
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("hello#") }
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("hello:99") }
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Hostname is not filtered. Tabs and newlines are invalid host code points, cause setter to fail.
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("\thel\nlo") }
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Swift model can distinguish between empty and not-present hostnames.
@@ -406,24 +406,24 @@ extension WebURLTests {
     XCTAssertThrowsSpecific(URLSetterError.schemeDoesNotSupportNilOrEmptyHostnames) {
       try url.setHostname(String?.none)
     }
-    XCTAssertEqual(url.serialized, "http://example.com/")
+    XCTAssertEqual(url.serialized(), "http://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     // 'file' allows empty hostnames, but not 'nil' hostnames.
     url = WebURL("file:///some/path")!
     XCTAssertEqual(url.hostname, "")
     XCTAssertEqual(url.scheme, "file")
-    XCTAssertEqual(url.serialized, "file:///some/path")
+    XCTAssertEqual(url.serialized(), "file:///some/path")
     XCTAssertThrowsSpecific(URLSetterError.schemeDoesNotSupportNilOrEmptyHostnames) {
       try url.setHostname(String?.none)
     }
-    XCTAssertEqual(url.serialized, "file:///some/path")
+    XCTAssertEqual(url.serialized(), "file:///some/path")
     XCTAssertURLIsIdempotent(url)
 
     // Non-special schemes allow 'nil' hostnames.
     url = WebURL("unix:///some/path")!
     XCTAssertNoThrow(try url.setHostname(String?.none))
-    XCTAssertEqual(url.serialized, "unix:/some/path")
+    XCTAssertEqual(url.serialized(), "unix:/some/path")
     XCTAssertURLIsIdempotent(url)
     // But not if they already have credentials or ports.
     url = WebURL("unix://user:pass@example/some/path")!
@@ -432,7 +432,7 @@ extension WebURLTests {
     XCTAssertThrowsSpecific(URLSetterError.cannotSetEmptyHostnameWithCredentialsOrPort) {
       try url.setHostname(String?.none)
     }
-    XCTAssertEqual(url.serialized, "unix://user:pass@example/some/path")
+    XCTAssertEqual(url.serialized(), "unix://user:pass@example/some/path")
     XCTAssertURLIsIdempotent(url)
 
     url = WebURL("unix://example:99/some/path")!
@@ -441,19 +441,19 @@ extension WebURLTests {
     XCTAssertThrowsSpecific(URLSetterError.cannotSetEmptyHostnameWithCredentialsOrPort) {
       try url.setHostname(String?.none)
     }
-    XCTAssertEqual(url.serialized, "unix://example:99/some/path")
+    XCTAssertEqual(url.serialized(), "unix://example:99/some/path")
     XCTAssertURLIsIdempotent(url)
     // When setting a hostname to/from 'nil', we may need to add/remove a path sigil.
     do {
       func check_has_path_sigil(url: WebURL) {
-        XCTAssertEqual(url.serialized, "web+demo:/.//not-a-host/test")
+        XCTAssertEqual(url.serialized(), "web+demo:/.//not-a-host/test")
         XCTAssertEqual(url.storage.structure.sigil, .path)
         XCTAssertEqual(url.hostname, nil)
         XCTAssertEqual(url.path, "//not-a-host/test")
         XCTAssertURLIsIdempotent(url)
       }
       func check_has_auth_sigil(url: WebURL, hostname: String) {
-        XCTAssertEqual(url.serialized, "web+demo://\(hostname)//not-a-host/test")
+        XCTAssertEqual(url.serialized(), "web+demo://\(hostname)//not-a-host/test")
         XCTAssertEqual(url.storage.structure.sigil, .authority)
         XCTAssertEqual(url.hostname, hostname)
         XCTAssertEqual(url.path, "//not-a-host/test")
@@ -477,58 +477,58 @@ extension WebURLTests {
     url = WebURL("mailto:bob")!
     XCTAssertNil(url.hostname)
     XCTAssertTrue(url.hasOpaquePath)
-    XCTAssertEqual(url.serialized, "mailto:bob")
+    XCTAssertEqual(url.serialized(), "mailto:bob")
     XCTAssertThrowsSpecific(URLSetterError.cannotSetHostWithOpaquePath) {
       try url.setHostname("somehost")
     }
-    XCTAssertEqual(url.serialized, "mailto:bob")
+    XCTAssertEqual(url.serialized(), "mailto:bob")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Cannot set empty hostname on special schemes.
     url = WebURL("http://example.com/p1/p2")!
     XCTAssertEqual(url.hostname, "example.com")
-    XCTAssertEqual(url.serialized, "http://example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com/p1/p2")
     XCTAssertThrowsSpecific(URLSetterError.schemeDoesNotSupportNilOrEmptyHostnames) {
       try url.setHostname("")
     }
-    XCTAssertEqual(url.serialized, "http://example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Cannot set empty hostname if the URL contains credentials or port.
     url = WebURL("foo://user@example.com/p1/p2")!
     XCTAssertEqual(url.username, "user")
     XCTAssertEqual(url.hostname, "example.com")
-    XCTAssertEqual(url.serialized, "foo://user@example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "foo://user@example.com/p1/p2")
     XCTAssertThrowsSpecific(URLSetterError.cannotSetEmptyHostnameWithCredentialsOrPort) {
       try url.setHostname("")
     }
-    XCTAssertEqual(url.serialized, "foo://user@example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "foo://user@example.com/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
     url = WebURL("foo://example.com:8080/p1/p2")!
     XCTAssertEqual(url.port, 8080)
     XCTAssertEqual(url.hostname, "example.com")
-    XCTAssertEqual(url.serialized, "foo://example.com:8080/p1/p2")
+    XCTAssertEqual(url.serialized(), "foo://example.com:8080/p1/p2")
     XCTAssertThrowsSpecific(URLSetterError.cannotSetEmptyHostnameWithCredentialsOrPort) {
       try url.setHostname("")
     }
-    XCTAssertEqual(url.serialized, "foo://example.com:8080/p1/p2")
+    XCTAssertEqual(url.serialized(), "foo://example.com:8080/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Invalid hostnames.
     url = WebURL("foo://example.com/")!
     XCTAssertEqual(url.hostname, "example.com")
-    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertEqual(url.serialized(), "foo://example.com/")
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("@") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertEqual(url.serialized(), "foo://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("/a/b/c") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertEqual(url.serialized(), "foo://example.com/")
     XCTAssertURLIsIdempotent(url)
 
     XCTAssertThrowsSpecific(URLSetterError.invalidHostname) { try url.setHostname("[:::]") }
-    XCTAssertEqual(url.serialized, "foo://example.com/")
+    XCTAssertEqual(url.serialized(), "foo://example.com/")
     XCTAssertURLIsIdempotent(url)
   }
 
@@ -541,16 +541,16 @@ extension WebURLTests {
     // [Throw] Adding a port to a URL which does not allow them.
     var url = WebURL("file://somehost/p1/p2")!
     XCTAssertThrowsSpecific(URLSetterError.cannotHaveCredentialsOrPort) { try url.setPort(99) }
-    XCTAssertEqual(url.serialized, "file://somehost/p1/p2")
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
     // [Throw] Setting a port to a non-valid UInt16 value.
     url = WebURL("http://example.com/p1/p2")!
     XCTAssertThrowsSpecific(URLSetterError.portValueOutOfBounds) { try url.setPort(-99) }
-    XCTAssertEqual(url.serialized, "http://example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com/p1/p2")
     XCTAssertURLIsIdempotent(url)
     XCTAssertThrowsSpecific(URLSetterError.portValueOutOfBounds) { try url.setPort(Int(UInt32.max)) }
-    XCTAssertEqual(url.serialized, "http://example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Non-present port is represented as 'nil', rather than empty string.
@@ -558,12 +558,12 @@ extension WebURLTests {
     // Set the port to a non-nil value.
     XCTAssertNoThrow(try url.setPort(42))
     XCTAssertEqual(url.port, 42)
-    XCTAssertEqual(url.serialized, "http://example.com:42/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com:42/p1/p2")
     XCTAssertURLIsIdempotent(url)
     // And back to nil.
     XCTAssertNoThrow(try url.setPort(nil))
     XCTAssertNil(url.port)
-    XCTAssertEqual(url.serialized, "http://example.com/p1/p2")
+    XCTAssertEqual(url.serialized(), "http://example.com/p1/p2")
     XCTAssertURLIsIdempotent(url)
   }
 
@@ -578,14 +578,14 @@ extension WebURLTests {
     XCTAssertEqual(url.path, "bob")
     XCTAssertTrue(url.hasOpaquePath)
     XCTAssertThrowsSpecific(URLSetterError.cannotModifyOpaquePath) { try url.setPath("frank") }
-    XCTAssertEqual(url.serialized, "mailto:bob")
+    XCTAssertEqual(url.serialized(), "mailto:bob")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Tabs and newlines are not trimmed.
     url = WebURL("file:///hello/world?someQuery")!
     XCTAssertNoThrow(try url.setPath("\t\n\t"))
     XCTAssertEqual(url.path, "/%09%0A%09")
-    XCTAssertEqual(url.serialized, "file:///%09%0A%09?someQuery")
+    XCTAssertEqual(url.serialized(), "file:///%09%0A%09?someQuery")
     XCTAssertURLIsIdempotent(url)
   }
 
@@ -598,33 +598,33 @@ extension WebURLTests {
 
     // [Deviation] The Swift model does not include the leading "?" in the getter, uses 'nil' to mean 'not present'.
     var url = WebURL("http://example.com/hello")!
-    XCTAssertEqual(url.serialized, "http://example.com/hello")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello")
     XCTAssertNil(url.query)
 
     url.query = ""
-    XCTAssertEqual(url.serialized, "http://example.com/hello?")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello?")
     XCTAssertEqual(url.query, "")
     XCTAssertURLIsIdempotent(url)
 
     url.query = "a=b&c=d"
-    XCTAssertEqual(url.serialized, "http://example.com/hello?a=b&c=d")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello?a=b&c=d")
     XCTAssertEqual(url.query, "a=b&c=d")
     XCTAssertURLIsIdempotent(url)
 
     url.query = nil
-    XCTAssertEqual(url.serialized, "http://example.com/hello")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello")
     XCTAssertNil(url.query)
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] The Swift model does not trim the leading "?" from the new value when setting.
     url.query = "?e=f&g=h"
-    XCTAssertEqual(url.serialized, "http://example.com/hello??e=f&g=h")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello??e=f&g=h")
     XCTAssertEqual(url.query, "?e=f&g=h")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation] Newlines and tabs are not filtered.
     url.query = "\tso\nmething"
-    XCTAssertEqual(url.serialized, "http://example.com/hello?%09so%0Amething")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello?%09so%0Amething")
     XCTAssertEqual(url.query, "%09so%0Amething")
     XCTAssertURLIsIdempotent(url)
   }
@@ -638,33 +638,33 @@ extension WebURLTests {
 
     // [Deviation]: The Swift model does not include the leading "#" in the getter, uses 'nil' to mean 'not present'.
     var url = WebURL("http://example.com/hello")!
-    XCTAssertEqual(url.serialized, "http://example.com/hello")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello")
     XCTAssertNil(url.fragment)
 
     url.fragment = ""
-    XCTAssertEqual(url.serialized, "http://example.com/hello#")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello#")
     XCTAssertEqual(url.fragment, "")
     XCTAssertURLIsIdempotent(url)
 
     url.fragment = "test"
-    XCTAssertEqual(url.serialized, "http://example.com/hello#test")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello#test")
     XCTAssertEqual(url.fragment, "test")
     XCTAssertURLIsIdempotent(url)
 
     url.fragment = nil
-    XCTAssertEqual(url.serialized, "http://example.com/hello")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello")
     XCTAssertNil(url.fragment)
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation]: The Swift model does not trim the leading "#" from the new value when setting.
     url.fragment = "#test"
-    XCTAssertEqual(url.serialized, "http://example.com/hello##test")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello##test")
     XCTAssertEqual(url.fragment, "#test")
     XCTAssertURLIsIdempotent(url)
 
     // [Deviation]: Newlines and tabs are not filtered.
     url.fragment = "\tso\nmething"
-    XCTAssertEqual(url.serialized, "http://example.com/hello#%09so%0Amething")
+    XCTAssertEqual(url.serialized(), "http://example.com/hello#%09so%0Amething")
     XCTAssertEqual(url.fragment, "%09so%0Amething")
     XCTAssertURLIsIdempotent(url)
   }
@@ -675,20 +675,20 @@ extension WebURLTests {
   func testSerializedExcludingFragment() {
     do {
       let url = WebURL("http://example.com/some/path?and&a&query#withAFragment")!
-      XCTAssertEqual(url.serialized, "http://example.com/some/path?and&a&query#withAFragment")
-      XCTAssertEqual(url.serializedExcludingFragment, "http://example.com/some/path?and&a&query")
+      XCTAssertEqual(url.serialized(), "http://example.com/some/path?and&a&query#withAFragment")
+      XCTAssertEqual(url.serialized(excludingFragment: true), "http://example.com/some/path?and&a&query")
     }
     // Fragment with a bunch of extra '#'s.
     do {
       let url = WebURL("http://example.com/some/path?and&a&query######withAFragment")!
-      XCTAssertEqual(url.serialized, "http://example.com/some/path?and&a&query######withAFragment")
-      XCTAssertEqual(url.serializedExcludingFragment, "http://example.com/some/path?and&a&query")
+      XCTAssertEqual(url.serialized(), "http://example.com/some/path?and&a&query######withAFragment")
+      XCTAssertEqual(url.serialized(excludingFragment: true), "http://example.com/some/path?and&a&query")
     }
     // No fragment.
     do {
       let url = WebURL("http://example.com/some/path?and&a&query")!
-      XCTAssertEqual(url.serialized, "http://example.com/some/path?and&a&query")
-      XCTAssertEqual(url.serializedExcludingFragment, "http://example.com/some/path?and&a&query")
+      XCTAssertEqual(url.serialized(), "http://example.com/some/path?and&a&query")
+      XCTAssertEqual(url.serialized(excludingFragment: true), "http://example.com/some/path?and&a&query")
     }
   }
 
@@ -696,74 +696,74 @@ extension WebURLTests {
     // Special schemes.
     do {
       let url = WebURL("file:///usr/bin/swift")!
-      XCTAssertEqual(url.serialized, "file:///usr/bin/swift")
+      XCTAssertEqual(url.serialized(), "file:///usr/bin/swift")
       XCTAssertNil(url.port)
       XCTAssertNil(url.portOrKnownDefault)
     }
     do {
       var url = WebURL("http://example.com/")!
-      XCTAssertEqual(url.serialized, "http://example.com/")
+      XCTAssertEqual(url.serialized(), "http://example.com/")
       XCTAssertNil(url.port)
       XCTAssertEqual(url.portOrKnownDefault, 80)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "http://example.com:999/")
+      XCTAssertEqual(url.serialized(), "http://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
     do {
       var url = WebURL("ws://example.com/")!
-      XCTAssertEqual(url.serialized, "ws://example.com/")
+      XCTAssertEqual(url.serialized(), "ws://example.com/")
       XCTAssertNil(url.port)
       XCTAssertEqual(url.portOrKnownDefault, 80)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "ws://example.com:999/")
+      XCTAssertEqual(url.serialized(), "ws://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
     do {
       var url = WebURL("https://example.com/")!
-      XCTAssertEqual(url.serialized, "https://example.com/")
+      XCTAssertEqual(url.serialized(), "https://example.com/")
       XCTAssertNil(url.port)
       XCTAssertEqual(url.portOrKnownDefault, 443)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "https://example.com:999/")
+      XCTAssertEqual(url.serialized(), "https://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
     do {
       var url = WebURL("wss://example.com/")!
-      XCTAssertEqual(url.serialized, "wss://example.com/")
+      XCTAssertEqual(url.serialized(), "wss://example.com/")
       XCTAssertNil(url.port)
       XCTAssertEqual(url.portOrKnownDefault, 443)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "wss://example.com:999/")
+      XCTAssertEqual(url.serialized(), "wss://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
     do {
       var url = WebURL("ftp://example.com/")!
-      XCTAssertEqual(url.serialized, "ftp://example.com/")
+      XCTAssertEqual(url.serialized(), "ftp://example.com/")
       XCTAssertNil(url.port)
       XCTAssertEqual(url.portOrKnownDefault, 21)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "ftp://example.com:999/")
+      XCTAssertEqual(url.serialized(), "ftp://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
     // Non-special scheme.
     do {
       var url = WebURL("foo://example.com/")!
-      XCTAssertEqual(url.serialized, "foo://example.com/")
+      XCTAssertEqual(url.serialized(), "foo://example.com/")
       XCTAssertNil(url.port)
       XCTAssertNil(url.portOrKnownDefault)
 
       url.port = 999
-      XCTAssertEqual(url.serialized, "foo://example.com:999/")
+      XCTAssertEqual(url.serialized(), "foo://example.com:999/")
       XCTAssertEqual(url.port, 999)
       XCTAssertEqual(url.portOrKnownDefault, 999)
     }
@@ -785,7 +785,7 @@ extension WebURLTests {
 
     do {  // Remove hostname with no path present. Must fail.
       var url = WebURL("foo://somehost")!
-      XCTAssertEqual(url.serialized, "foo://somehost")
+      XCTAssertEqual(url.serialized(), "foo://somehost")
       XCTAssertEqual(url.path, "")
       XCTAssertEqual(url.hostname, "somehost")
       XCTAssertFalse(url.hasOpaquePath)
@@ -794,19 +794,19 @@ extension WebURLTests {
         try url.setHostname(String?.none)
       }
 
-      XCTAssertEqual(url.serialized, "foo://somehost")
+      XCTAssertEqual(url.serialized(), "foo://somehost")
       XCTAssertURLIsIdempotent(url)
     }
     do {  // Remove hostname with path present. Succeeds.
       var url = WebURL("foo://somehost/bar")!
-      XCTAssertEqual(url.serialized, "foo://somehost/bar")
+      XCTAssertEqual(url.serialized(), "foo://somehost/bar")
       XCTAssertEqual(url.path, "/bar")
       XCTAssertEqual(url.hostname, "somehost")
       XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertNoThrow(try url.setHostname(String?.none))
 
-      XCTAssertEqual(url.serialized, "foo:/bar")
+      XCTAssertEqual(url.serialized(), "foo:/bar")
       XCTAssertEqual(url.path, "/bar")
       XCTAssertNil(url.hostname)
       XCTAssertFalse(url.hasOpaquePath)
@@ -818,14 +818,14 @@ extension WebURLTests {
 
     do {  // Set empty path via setter with no hostname present. Sets root path.
       var url = WebURL("foo:/hello/world?someQuery")!
-      XCTAssertEqual(url.serialized, "foo:/hello/world?someQuery")
+      XCTAssertEqual(url.serialized(), "foo:/hello/world?someQuery")
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertNil(url.hostname)
       XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertNoThrow(try url.setPath(""))
 
-      XCTAssertEqual(url.serialized, "foo:/?someQuery")
+      XCTAssertEqual(url.serialized(), "foo:/?someQuery")
       XCTAssertEqual(url.path, "/")
       XCTAssertNil(url.hostname)
       XCTAssertFalse(url.hasOpaquePath)
@@ -833,13 +833,13 @@ extension WebURLTests {
     }
     do {  // Set empty path via .pathComponents with no hostname present. Sets root path.
       var url = WebURL("foo:/hello/world?someQuery")!
-      XCTAssertEqual(url.serialized, "foo:/hello/world?someQuery")
+      XCTAssertEqual(url.serialized(), "foo:/hello/world?someQuery")
       XCTAssertEqual(url.path, "/hello/world")
       XCTAssertNil(url.hostname)
       XCTAssertFalse(url.hasOpaquePath)
 
       let urlWithNoPath = WebURL("bar://somehost?anotherQuery")!
-      XCTAssertEqual(urlWithNoPath.serialized, "bar://somehost?anotherQuery")
+      XCTAssertEqual(urlWithNoPath.serialized(), "bar://somehost?anotherQuery")
       XCTAssertEqual(urlWithNoPath.path, "")
       XCTAssertEqual(urlWithNoPath.hostname, "somehost")
       XCTAssertFalse(url.hasOpaquePath)
@@ -848,7 +848,7 @@ extension WebURLTests {
 
       url.pathComponents = urlWithNoPath.pathComponents
 
-      XCTAssertEqual(url.serialized, "foo:/?someQuery")
+      XCTAssertEqual(url.serialized(), "foo:/?someQuery")
       XCTAssertEqual(url.path, "/")
       XCTAssertNil(url.hostname)
       XCTAssertFalse(url.hasOpaquePath)
@@ -856,14 +856,14 @@ extension WebURLTests {
     }
     do {  // Set empty path with hostname present. Sets empty path.
       var url = WebURL("foo://somehost/bar?someQuery")!
-      XCTAssertEqual(url.serialized, "foo://somehost/bar?someQuery")
+      XCTAssertEqual(url.serialized(), "foo://somehost/bar?someQuery")
       XCTAssertEqual(url.path, "/bar")
       XCTAssertEqual(url.hostname, "somehost")
       XCTAssertFalse(url.hasOpaquePath)
 
       XCTAssertNoThrow(try url.setPath(""))
 
-      XCTAssertEqual(url.serialized, "foo://somehost?someQuery")
+      XCTAssertEqual(url.serialized(), "foo://somehost?someQuery")
       XCTAssertEqual(url.path, "")
       XCTAssertEqual(url.hostname, "somehost")
       XCTAssertFalse(url.hasOpaquePath)


### PR DESCRIPTION
This causes an unfortunate amount of code churn, but I think it's a better API all things considered.

Sorry!