### PR TITLE
Rename WebURL.(from)FilePathBytes -> WebURL.(from)BinaryFilePath

### DIFF
--- a/Sources/WebURL/DeprecatedAPIs.swift
+++ b/Sources/WebURL/DeprecatedAPIs.swift
@@ -490,3 +490,26 @@ extension StringProtocol {
     self.percentDecoded(substitutions: .formEncoding)
   }
 }
+
+
+// ------------------------------------------------
+// MARK: - Binary File Paths (renamed from: 0.2.1)
+// ------------------------------------------------
+
+
+extension WebURL {
+
+  @available(*, deprecated, renamed: "fromBinaryFilePath")
+  public static func fromFilePathBytes<Bytes>(
+    _ path: Bytes, format: FilePathFormat = .native
+  ) throws -> WebURL where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
+    try fromBinaryFilePath(path, format: format)
+  }
+
+  @available(*, deprecated, renamed: "binaryFilePath")
+  public static func filePathBytes(
+    from url: WebURL, format: FilePathFormat = .native, nullTerminated: Bool
+  ) throws -> ContiguousArray<UInt8> {
+    ContiguousArray(try binaryFilePath(from: url, format: format, nullTerminated: nullTerminated))
+  }
+}

--- a/Sources/WebURL/WebURL+FilePaths.swift
+++ b/Sources/WebURL/WebURL+FilePaths.swift
@@ -146,7 +146,7 @@ extension WebURL {
   public init<S>(
     filePath: S, format: FilePathFormat = .native
   ) throws where S: StringProtocol, S.UTF8View: BidirectionalCollection {
-    self = try WebURL.fromFilePathBytes(filePath.utf8, format: format)
+    self = try WebURL.fromBinaryFilePath(filePath.utf8, format: format)
   }
 }
 
