### PR TITLE
Fix WebURLSystemExtras on iOS, but for older versions of Xcode this time

### DIFF
--- a/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
+++ b/Sources/WebURLSystemExtras/WebURL+FilePaths+System.swift
@@ -39,9 +39,12 @@ import WebURL
 
     /// Creates a `file:` URL representation of the given `FilePath`.
     ///
-    /// The given path must be absolute and must not contain any components which traverse to their parent directories (`..` components).
-    /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path if it is not.
-    /// Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `..` components.
+    /// The given path must be absolute and must not contain any components which traverse to their parent directories
+    /// (`".."` components).
+    ///
+    /// Use the `FilePath.isAbsolute` property to check that the path is absolute, and resolve it against a base path
+    /// if it is not. Use the `FilePath.lexicallyNormalize` or `.lexicallyResolving` methods to resolve any `".."`
+    /// components.
     ///
     /// - parameters:
     ///   - filePath: The file path from which to create the file URL.
@@ -66,8 +69,9 @@ import WebURL
     /// The given URL must be a `file:` URL representation of an absolute path according to this system's path format.
     /// The resulting `FilePath` is both absolute and lexically normalized.
     ///
-    /// On Windows, the reconstructed path is first interpreted as UTF-8. Should it not contain valid UTF-8, it will be interpreted
-    /// using the system's active code-page and converted to its Unicode representation.
+    /// On Windows, the reconstructed path is first interpreted as UTF-8.
+    /// Should it not contain valid UTF-8, it will be interpreted using the system's active code-page
+    /// and converted to its Unicode representation.
     ///
     /// - parameters:
     ///   - url: The file URL from which to reconstruct the file path.
@@ -171,7 +175,8 @@ private protocol PlatformStringConversionsProtocol {
 
   /// Converts a null-terminated buffer of platform characters to a null-terminated buffer of bytes.
   ///
-  /// If the platform string is known to contain textual code-points, the buffer passed to `body` will be encoded with UTF-8.
+  /// If the platform string is known to contain textual code-points,
+  /// the buffer passed to `body` will be encoded with UTF-8.
   ///
   static func toMultiByte<ResultType>(
     _ platformString: UnsafeBufferPointer<CInterop_PlatformChar>,
@@ -180,7 +185,8 @@ private protocol PlatformStringConversionsProtocol {
 
   /// Converts a null-terminated buffer of bytes to a null-terminated platform string.
   ///
-  /// If the platform string requires its contents to be textual code-points, this function will attempt to infer the encoding of the bytes.
+  /// If the platform string requires its contents to be textual code-points,
+  /// this function will attempt to infer the encoding of the bytes.
   ///
   static func fromMultiByte<ResultType>(
     _ mbString: UnsafeBufferPointer<UInt8>,
@@ -258,10 +264,14 @@ private protocol PlatformStringConversionsProtocol {
       return try transcoded.withUnsafeBufferPointer(body)
     }
 
-    /// Interprets `input` as a string in the fallback code-page and attempts to transcode it to UTF-16, storing the result in `output`.
+    /// Interprets `input` as a string in the fallback code-page and attempts to transcode it to UTF-16,
+    /// storing the result in `output`.
     ///
-    /// Note that `input` must be null-terminated, and the result will be null-terminated. `output` will have its contents replaced with the resulting string
-    /// and will be resized as needed, reusing any previously-allocated capacity if possible. If transcoding fails, the contents of `output` are unspecified.
+    /// Note that `input` must be null-terminated, and the result will be null-terminated.
+    /// `output` will have its contents replaced with the resulting string and will be resized as needed,
+    /// reusing any previously-allocated capacity if possible.
+    ///
+    /// If transcoding fails, the contents of `output` are unspecified.
     ///
     /// - returns: `true` if transcoding was successful, otherwise `false`.
     ///

--- a/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
+++ b/Tests/WebURLSystemExtrasTests/SystemFilePathTests.swift
@@ -659,75 +659,77 @@ final class SystemFilePathTests: XCTestCase {}
   // --------------------------------------------
 
 
-  #if canImport(System) && !os(iOS) /* FB9832953 - System.framework for iOS is broken in Xcode 13. Last tested: Xcode 13.2.1 */
-    import System
+  #if !os(iOS)  // FB9832953 - System.framework for iOS is broken in Xcode 13. Last tested: Xcode 13.2.1
+    #if canImport(System)
+      import System
 
-    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
-    extension System.FilePath: POSIXFilePathProtocol {
+      @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+      extension System.FilePath: POSIXFilePathProtocol {
 
-      func toURL() throws -> WebURL {
-        try WebURL(filePath: self)
-      }
-      func toString() -> String {
-        String(decoding: self)
-      }
-    }
-
-    // Requires beta SDK:
-    // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    // extension System.FilePath: POSIXFilePathProtocolV2 {}
-    // + add testRelativePaths_framework
-
-    extension SystemFilePathTests {
-
-      func testASCII_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testASCII()
-        } else {
-          try XCTSkipIf(true)
+        func toURL() throws -> WebURL {
+          try WebURL(filePath: self)
+        }
+        func toString() -> String {
+          String(decoding: self)
         }
       }
 
-      func testUnicode_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testUnicode()
-        } else {
-          try XCTSkipIf(true)
-        }
-      }
+      // Requires beta SDK:
+      // @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+      // extension System.FilePath: POSIXFilePathProtocolV2 {}
+      // + add testRelativePaths_framework
 
-      func testUnpairedSurrogateInURL_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInURL()
-        } else {
-          try XCTSkipIf(true)
-        }
-      }
+      extension SystemFilePathTests {
 
-      func testUnpairedSurrogateInFilePath_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInFilePath()
-        } else {
-          try XCTSkipIf(true)
+        func testASCII_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testASCII()
+          } else {
+            try XCTSkipIf(true)
+          }
         }
-      }
 
-      func testLatin1_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testLatin1()
-        } else {
-          try XCTSkipIf(true)
+        func testUnicode_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testUnicode()
+          } else {
+            try XCTSkipIf(true)
+          }
         }
-      }
 
-      func testGreek_framework() throws {
-        if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
-          try POSIXFilePathTestSpecs<System.FilePath>.testGreek()
-        } else {
-          try XCTSkipIf(true)
+        func testUnpairedSurrogateInURL_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInURL()
+          } else {
+            try XCTSkipIf(true)
+          }
+        }
+
+        func testUnpairedSurrogateInFilePath_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testUnpairedSurrogateInFilePath()
+          } else {
+            try XCTSkipIf(true)
+          }
+        }
+
+        func testLatin1_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testLatin1()
+          } else {
+            try XCTSkipIf(true)
+          }
+        }
+
+        func testGreek_framework() throws {
+          if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+            try POSIXFilePathTestSpecs<System.FilePath>.testGreek()
+          } else {
+            try XCTSkipIf(true)
+          }
         }
       }
-    }
-  #endif  // canImport(System)
+    #endif  // canImport(System)
+  #endif  // !os(iOS)
 
 #endif  // !os(Windows)


### PR DESCRIPTION
Previous fix worked for me, but apparently not for `swiftpackageindex.com`