### PR TITLE
Minor tweaks to UTF8View, PathComponents.distance calculation

### DIFF
--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -176,9 +176,16 @@ extension WebURL.PathComponents: BidirectionalCollection {
     guard start <= end else {
       return -1 * distance(from: end, to: start)
     }
-    return storage.utf8[start.range.lowerBound..<end.range.lowerBound].lazy.filter {
-      $0 == ASCII.forwardSlash.codePoint
-    }.count
+    let pathSlice = storage.utf8[start.range.lowerBound..<end.range.lowerBound]
+    var n = 0
+    var idx = pathSlice.startIndex
+    while idx < pathSlice.endIndex {
+      if pathSlice[idx] == ASCII.forwardSlash.codePoint {
+        n &+= 1
+      }
+      pathSlice.formIndex(after: &idx)
+    }
+    return n
   }
 
   public func index(after i: Index) -> Index {

--- a/Sources/WebURL/WebURL+UTF8View.swift
+++ b/Sources/WebURL/WebURL+UTF8View.swift
@@ -131,13 +131,8 @@ extension WebURL.UTF8View: RandomAccessCollection {
   }
 
   @inlinable
-  public func index(_ i: Index, offsetBy distance: Index) -> Index {
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
     i &+ distance
-  }
-
-  @inlinable
-  public func formIndex(_ i: inout Index, offsetBy distance: Index) {
-    i &+= distance
   }
 
   @inlinable


### PR DESCRIPTION
- By avoiding lazy filter, the compiler can vectorise the PathComponents.distance(from:to:) calculation. Which is totally awesome. It's a bit of a shame that it doesn't do that with lazy filter, but whatever.

- RandomAccessCollection closes off `formIndex(_:offsetBy:)` as a customisation point. Although, strangely, `index(_:offsetBy:)` is still a customisation point. This looks like a stdlib bug.