@@ -217,7 +217,7 @@ extension WebURL {
   /// - throws: `URLFromFilePathError`
   ///
   @inlinable
-  public static func fromFilePathBytes<Bytes>(
+  public static func fromBinaryFilePath<Bytes>(
     _ path: Bytes, format: FilePathFormat = .native
   ) throws -> WebURL where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
     switch format._fmt {
@@ -584,7 +584,7 @@ extension WebURL {
   /// ## Normalization
   ///
   /// Some minimal normalization is applied to the path, such as removing empty path components.
-  /// Unlike the `WebURL.fromFilePathBytes` function, Windows path components are never trimmed.
+  /// Unlike the `WebURL.fromBinaryFilePath` function, Windows path components are never trimmed.
   ///
   /// - parameters:
   ///   - url:    The file URL.
@@ -595,12 +595,12 @@ extension WebURL {
   /// - throws: `FilePathFromURLError`
   ///
   @inlinable
-  public static func filePathBytes(
+  public static func binaryFilePath(
     from url: WebURL, format: FilePathFormat = .native, nullTerminated: Bool
-  ) throws -> ContiguousArray<UInt8> {
+  ) throws -> [UInt8] {
     switch format._fmt {
-    case .posix: return try _filePathFromURL_posix(url, nullTerminated: nullTerminated).get()
-    case .windows: return try _filePathFromURL_windows(url, nullTerminated: nullTerminated).get()
+    case .posix: return Array(try _filePathFromURL_posix(url, nullTerminated: nullTerminated).get())
+    case .windows: return Array(try _filePathFromURL_windows(url, nullTerminated: nullTerminated).get())
     }
   }
 }

--- a/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
+++ b/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
@@ -53,7 +53,7 @@ import WebURL
         try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
           guard let mbStr = $0 else { throw URLFromFilePathError.transcodingFailure }
           precondition(mbStr.last == 0, "Expected a null-terminated string")
-          return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+          return try WebURL.fromBinaryFilePath(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
         }
       }
     }
@@ -75,7 +75,7 @@ import WebURL
     /// - throws: `FilePathFromURLError`
     ///
     public init(url: WebURL) throws {
-      self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+      self = try WebURL.binaryFilePath(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
         try PlatformStringConversions.fromMultiByte($0) {
           guard let platformString = $0 else { throw FilePathFromURLError.transcodingFailure }
           return FilePath(platformString: platformString.baseAddress!)
@@ -113,7 +113,7 @@ import WebURL
         try PlatformStringConversions.toMultiByte(UnsafeBufferPointer(start: platformStr, count: filePath.length + 1)) {
           guard let mbStr = $0 else { throw URLFromFilePathError.transcodingFailure }
           precondition(mbStr.last == 0, "Expected a null-terminated string")
-          return try WebURL.fromFilePathBytes(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
+          return try WebURL.fromBinaryFilePath(UnsafeBufferPointer(rebasing: mbStr.dropLast()), format: .native)
         }
       }
     }
@@ -136,7 +136,7 @@ import WebURL
     /// - throws: `FilePathFromURLError`
     ///
     public init(url: WebURL) throws {
-      self = try WebURL.filePathBytes(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
+      self = try WebURL.binaryFilePath(from: url, format: .native, nullTerminated: true).withUnsafeBufferPointer {
         try PlatformStringConversions.fromMultiByte($0) {
           guard let platformString = $0 else { throw FilePathFromURLError.transcodingFailure }
           return FilePath(cString: platformString.baseAddress!)

--- a/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
+++ b/Sources/WebURLTestSupport/FilePathTests+WebURLReportHarness.swift
@@ -50,7 +50,7 @@ extension FilePathToURLTests.WebURLReportHarness: FilePathToURLTests.Harness {
     case .invalidHostname: return .invalidHostname
     case .invalidPath: return .invalidPath
     case .unsupportedWin32NamespacedPath: return .unsupportedWin32NamespacedPath
-    case .transcodingFailure: fatalError("WebURL.fromFilePathBytes should not be transcoding anything")
+    case .transcodingFailure: fatalError("WebURL.fromBinaryFilePath should not be transcoding anything")
     default: fatalError("Unknown error")
     }
   }
@@ -101,7 +101,7 @@ extension URLToFilePathTests.WebURLReportHarness: URLToFilePathTests.Harness {
     _ url: WebURL, format: FilePathFormat
   ) -> Result<String, URLToFilePathTests.FailureReason> {
     Result {
-      String(decoding: try WebURL.filePathBytes(from: url, format: format, nullTerminated: false), as: UTF8.self)
+      String(decoding: try WebURL.binaryFilePath(from: url, format: format, nullTerminated: false), as: UTF8.self)
     }.mapError { Self.errorToFailureReason($0 as! FilePathFromURLError) }
   }
 
@@ -113,7 +113,7 @@ extension URLToFilePathTests.WebURLReportHarness: URLToFilePathTests.Harness {
     case .unsupportedNonLocalFile: return .unsupportedNonLocalFile
     case .unsupportedHostname: return .unsupportedHostname
     case .windowsPathIsNotFullyQualified: return .relativePath
-    case .transcodingFailure: fatalError("WebURL.filePathBytes should not be transcoding anything")
+    case .transcodingFailure: fatalError("WebURL.binaryFilePath should not be transcoding anything")
     default: fatalError("Unknown error")
     }
   }

--- a/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
+++ b/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
@@ -128,7 +128,7 @@ final class SystemFilePathTests: XCTestCase {}
       ]
 
       // Create a file URL from the raw bytes.
-      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .windows)
       XCTAssertEqual(fileURL.serialized(), "file:///C:/fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
@@ -172,7 +172,7 @@ final class SystemFilePathTests: XCTestCase {}
       ]
 
       // Create a file URL from the raw bytes.
-      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(latin1, format: .windows)
       XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/caf%E9%DD")
@@ -224,7 +224,7 @@ final class SystemFilePathTests: XCTestCase {}
       ]
 
       // Create a file URL from the raw bytes.
-      let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(greek, format: .windows)
       XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/hi%E1%E2%E3")
@@ -443,7 +443,7 @@ final class SystemFilePathTests: XCTestCase {}
       ]
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
-      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .posix)
       XCTAssertEqual(fileURL.serialized(), "file:///fo%ED%A0%80o/bar")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
@@ -509,7 +509,7 @@ final class SystemFilePathTests: XCTestCase {}
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), "/caf��")
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
-      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(latin1, format: .posix)
       XCTAssertEqual(fileURL.serialized(), "file:///caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/caf%E9%DD")
@@ -539,7 +539,7 @@ final class SystemFilePathTests: XCTestCase {}
       XCTAssertEqual(String(decoding: greek, as: UTF8.self), "/hi���")
 
       // Create a file URL from the raw bytes. No UTF-8 validation is performed.
-      let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(greek, format: .posix)
       XCTAssertEqual(fileURL.serialized(), "file:///hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/hi%E1%E2%E3")

