### PR TITLE
Force bridged Strings to contiguous storage and avoid specializing on String.UTF8View.

### DIFF
--- a/Sources/WebURL/Parser/Parser+Path.swift
+++ b/Sources/WebURL/Parser/Parser+Path.swift
@@ -358,7 +358,7 @@ extension _PathParser {
     // Complete parsing from input, handle drive letter quirks.
     // ========================================================
 
-    var baseDrive: WebURL.UTF8View.SubSequence? = nil
+    var baseDrive: Optional<WebURL.UTF8View.SubSequence> = nil
 
     if case .file = schemeKind {
       if let base = baseURL {

--- a/Sources/WebURL/PercentEncoding.swift
+++ b/Sources/WebURL/PercentEncoding.swift
@@ -673,7 +673,7 @@ extension StringProtocol {
   ///
   @inlinable
   public func percentEncoded<EncodeSet: PercentEncodeSet>(using encodeSet: EncodeSet) -> String {
-    utf8.percentEncodedString(using: encodeSet)
+    _withContiguousUTF8 { $0.percentEncodedString(using: encodeSet) }
   }
 
   // _StaticMember variant for pre-5.5 toolchains.
@@ -1194,10 +1194,12 @@ extension StringProtocol {
   ///
   @inlinable
   public func percentDecodedBytesArray<Substitutions: SubstitutionMap>(substitutions: Substitutions) -> [UInt8] {
-    if utf8.withContiguousStorageIfAvailable({ substitutions._canSkipDecoding($0) }) == true {
-      return Array(utf8)
+    _withContiguousUTF8 { utf8 in
+      if substitutions._canSkipDecoding(utf8) {
+        return Array(utf8)
+      }
+      return Array(utf8.lazy.percentDecoded(substitutions: substitutions))
     }
-    return Array(utf8.lazy.percentDecoded(substitutions: substitutions))
   }
 
   // _StaticMember variant for pre-5.5 toolchains.
@@ -1293,10 +1295,12 @@ extension StringProtocol {
   ///
   @inlinable
   public func percentDecoded<Substitutions: SubstitutionMap>(substitutions: Substitutions) -> String {
-    if utf8.withContiguousStorageIfAvailable({ substitutions._canSkipDecoding($0) }) == true {
-      return String(self)
+    _withContiguousUTF8 { utf8 in
+      if substitutions._canSkipDecoding(utf8) {
+        return String(self)
+      }
+      return utf8.percentDecodedString(substitutions: substitutions)
     }
-    return utf8.percentDecodedString(substitutions: substitutions)
   }
 
   // _StaticMember variant for pre-5.5 toolchains.

--- a/Sources/WebURL/WebURL.swift
+++ b/Sources/WebURL/WebURL.swift
@@ -51,10 +51,12 @@ public struct WebURL {
   /// [URL-spec]: https://url.spec.whatwg.org/
   ///
   @inlinable @inline(__always)
-  public init?<StringType>(
-    _ string: StringType
-  ) where StringType: StringProtocol, StringType.UTF8View: BidirectionalCollection {
-    self.init(utf8: string.utf8)
+  public init?<StringType>(_ string: StringType) where StringType: StringProtocol {
+    if let result = string._withContiguousUTF8({ WebURL(utf8: $0) }) {
+      self = result
+    } else {
+      return nil
+    }
   }
 
   /// Parses a URL string from a collection of UTF-8 code-units.
@@ -126,10 +128,8 @@ public struct WebURL {
   /// [URL-spec]: https://url.spec.whatwg.org/
   ///
   @inlinable @inline(__always)
-  public func resolve<StringType>(
-    _ string: StringType
-  ) -> WebURL? where StringType: StringProtocol, StringType.UTF8View: BidirectionalCollection {
-    utf8.resolve(string.utf8)
+  public func resolve<StringType>(_ string: StringType) -> WebURL? where StringType: StringProtocol {
+    string._withContiguousUTF8 { utf8.resolve($0) }
   }
 }
 
@@ -759,7 +759,7 @@ extension WebURL {
   ///
   @inlinable
   public mutating func setScheme<StringType>(_ newScheme: StringType) throws where StringType: StringProtocol {
-    try utf8.setScheme(newScheme.utf8)
+    try newScheme._withContiguousUTF8 { try utf8.setScheme($0) }
   }
 
   /// Replaces this URL's ``username`` or throws an error.
@@ -789,7 +789,7 @@ extension WebURL {
   ///
   @inlinable
   public mutating func setUsername<StringType>(_ newUsername: StringType?) throws where StringType: StringProtocol {
-    try utf8.setUsername(newUsername?.utf8)
+    try newUsername._withContiguousUTF8 { try utf8.setUsername($0) }
   }
 
   /// Replaces this URL's ``password`` or throws an error.
@@ -819,7 +819,7 @@ extension WebURL {
   ///
   @inlinable
   public mutating func setPassword<StringType>(_ newPassword: StringType?) throws where StringType: StringProtocol {
-    try utf8.setPassword(newPassword?.utf8)
+    try newPassword._withContiguousUTF8 { try utf8.setPassword($0) }
   }
 
   /// Replaces this URL's ``hostname`` or throws an error.
@@ -849,10 +849,8 @@ extension WebURL {
   /// - ``WebURL/UTF8View/setHostname(_:)``
   ///
   @inlinable
-  public mutating func setHostname<StringType>(
-    _ newHostname: StringType?
-  ) throws where StringType: StringProtocol, StringType.UTF8View: BidirectionalCollection {
-    try utf8.setHostname(newHostname?.utf8)
+  public mutating func setHostname<StringType>(_ newHostname: StringType?) throws where StringType: StringProtocol {
+    try newHostname._withContiguousUTF8 { try utf8.setHostname($0) }
   }
 
   /// Replaces this URL's ``port`` or throws an error.
@@ -908,10 +906,8 @@ extension WebURL {
   /// - ``WebURL/UTF8View/setPath(_:)``
   ///
   @inlinable
-  public mutating func setPath<StringType>(
-    _ newPath: StringType
-  ) throws where StringType: StringProtocol, StringType.UTF8View: BidirectionalCollection {
-    try utf8.setPath(newPath.utf8)
+  public mutating func setPath<StringType>(_ newPath: StringType) throws where StringType: StringProtocol {
+    try newPath._withContiguousUTF8 { try utf8.setPath($0) }
   }
 
   /// Replaces this URL's ``query`` or throws an error.
@@ -939,7 +935,7 @@ extension WebURL {
   ///
   @inlinable
   public mutating func setQuery<StringType>(_ newQuery: StringType?) throws where StringType: StringProtocol {
-    try utf8.setQuery(newQuery?.utf8)
+    try newQuery._withContiguousUTF8 { try utf8.setQuery($0) }
   }
 
   /// Replaces this URL's ``fragment`` or throws an error.
@@ -967,6 +963,6 @@ extension WebURL {
   ///
   @inlinable
   public mutating func setFragment<StringType>(_ newFragment: StringType?) throws where StringType: StringProtocol {
-    try utf8.setFragment(newFragment?.utf8)
+    try newFragment._withContiguousUTF8 { try utf8.setFragment($0) }
   }
 }


### PR DESCRIPTION
Using the `cmpcodesize` util from the compiler repository, comparing the size of the benchmarks executable:

```
karl@Karls-MBP Benchmarks % ../../../swift-project/swift/utils/cmpcodesize/cmpcodesize.py before/WebURLBenchmark .build/release/WebURLBenchmark                                 

Title                              Section             Old             New  Percent
WebURLBenchmark                     __text:        1775009         1425601   -19.7%
```

`WebURL.swiftmodule` goes from 3.9MB to 3.1MB, and the overall benchmarks executable goes from 5MB to 4.4MB.

The detailed diff is pretty much what you'd expect. We no longer generate specializations for parsing and writing URLs from a `UTF8View`, or `NewlineAndTabFiltered<UTF8View>`.

```
Only in old file(s)
[...]
    7528 generic specialization <WebURL.ASCII.NewlineAndTabFiltered<Swift.Substring.UTF8View>, WebURL.UnsafePresizedBufferWriter> of WebURL.ParsedURLString.ProcessedMapping.write<A where A1: WebURL.URLWriter>(inputString: A, baseURL: WebURL.WebURL?, to: inout A1) -> ()
   10647 generic specialization <Swift.Substring.UTF8View, WebURL.UnsafePresizedBufferWriter> of WebURL.ParsedURLString.ProcessedMapping.write<A where A1: WebURL.URLWriter>(inputString: A, baseURL: WebURL.WebURL?, to: inout A1) -> ()
Total size of functions only in old file: 416146
Total size of functions only in new file:  65078
```

[codesize_diff.txt](https://github.com/karwa/swift-url/files/7741401/codesize_diff.txt)