### PR TITLE
Add a percent decoding fast-path

### DIFF
--- a/Benchmarks/Sources/WebURLBenchmark/URLEncoded.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/URLEncoded.swift
@@ -49,4 +49,16 @@ let urlEncoded_Decoded = BenchmarkSuite(name: "URLEncoded") { suite in
       blackHole(string.percentDecoded())
     }
   }
+
+  let urlDecoded_notEncoded_strings = [
+    #"This string does not contain any percent-encoding"#,
+    #"This is another string -- which also does not contain any percent-encoding"#,
+    #"This 🧵 does not contain any ٪-encoding"#,
+    #"This 🧵 does not contain any ٪-encoding -- This 🧵 does not contain any ٪-encoding -- This 🧵 does not contain any ٪-encoding"#
+  ]
+  suite.benchmark("String.urlDecoded.notEncoded") {
+    for string in urlDecoded_notEncoded_strings {
+      blackHole(string.percentDecoded())
+    }
+  }
 }

--- a/Sources/WebURL/IPAddress.swift
+++ b/Sources/WebURL/IPAddress.swift
@@ -1498,7 +1498,7 @@ extension IPv4Address {
   ///
   /// [rfc4001]: https://tools.ietf.org/html/rfc4001#page-7
   ///
-	/// ## See Also
+  /// ## See Also
   ///
   /// - ``IPv4Address/init(_:)``
   /// - ``IPv4Address/init(dottedDecimal:)``

--- a/Sources/WebURL/Util/BitTwiddling.swift
+++ b/Sources/WebURL/Util/BitTwiddling.swift
@@ -1,0 +1,71 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extension UInt64 {
+
+  /// Creates an 8-byte integer, each of which is equal to the given byte.
+  ///
+  @inlinable @inline(__always)
+  internal init(repeatingByte byte: UInt8) {
+    self = 0
+    withUnsafeMutableBytes(of: &self) {
+      $0[0] = byte
+      $0[1] = byte
+      $0[2] = byte
+      $0[3] = byte
+      $0[4] = byte
+      $0[5] = byte
+      $0[6] = byte
+      $0[7] = byte
+    }
+  }
+}
+
+extension UnsafeBufferPointer where Element == UInt8 {
+
+  /// Whether or not the buffer contains the given byte.
+  ///
+  /// This implementation compares chunks of 8 bytes at a time,
+  /// using only 4 instructions per chunk of 8 bytes.
+  ///
+  @inlinable @inline(__always)  // mask must be constant-folded.
+  internal func _fastContains(_ element: UInt8) -> Bool {
+    let mask = UInt64(repeatingByte: element)
+    return __fastContains(element: element, mask: mask)
+  }
+
+  @inlinable
+  internal func __fastContains(element: UInt8, mask: UInt64) -> Bool {
+    var i = startIndex
+    while distance(from: i, to: endIndex) >= 8 {
+      // Load 8 bytes from the source.
+      var eightBytes = UnsafeRawPointer(
+        self.baseAddress.unsafelyUnwrapped.advanced(by: i)
+      ).loadUnaligned(as: UInt64.self)
+      // XOR every byte with the element we're searching for.
+      // If there are any matches, we'll get a zero byte in that position.
+      eightBytes ^= mask
+      // Use bit-twiddling to detect if any bytes were zero.
+      // https://graphics.stanford.edu/~seander/bithacks.html#ValueInWord
+      let found = (eightBytes &- 0x0101_0101_0101_0101) & (~eightBytes & 0x8080_8080_8080_8080)
+      if found != 0 { return true }
+      i &+= 8
+    }
+    while i < endIndex {
+      if self[i] == element { return true }
+      i &+= 1
+    }
+    return false
+  }
+}

--- a/Sources/WebURL/Util/Pointers.swift
+++ b/Sources/WebURL/Util/Pointers.swift
@@ -30,7 +30,9 @@ extension UnsafeRawPointer {
     assert(_isPOD(T.self))
     var val: T = 0
     withUnsafeMutableBytes(of: &val) {
-      $0.copyMemory(from: UnsafeRawBufferPointer(start: self + offset, count: MemoryLayout<T>.stride))
+      for i in Range(uncheckedBounds: (0, T.bitWidth / 8)) {
+        $0[i] = load(fromByteOffset: offset &+ i, as: UInt8.self)
+      }
     }
     return val
   }

--- a/Sources/WebURL/WebURL+PathComponents.swift
+++ b/Sources/WebURL/WebURL+PathComponents.swift
@@ -152,7 +152,7 @@ extension WebURL {
   ///
   /// > Tip:
   /// > The documentation for this type can be found at: ``WebURL/pathComponents-swift.property``.
-  /// 
+  ///
   public struct PathComponents {
 
     @usableFromInline


### PR DESCRIPTION
If the source data does not even contain a "%", we can trivially determine that percent-decoding is not required. Similarly, if it does not contain a "%" or "+", we can determine that form-decoding is not required.

This cuts the time to iterate path components (which often don't contain percent-encoding) by about 30-40%, and sometimes much more -- if the source is a `String`, we don't even need to copy. And it has essentially no impact on data which actually is encoded, because constructing a string from decoded contents is way more expensive than this check.

Before:

```
name                                    time        std        iterations
-------------------------------------------------------------------------
PathComponents.Iteration.Small.Forwards 1284.000 ns ±  49.23 %    1000000       <-----
PathComponents.Iteration.Small.Reverse  1255.000 ns ±  44.46 %    1000000       <-----
PathComponents.Iteration.Long.Forwards  5708.000 ns ±  29.53 %     223292       <-----
PathComponents.Iteration.Long.Reverse   5663.000 ns ±  28.37 %     224446       <-----
PathComponents.Append.Single            1604.000 ns ±  44.27 %     776674
PathComponents.Append.Multiple          2206.000 ns ±  46.02 %     557985
PathComponents.RemoveLast.Single         836.000 ns ±  69.40 %    1000000
PathComponents.RemoveLast.Multiple       863.000 ns ±  46.90 %    1000000
PathComponents.ReplaceSubrange.Shrink   1616.000 ns ±  46.60 %     774023
PathComponents.ReplaceSubrange.Grow     2695.000 ns ±  38.74 %     465685
```

```
name                                    time        std        iterations
-------------------------------------------------------------------------
URLEncoded.String.urlEncoded            9156.000 ns ±  28.04 %     142419
URLEncoded.String.urlDecoded            4634.000 ns ±  30.95 %     275012
URLEncoded.String.urlDecoded.notEncoded 2114.000 ns ±  48.68 %     583163       <-----
```

After:

```
name                                    time        std        iterations
-------------------------------------------------------------------------
PathComponents.Iteration.Small.Forwards  878.000 ns ±  36.19 %    1000000       <-----
PathComponents.Iteration.Small.Reverse   861.000 ns ±  34.98 %    1000000       <-----
PathComponents.Iteration.Long.Forwards  3908.000 ns ±  17.90 %     342676       <-----
PathComponents.Iteration.Long.Reverse   3768.000 ns ±  18.62 %     354951       <-----
PathComponents.Append.Single            1562.000 ns ±  27.47 %     804555
PathComponents.Append.Multiple          2140.000 ns ±  23.04 %     631751
PathComponents.RemoveLast.Single         698.000 ns ±  33.81 %    1000000
PathComponents.RemoveLast.Multiple       714.000 ns ±  32.44 %    1000000
PathComponents.ReplaceSubrange.Shrink   1642.000 ns ±  24.41 %     781916
PathComponents.ReplaceSubrange.Grow     2658.000 ns ±  21.13 %     500778
```

```
name                                    time        std        iterations
-------------------------------------------------------------------------
URLEncoded.String.urlEncoded            8775.000 ns ±  26.12 %     138089
URLEncoded.String.urlDecoded            4417.000 ns ±  36.92 %     290181
URLEncoded.String.urlDecoded.notEncoded  403.000 ns ±  68.14 %    1000000       <-----
```