--- a/Tests/WebURLTests/FilePathTests.swift
+++ b/Tests/WebURLTests/FilePathTests.swift
@@ -109,7 +109,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), "/hi")
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .posix)
+        let _ = try WebURL.fromBinaryFilePath(nullTerminated, format: .posix)
       }
     }
 
@@ -123,7 +123,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), "/hi")
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(includesNulls, format: .posix)
+        let _ = try WebURL.fromBinaryFilePath(includesNulls, format: .posix)
       }
     }
 
@@ -135,14 +135,14 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"/fo���o/bar"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .posix)
 
       XCTAssertEqual(fileURL.serialized(), #"file:///fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 2)
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, unpairedSurrogate)
     }
 
@@ -153,7 +153,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), "/caf��")
 
-      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(latin1, format: .posix)
 
       XCTAssertEqual(fileURL.serialized(), "file:///caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
@@ -163,7 +163,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.startIndex], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.first, "caf��")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1)
     }
 
@@ -174,7 +174,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: greek, as: UTF8.self), "/hi���")
 
-      let fileURL = try WebURL.fromFilePathBytes(greek, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(greek, format: .posix)
 
       XCTAssertEqual(fileURL.serialized(), "file:///hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
@@ -184,7 +184,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.startIndex], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.first, "hi���")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek)
     }
 
@@ -194,7 +194,7 @@ extension FilePathTests {
       allBytes.insert(contentsOf: 1...UInt8.max, at: 3)  // NULL bytes not allowed.
       XCTAssert(String(decoding: allBytes, as: UTF8.self).contains("�"))
 
-      let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .posix)
+      let fileURL = try WebURL.fromBinaryFilePath(allBytes, format: .posix)
 
       XCTAssertEqual(
         fileURL.serialized(),
@@ -221,7 +221,7 @@ extension FilePathTests {
       )
       XCTAssertEqual(fileURL.pathComponents.count, 3)
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .posix, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .posix, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, allBytes)
     }
   }
@@ -247,7 +247,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), #"C:\hi"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(nullTerminated, format: .windows)
       }
     }
 
@@ -262,7 +262,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), #"C:\hi"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(includesNulls, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(includesNulls, format: .windows)
       }
     }
 
@@ -275,14 +275,14 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"C:\fo���o\bar"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), #"file:///C:/fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, unpairedSurrogate)
     }
 
@@ -294,7 +294,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"C:\caf��"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(latin1, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
@@ -304,7 +304,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.last, "caf��")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1)
     }
 
@@ -316,7 +316,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: greek, as: UTF8.self), #"C:\hi���"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(greek, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
@@ -326,7 +326,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.last, "hi���")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek)
     }
 
@@ -336,7 +336,7 @@ extension FilePathTests {
       allBytes.insert(contentsOf: 1...UInt8.max, at: 5)  // NULL bytes not allowed.
       XCTAssert(String(decoding: allBytes, as: UTF8.self).contains("�"))
 
-      let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(allBytes, format: .windows)
 
       XCTAssertEqual(
         fileURL.serialized(),
@@ -366,7 +366,7 @@ extension FilePathTests {
       // Unfortunately, this does not precisely round-trip due to trimming and Windows having 2 path separators,
       // but if we reverse those transformations, the round-trip result should then be the same as the original.
 
-      var roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      var roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       roundtripPath.insert(0x2E, at: 5 + 0x2E - 1)  // re-insert the trimmed '.'
       roundtripPath[5 + 0x2F - 1] = 0x2F  // URL paths have forward slashes, are turned to backslashes in path.
       XCTAssertEqualElements(roundtripPath, allBytes)
@@ -383,7 +383,7 @@ extension FilePathTests {
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"\\caf��\hi\bye\"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(latin1, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(latin1, format: .windows)
       }
     }
 
@@ -398,7 +398,7 @@ extension FilePathTests {
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"\\ca���\hi\bye\"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .windows)
       }
     }
 
@@ -406,7 +406,7 @@ extension FilePathTests {
     do {
       let unicode = #"\\🦆\share\bread\"#
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(unicode.utf8, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(unicode.utf8, format: .windows)
       }
     }
   }
@@ -426,7 +426,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: nullTerminated.map { CChar(bitPattern: $0) }), #"\\?\C:\hi"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(nullTerminated, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(nullTerminated, format: .windows)
       }
     }
 
