### PR TITLE
More performance and code-size tweaks

### DIFF
--- a/Sources/WebURL/Parser/Parser.swift
+++ b/Sources/WebURL/Parser/Parser.swift
@@ -41,7 +41,7 @@
 //
 //-------------------------------------------------------------------------
 
-@inlinable
+@inlinable @inline(__always)
 func urlFromBytes<Bytes>(_ inputString: Bytes, baseURL: WebURL?) -> WebURL?
 where Bytes: BidirectionalCollection, Bytes.Element == UInt8 {
 

--- a/Sources/WebURL/SPIs.swift
+++ b/Sources/WebURL/SPIs.swift
@@ -87,7 +87,7 @@ extension WebURL._SPIs {
     return path._withContiguousUTF8 { pathUTF8 in
       var writer = StringWriter()
       writer.utf8.reserveCapacity(pathUTF8.count)
-      writer.walkPathComponents(
+      writer.parsePathComponents(
         pathString: pathUTF8.boundsChecked,
         schemeKind: _url.schemeKind,
         hasAuthority: _url.utf8.hostname != nil,

--- a/Sources/WebURL/SPIs.swift
+++ b/Sources/WebURL/SPIs.swift
@@ -68,8 +68,8 @@ extension WebURL._SPIs {
       var utf8: [UInt8] = []
 
       typealias InputString = UnsafeBoundsCheckedBufferPointer<UInt8>
-      mutating func visitEmptyPathComponents(_ n: UInt) {
-        utf8.insert(contentsOf: repeatElement(ASCII.forwardSlash.codePoint, count: Int(n)), at: 0)
+      mutating func visitEmptyPathComponent() {
+        utf8.insert(ASCII.forwardSlash.codePoint, at: 0)
       }
       mutating func visitInputPathComponent(_ pathComponent: InputString.SubSequence) {
         utf8.insert(contentsOf: pathComponent, at: 0)

--- a/Sources/WebURL/URLStorage+Setters.swift
+++ b/Sources/WebURL/URLStorage+Setters.swift
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 
+// Inlining:
+// The setter implementations in URLStorage are all `@inlinable @inline(never)`, so they will be specialized
+// but never inlined. They are accessed via generic entrypoints in UTF8View, which use `@inline(__always)`,
+// so withContiguousStorageIfAvailable can be eliminated and call the correct specialization directly.
+
+
 // --------------------------------------------
 // MARK: - Scheme
 // --------------------------------------------

--- a/Sources/WebURL/Util/ManagedArrayBuffer.swift
+++ b/Sources/WebURL/Util/ManagedArrayBuffer.swift
@@ -131,7 +131,7 @@ internal struct AltManagedBufferReference<Header: ManagedBufferHeader, Element> 
   ///
   /// - Note: This pointer is valid only for the duration of the call to `body`.
   ///
-  @inlinable
+  @inlinable @inline(__always)
   internal func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
@@ -142,7 +142,7 @@ internal struct AltManagedBufferReference<Header: ManagedBufferHeader, Element> 
   ///
   /// - Note: This pointer is valid only for the duration of the call to `body`.
   ///
-  @inlinable
+  @inlinable @inline(__always)
   internal func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
@@ -153,7 +153,7 @@ internal struct AltManagedBufferReference<Header: ManagedBufferHeader, Element> 
   ///
   /// - Note: These pointers are valid only for the duration of the call to `body`.
   ///
-  @inlinable
+  @inlinable @inline(__always)
   internal func withUnsafeMutablePointers<R>(
     _ body: (UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
@@ -439,12 +439,12 @@ extension ManagedArrayBuffer: RandomAccessCollection {
     i &- 1
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   internal func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {
     try withUnsafeBufferPointer(body)
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   internal mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
@@ -520,7 +520,7 @@ extension ManagedArrayBuffer {
 
 extension ManagedArrayBuffer {
 
-  @inlinable
+  @inlinable @inline(__always)
   internal func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
@@ -529,7 +529,7 @@ extension ManagedArrayBuffer {
     }
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   internal mutating func withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
@@ -540,7 +540,7 @@ extension ManagedArrayBuffer {
     }
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   internal func withUnsafeBufferPointer<R>(
     range: Range<Index>, _ block: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {

--- a/Sources/WebURL/WebURL+UTF8View.swift
+++ b/Sources/WebURL/WebURL+UTF8View.swift
@@ -357,6 +357,12 @@ extension WebURL.UTF8View {
 // --------------------------------------------
 
 
+// Inlining:
+// The setter implementations in URLStorage are all `@inlinable @inline(never)`, so they will be specialized
+// but never inlined. The generic entrypoints here use `@inline(__always)`, so withContiguousStorageIfAvailable
+// can be eliminated and call the correct specialization directly.
+
+
 extension WebURL.UTF8View {
 
   /// A slice containing the scheme of this URL.
@@ -398,7 +404,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setScheme(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setScheme<UTF8Bytes>(
     _ newScheme: UTF8Bytes
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -448,7 +454,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setUsername(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setUsername<UTF8Bytes>(
     _ newUsername: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -503,7 +509,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setPassword(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setPassword<UTF8Bytes>(
     _ newPassword: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -556,7 +562,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setHostname(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setHostname<UTF8Bytes>(
     _ newHostname: UTF8Bytes?
   ) throws where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
@@ -627,7 +633,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setPath(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setPath<UTF8Bytes>(
     _ newPath: UTF8Bytes
   ) throws where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
@@ -679,7 +685,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setQuery(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setQuery<UTF8Bytes>(
     _ newQuery: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {
@@ -734,7 +740,7 @@ extension WebURL.UTF8View {
   ///
   /// - ``WebURL/WebURL/setFragment(_:)``
   ///
-  @inlinable
+  @inlinable @inline(__always)
   public mutating func setFragment<UTF8Bytes>(
     _ newFragment: UTF8Bytes?
   ) throws where UTF8Bytes: Collection, UTF8Bytes.Element == UInt8 {


### PR DESCRIPTION
Small code size improvement:

```
Title                              Section             Old             New  Percent
WebURLBenchmark                     __text:        1425601         1421009    -0.3%
```

Also some small performance improvements. The numbers are so tight that it's almost margin-of-error, but long paths going from 92ms to 78ms looks significant. We're hitting the point of diminishing returns, where even a 10% improvement amounts to ~2.5ms, which is difficult to reliably measure. In any case, this looks like it's moving in the right direction, the code looks nicer, and looking at the generated assembly, the gains seem realistic.

Before:

```
name                                                   time         std        iterations warmup         
---------------------------------------------------------------------------------------------------------
Constructor.SpecialNonFile.AverageURLs                 27093.000 ns ±  21.15 %      50830  6862462.000 ns
Constructor.SpecialNonFile.AverageURLs filtered        43105.000 ns ±  24.54 %      29515  4397805.000 ns
Constructor.SpecialNonFile.IPv4 host                   26586.000 ns ±  24.66 %      48909  2682248.000 ns
Constructor.SpecialNonFile.IPv4 host filtered          35014.000 ns ±  23.59 %      36598  3813488.000 ns
Constructor.SpecialNonFile.IPv6 host                   27508.000 ns ±  25.92 %      46141  3953910.000 ns
Constructor.SpecialNonFile.IPv6 host filtered          34646.500 ns ±  25.42 %      36586  3496124.000 ns
Constructor.SpecialNonFile.Percent-encoding components 11103.000 ns ±  28.59 %     120104  1128002.000 ns
Constructor.SpecialNonFile.Percent-encoded hostnames    9559.000 ns ±  25.98 %     137210  1029788.000 ns
Constructor.SpecialNonFile.Long paths                  92709.500 ns ±  21.19 %      13776 11634195.000 ns
Constructor.SpecialNonFile.Complex paths 1             26439.000 ns ±  23.22 %      49379  3268694.000 ns
Constructor.SpecialNonFile.Complex paths 2             32399.000 ns ±  24.43 %      39485  4699926.000 ns
Constructor.SpecialNonFile.Long query 1                 2445.000 ns ±  39.59 %     533375   321357.000 ns
Constructor.SpecialNonFile.Long query 2                21525.500 ns ±  23.29 %      58662  2854033.000 ns
```

After:

```
name                                                   time         std        iterations warmup        
--------------------------------------------------------------------------------------------------------
Constructor.SpecialNonFile.AverageURLs                 24860.000 ns ±  13.54 %      51832 3118901.000 ns
Constructor.SpecialNonFile.AverageURLs filtered        40453.000 ns ±  13.20 %      32265 4314659.000 ns
Constructor.SpecialNonFile.IPv4 host                   23958.000 ns ±  15.75 %      54709 2461829.000 ns
Constructor.SpecialNonFile.IPv4 host filtered          34855.000 ns ±  11.76 %      38040 3624207.000 ns
Constructor.SpecialNonFile.IPv6 host                   25037.000 ns ±  16.08 %      53182 2600285.000 ns
Constructor.SpecialNonFile.IPv6 host filtered          32421.000 ns ±  13.48 %      40545 3427260.000 ns
Constructor.SpecialNonFile.Percent-encoding components 10134.000 ns ±  16.55 %     119120 1148119.000 ns
Constructor.SpecialNonFile.Percent-encoded hostnames    8949.000 ns ±  14.63 %     149105  989243.000 ns
Constructor.SpecialNonFile.Long paths                  78507.000 ns ±   9.45 %      17017 8044446.000 ns
Constructor.SpecialNonFile.Complex paths 1             24138.000 ns ±   9.95 %      54900 2501131.000 ns
Constructor.SpecialNonFile.Complex paths 2             29436.000 ns ±  13.00 %      43328 3051703.000 ns
Constructor.SpecialNonFile.Long query 1                 2305.000 ns ±  27.23 %     545664  286796.000 ns
Constructor.SpecialNonFile.Long query 2                20301.000 ns ±  11.60 %      63377 2173905.000 ns
```