### PR TITLE
[DeprecatedAPIs] Remove some zero-width spaces which crept in to the deprecated typealias name

### DIFF
--- a/Sources/WebURL/DeprecatedAPIs.swift
+++ b/Sources/WebURL/DeprecatedAPIs.swift
@@ -346,7 +346,7 @@ extension StringProtocol {
 /// to accurately decode content encoded with substitutions.
 ///
 @available(*, deprecated, renamed: "LazilyPercentDecoded")
-public typealias Lazily​Percent​Decoded​UTF8Without​Substitutions<Source> = LazilyPercentDecoded<Source>
+public typealias LazilyPercentDecodedUTF8WithoutSubstitutions<Source> = LazilyPercentDecoded<Source>
 where Source: Collection, Source.Element == UInt8
 
 /// A `Collection` which percent-decodes elements from its `Source` on-demand, and reverses substitutions made by a ``SubstitutionMap``.
@@ -356,11 +356,12 @@ where Source: Collection, Source.Element == UInt8
 /// ``SubstitutionMap`` to accurately decode content encoded with substitutions.
 ///
 @available(*, deprecated, renamed: "LazilyPercentDecodedWithSubstitutions")
-public typealias Lazily​Percent​Decoded​UTF8<Source, Subs> = LazilyPercentDecodedWithSubstitutions<Source, Subs>
+public typealias LazilyPercentDecodedUTF8<Source, Subs> = LazilyPercentDecodedWithSubstitutions<Source, Subs>
 where Source: Collection, Source.Element == UInt8, Subs: SubstitutionMap
 
 /// A namespace for substitution maps used by percent-encode sets defined by the URL Standard.
 ///
+@available(*, deprecated)
 public struct PercentDecodeSet_Namespace {
   internal init() {}
 


### PR DESCRIPTION
While refactoring the percent-encoding API, I copied the old names from DocC for the deprecated typealiases. Unfortunately, DocC inserts zero-width spaces in type names, and neither Xcode nor GitHub show them, so I didn't notice.

The Swift compiler seems oddly okay with it, either way. But it's weird and should go.