@@ -442,7 +442,7 @@ extension FilePathTests {
       XCTAssertEqual(String(cString: includesNulls.map { CChar(bitPattern: $0) }), #"\\?\C:\hi"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.nullBytes) {
-        let _ = try WebURL.fromFilePathBytes(includesNulls, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(includesNulls, format: .windows)
       }
     }
 
@@ -456,14 +456,14 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"\\?\C:\fo���o\bar"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), #"file:///C:/fo%ED%A0%80o/bar"#)
       XCTAssertURLIsIdempotent(fileURL)
       XCTAssertURLComponents(fileURL, scheme: "file", hostname: "", path: "/C:/fo%ED%A0%80o/bar")
       XCTAssertEqual(fileURL.pathComponents.count, 3)
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, unpairedSurrogate.dropFirst(4) /* \\?\ prefix */)
     }
 
@@ -476,7 +476,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"\\?\C:\caf��"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(latin1, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(latin1, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), "file:///C:/caf%E9%DD")
       XCTAssertURLIsIdempotent(fileURL)
@@ -486,7 +486,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "caf%E9%DD")
       XCTAssertEqual(fileURL.pathComponents.last, "caf��")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, latin1.dropFirst(4) /* \\?\ prefix */)
     }
 
@@ -499,7 +499,7 @@ extension FilePathTests {
       ]
       XCTAssertEqual(String(decoding: greek, as: UTF8.self), #"\\?\C:\hi���"#)
 
-      let fileURL = try WebURL.fromFilePathBytes(greek, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(greek, format: .windows)
 
       XCTAssertEqual(fileURL.serialized(), "file:///C:/hi%E1%E2%E3")
       XCTAssertURLIsIdempotent(fileURL)
@@ -509,7 +509,7 @@ extension FilePathTests {
       XCTAssertEqual(fileURL.pathComponents[raw: fileURL.pathComponents.indices.last!], "hi%E1%E2%E3")
       XCTAssertEqual(fileURL.pathComponents.last, "hi���")
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, greek.dropFirst(4) /* \\?\ prefix */)
     }
 
@@ -519,7 +519,7 @@ extension FilePathTests {
       allBytes.insert(contentsOf: [1...0x2E, 0x30...UInt8.max].joined(), at: 9)  // NULL and 0x2F not allowed.
       XCTAssert(String(decoding: allBytes, as: UTF8.self).contains("�"))
 
-      let fileURL = try WebURL.fromFilePathBytes(allBytes, format: .windows)
+      let fileURL = try WebURL.fromBinaryFilePath(allBytes, format: .windows)
 
       XCTAssertEqual(
         fileURL.serialized(),
@@ -549,7 +549,7 @@ extension FilePathTests {
       // Unlike the non-Win32 namespaced variant, no trimming is performed and forward-slashes aren't allowed.
       // That means the path does actually round-trip! (I mean, besides the \\?\ prefix, which we can't preserve).
 
-      let roundtripPath = try WebURL.filePathBytes(from: fileURL, format: .windows, nullTerminated: false)
+      let roundtripPath = try WebURL.binaryFilePath(from: fileURL, format: .windows, nullTerminated: false)
       XCTAssertEqualElements(roundtripPath, allBytes.dropFirst(4) /* \\?\ prefix */)
     }
 
@@ -566,7 +566,7 @@ extension FilePathTests {
       XCTAssertEqual(String(decoding: latin1, as: UTF8.self), #"\\?\UNC\caf��\hi\bye\"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(latin1, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(latin1, format: .windows)
       }
     }
 
@@ -583,7 +583,7 @@ extension FilePathTests {
       XCTAssertEqual(String(decoding: unpairedSurrogate, as: UTF8.self), #"\\?\UNC\ca���\hi\bye\"#)
 
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(unpairedSurrogate, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(unpairedSurrogate, format: .windows)
       }
     }
 
@@ -591,7 +591,7 @@ extension FilePathTests {
     do {
       let unicode = #"\\?\UNC\🦆\share\bread\"#
       XCTAssertThrowsSpecific(URLFromFilePathError.invalidHostname) {
-        let _ = try WebURL.fromFilePathBytes(unicode.utf8, format: .windows)
+        let _ = try WebURL.fromBinaryFilePath(unicode.utf8, format: .windows)
       }
     }
   }


### PR DESCRIPTION
Emerged while writing the DocC docs. 

"file path bytes" vs "file path strings" isn't that clear, but "binary file paths" are (a little bit) more clearly different from "file path strings". It is arguably a bit more correct, too.