### PR TITLE
Initial WebURL-to-Foundation conversion

### DIFF
--- a/Sources/WebURL/SPIs.swift
+++ b/Sources/WebURL/SPIs.swift
@@ -58,7 +58,7 @@ extension WebURL {
 
 extension WebURL._SPIs {
 
-  /// Whether or not this URL's scheme is considered "special".
+  /// Whether this URL's scheme is considered "special".
   ///
   /// > Important:
   /// > This property is not considered part of WebURL's supported API.
@@ -67,6 +67,17 @@ extension WebURL._SPIs {
   @inlinable
   public var _isSpecial: Bool {
     _url.schemeKind.isSpecial
+  }
+
+  /// Whether this URL contains a path sigil.
+  ///
+  /// > Important:
+  /// > This property is not considered part of WebURL's supported API.
+  /// > Please **do not use** it. It may disappear, or its behavior may change, at any time.
+  ///
+  @inlinable
+  public var _hasPathSigil: Bool {
+    _url.storage.structure.hasPathSigil
   }
 }
 
@@ -183,6 +194,20 @@ extension WebURL._SPIs {
     case .empty:
       return .empty
     }
+  }
+
+  /// Whether this URL's host is an IPv6 address.
+  ///
+  /// > Important:
+  /// > This property is not considered part of WebURL's supported API.
+  /// > Please **do not use** it. It may disappear, or its behavior may change, at any time.
+  ///
+  @inlinable
+  public var _isIPv6: Bool {
+    if case .some(.ipv6Address) = _url.hostKind {
+      return true
+    }
+    return false
   }
 }
 

--- a/Sources/WebURL/SPIs.swift
+++ b/Sources/WebURL/SPIs.swift
@@ -70,6 +70,12 @@ extension WebURL._SPIs {
   }
 }
 
+
+// --------------------------------------------
+// MARK: - Path Parsing
+// --------------------------------------------
+
+
 extension WebURL._SPIs {
 
   /// Returns a simplified path string, formed by parsing the given string
@@ -122,6 +128,12 @@ extension WebURL._SPIs {
   }
 }
 
+
+// --------------------------------------------
+// MARK: - Hosts
+// --------------------------------------------
+
+
 extension WebURL._SPIs {
 
   /// The host of this URL.
@@ -171,5 +183,240 @@ extension WebURL._SPIs {
     case .empty:
       return .empty
     }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - Percent-Encoding
+// --------------------------------------------
+
+
+extension WebURL._SPIs {
+
+  /// The result of an operation which adds percent-encoding to URL components in-place.
+  ///
+  /// Either percent-encoding was added, or it wasn't, or the operation failed because we would exceed
+  /// `URLStorage.SizeType.max`. In the latter case, it is possible that some components were encoded and some not.
+  ///
+  /// > Important:
+  /// > This type, any nested types, and all of their static/member functions, are not considered
+  /// > part of WebURL's supported API. Please **do not use** these APIs.
+  /// > They may disappear, or their behavior may change, at any time.
+  ///
+  public enum _AddPercentEncodingResult {
+    case doesNotNeedEncoding
+    case encodingAdded
+    case exceededMaximumCapacity
+
+    @inlinable
+    internal static func += (lhs: inout Self, rhs: Self) {
+      switch (lhs, rhs) {
+      case (.exceededMaximumCapacity, _):
+        assertionFailure("Operation has already failed, nothing more should be combined")
+      case (_, .exceededMaximumCapacity):
+        lhs = .exceededMaximumCapacity
+      case (.doesNotNeedEncoding, .encodingAdded):
+        lhs = .encodingAdded
+      case (.encodingAdded, .encodingAdded),
+        (.doesNotNeedEncoding, .doesNotNeedEncoding),
+        (.encodingAdded, .doesNotNeedEncoding):
+        break
+      }
+    }
+  }
+
+  /// Adds percent-encoding to the specified characters in all URL components.
+  ///
+  /// Note that this is not the same as straight percent-encoding each component;
+  /// this function only adds encoding for characters that are not already part of a percent-encoded byte sequence.
+  /// This ensures that a single round of decoding produces the same result before and after this operation,
+  /// rather than introducing nested percent-encoding.
+  ///
+  /// For example, if the encode-set includes the `"%"` sign itself, `"%hello"` would be encoded to `"%25hello"`,
+  /// but `"%AB"` would remain as `"%AB"`.
+  ///
+  /// - No encoding is added to domains or IP addresses, since they do not support percent-encoding.
+  /// - Encoding is only added to list-style paths.
+  /// - The given encode-set must not contain:
+  ///   - the ASCII forward slash (`"/"`, 0x2F),
+  ///   - ampersand (`"&"`, 0x26),
+  ///   - plus sign (`"+"`, 0x2B), or
+  ///   - equals-sign (`"="`, 0x3D) code-points.
+  ///
+  /// > Important:
+  /// > This property is not considered part of WebURL's supported API.
+  /// > Please **do not use** it. It may disappear, or its behavior may change, at any time.
+  ///
+  @inlinable @inline(never)
+  public mutating func _addPercentEncodingToAllComponents<EncodeSet>(
+    _ encodeSet: EncodeSet
+  ) -> _AddPercentEncodingResult where EncodeSet: PercentEncodeSet {
+
+    // Since we're only _adding_ percent-encoding to the contents of each component (not including its delimiters),
+    // and we exclude internal subdelimiters for the path and query params, we can just encode the code-units directly
+    // rather than going through the setter functions.
+    precondition(!encodeSet.shouldPercentEncode(ascii: ASCII.forwardSlash.codePoint), "'/' must not be encoded")
+    precondition(!encodeSet.shouldPercentEncode(ascii: ASCII.plus.codePoint), "'+' must not be encoded")
+    precondition(!encodeSet.shouldPercentEncode(ascii: ASCII.equalSign.codePoint), "'=' must not be encoded")
+    precondition(!encodeSet.shouldPercentEncode(ascii: ASCII.ampersand.codePoint), "'&' must not be encoded")
+
+    var result = _AddPercentEncodingResult.doesNotNeedEncoding
+    var buffer = [UInt8]()
+
+    // Username and Password.
+    result += _addPercentEncodingInPlace(_url.utf8.username, encodeSet: encodeSet, buffer: &buffer) {
+      structure, newLength in structure.usernameLength = newLength
+    }
+    if case .exceededMaximumCapacity = result { return result }
+
+    result += _addPercentEncodingInPlace(_url.utf8.password, encodeSet: encodeSet, buffer: &buffer) {
+      structure, newLength in structure.passwordLength = newLength + 1
+    }
+    if case .exceededMaximumCapacity = result { return result }
+
+    // Hostname (opaque hosts only; we can't add percent-encoding to domains or IP addresses).
+    if case .opaque = _url.storage.structure.hostKind {
+      result += _addPercentEncodingInPlace(_url.utf8.hostname, encodeSet: encodeSet, buffer: &buffer) {
+        structure, newLength in structure.hostnameLength = newLength
+      }
+    }
+    if case .exceededMaximumCapacity = result { return result }
+
+    // Path.
+    if !_url.hasOpaquePath {
+      let pathResult = _addPercentEncodingInPlace(_url.utf8.path, encodeSet: encodeSet, buffer: &buffer) {
+        structure, newLength in structure.pathLength = newLength
+      }
+      if case .encodingAdded = pathResult {
+        let newPath = _url.utf8.path
+        _url.storage.structure.firstPathComponentLength = URLStorage.SizeType(
+          _url.storage.endOfPathComponent(startingAt: newPath.startIndex)! - newPath.startIndex
+        )
+      }
+      result += pathResult
+      if case .exceededMaximumCapacity = result { return result }
+    }
+
+    // Query.
+    result += _addPercentEncodingInPlace(_url.utf8.query, encodeSet: encodeSet, buffer: &buffer) {
+      structure, newLength in
+      structure.queryLength = newLength + 1
+      structure.queryIsKnownFormEncoded = false
+    }
+    if case .exceededMaximumCapacity = result { return result }
+
+    // Fragment.
+    result += _addPercentEncodingInPlace(_url.utf8.fragment, encodeSet: encodeSet, buffer: &buffer) {
+      structure, newLength in structure.fragmentLength = newLength + 1
+    }
+
+    return result
+  }
+
+  /// Adds percent-encoding to the given range of code-units in-place.
+  ///
+  /// Note that this is not the same as straight percent-encoding the component;
+  /// this function only adds encoding for characters that are not already part of a percent-encoded byte sequence.
+  /// This ensures that a single round of decoding produces the same result before and after this operation,
+  /// rather than introducing nested percent-encoding.
+  ///
+  /// For example, if the encode-set includes the `"%"` sign itself, `"%hello"` would be encoded to `"%25hello"`,
+  /// but `"%AB"` would remain as `"%AB"`.
+  ///
+  @inlinable
+  internal mutating func _addPercentEncodingInPlace<EncodeSet: PercentEncodeSet>(
+    _ codeUnits: WebURL.UTF8View.SubSequence?,
+    encodeSet: EncodeSet,
+    buffer: inout [UInt8],
+    adjustStructure: (inout URLStructure<URLStorage.SizeType>, _ newLength: URLStorage.SizeType) -> Void
+  ) -> _AddPercentEncodingResult {
+    guard
+      let component = codeUnits, !component.isEmpty,
+      case .encodingAdded = _addPercentEncoding(component, encodeSet: encodeSet, buffer: &buffer)
+    else {
+      return .doesNotNeedEncoding
+    }
+    // Ensure the URL string's new total length won't overflow the maximum total length.
+    let oldComponent = Range(uncheckedBounds: (component.startIndex, component.endIndex))
+    let newTotalLength = _url.storage.codeUnits.count - oldComponent.count + buffer.count
+    guard
+      let _ = URLStorage.SizeType(exactly: newTotalLength),
+      let newComponentLength = URLStorage.SizeType(exactly: buffer.count)
+    else {
+      return .exceededMaximumCapacity
+    }
+    // Replace the code-units, then adjust the structure.
+    _url.storage.codeUnits.replaceSubrange(oldComponent, with: buffer)
+    adjustStructure(&_url.storage.structure, newComponentLength)
+    return .encodingAdded
+  }
+}
+
+/// Adds percent-encoding to the given range of code-units.
+///
+/// Note that this is not the same as straight percent-encoding the code-units;
+/// this function only adds encoding for characters that are not already part of a percent-encoded byte sequence.
+/// This ensures that a single round of decoding either the source or encoded result produces the same end result,
+/// rather than introducing nested percent-encoding.
+///
+/// For example, if the encode-set includes the `"%"` sign itself, `"%hello"` would be encoded to `"%25hello"`,
+/// but `"%AB"` would remain as `"%AB"`.
+///
+/// - parameters:
+///   - source:    The code-units to add percent-encoding to.
+///   - encodeSet: The set of characters to encode.
+///   - buffer:    A pre-allocated buffer to store the result in to.
+///
+/// - returns: Whether or not percent-encoding was added to `source`. If the result is `encodingAdded`,
+///            the percent-encoded string will be contained in `buffer`. If the result is `doesNotNeedEncoding`,
+///            the contents of `buffer` are unspecified.
+///
+@inlinable
+internal func _addPercentEncoding<Source, EncodeSet>(
+  _ source: Source,
+  encodeSet: EncodeSet,
+  buffer: inout [UInt8]
+) -> WebURL._SPIs._AddPercentEncodingResult
+where Source: Collection, Source.Element == UInt8, EncodeSet: PercentEncodeSet {
+
+  buffer.removeAll(keepingCapacity: true)
+
+  let decoded = source.lazy.percentDecoded()
+
+  var startOfContiguousRange = source.startIndex
+
+  var i = decoded.startIndex
+  while i < decoded.endIndex {
+    if !decoded.isByteDecodedOrUnsubstituted(at: i), encodeSet.shouldPercentEncode(ascii: decoded[i]) {
+      // We need to encode something. Copy contiguous source bytes until this point.
+      let contiguousRange = Range(uncheckedBounds: (startOfContiguousRange, decoded.sourceIndices(at: i).lowerBound))
+      // But first - if the buffer is an empty array, give it some actual capacity.
+      if buffer.capacity < 512 {
+        let capacity = max(source.distance(from: contiguousRange.lowerBound, to: contiguousRange.upperBound) * 2, 512)
+        buffer.reserveCapacity(capacity)
+      }
+      if !contiguousRange.isEmpty {
+        buffer += source[contiguousRange]
+      }
+      // Append the encoded byte.
+      withPercentEncodedString(decoded[i]) { utf8 in
+        buffer += utf8
+      }
+      // Start a new contiguous range following this byte.
+      decoded.formIndex(after: &i)
+      startOfContiguousRange = decoded.sourceIndices(at: i).lowerBound
+
+    } else {
+      // The byte is already encoded, or doesn't need to be encoded. Keep the contiguous range going.
+      decoded.formIndex(after: &i)
+    }
+  }
+
+  if startOfContiguousRange == source.startIndex {
+    return .doesNotNeedEncoding
+  } else {
+    buffer += source[startOfContiguousRange...]
+    return .encodingAdded
   }
 }

--- a/Sources/WebURLFoundationExtras/StringAdditions.swift
+++ b/Sources/WebURLFoundationExtras/StringAdditions.swift
@@ -1,0 +1,53 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --------------------------------------------
+// MARK: - Contiguous UTF-8
+// --------------------------------------------
+// Copied from WebURL/Util/StringAdditions.swift
+
+
+extension StringProtocol {
+
+  /// Calls `body` with this string's contents in a contiguous UTF-8 buffer.
+  ///
+  /// - If this is already a native String/Substring, its contiguous storage will be used directly.
+  /// - Otherwise, it will be copied to contiguous storage.
+  ///
+  @inlinable @inline(__always)
+  internal func _withContiguousUTF8<Result>(_ body: (UnsafeBufferPointer<UInt8>) throws -> Result) rethrows -> Result {
+    if let resultWithExistingStorage = try utf8.withContiguousStorageIfAvailable(body) {
+      return resultWithExistingStorage
+    }
+    var copy = String(self)
+    return try copy.withUTF8(body)
+  }
+}
+
+extension Optional where Wrapped: StringProtocol {
+
+  /// Calls `body` with this string's contents in a contiguous UTF-8 buffer.
+  ///
+  /// - If this value is `nil`, `body` is invoked with `nil`.
+  /// - If this is already a native String/Substring, its contiguous storage will be used directly.
+  /// - Otherwise, it will be copied to contiguous storage.
+  ///
+  @inlinable @inline(__always)
+  internal func _withContiguousUTF8<Result>(_ body: (UnsafeBufferPointer<UInt8>?) throws -> Result) rethrows -> Result {
+    switch self {
+    case .some(let string): return try string._withContiguousUTF8(body)
+    case .none: return try body(nil)
+    }
+  }
+}

--- a/Sources/WebURLFoundationExtras/WebURLToFoundation.swift
+++ b/Sources/WebURLFoundationExtras/WebURLToFoundation.swift
@@ -1,0 +1,468 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WebURL
+
+// --------------------------------------------
+// MARK: - WebURL to Foundation
+// --------------------------------------------
+//
+// Because WebURLs are normalized, and Foundation's parser is strict, there is generally no additional normalization
+// which needs to be checked for compatibility with the WHATWG URL Standard. It's still important to verify
+// that the components have equivalent values, however "equivalence" for components can be simplified
+// to exact string equality.
+//
+// The most important thing we need to consider is that the WHATWG standard tolerates some (technically invalid)
+// characters which Foundation doesn't, so we offer (optional) percent-encoding to ensure that more URLs
+// can be successfully converted.
+//
+// ============ END ============
+
+
+extension Foundation.URL {
+
+  /// Creates a Foundation `URL` equivalent to the given `WebURL`.
+  ///
+  /// If any URL component contains the following characters, they will be percent-encoded:
+  ///
+  /// - Curly braces (`{}`)
+  /// - Backslashes (`\`)
+  /// - Circumflex accents (`^`)
+  /// - Backticks (`` ` ``)
+  /// - Vertical bars (`|`).
+  /// - Square brackets (`[]`), unless used to delimit an IPv6 address.
+  /// - Number signs (`#`), unless used to delimit the URL's fragment.
+  /// - Percent signs (`%`), unless used to delimit a percent-encoded byte.
+  ///
+  /// ```swift
+  /// "https://example.com/products?id={uuid}"
+  /// // original:                     ^    ^
+  /// "https://example.com/products?id=%7Buuid%7D"
+  /// // encoded:                      ^^^    ^^^
+  /// ```
+  ///
+  /// `WebURL`, in common with all major browsers, allows these characters even if they are not encoded,
+  /// but Foundation's `URL` does not. You may opt-out of this by setting the `addPercentEncoding` parameter to `false`,
+  /// but doing so will mean that URLs containing the above characters cannot be converted.
+  ///
+  /// - parameters:
+  ///   - webURL:             The URL to convert
+  ///   - addPercentEncoding: Whether characters disallowed by Foundation should be percent-encoded.
+  ///                         The default is `true`.
+  ///
+  public init?(_ webURL: WebURL, addPercentEncoding: Bool = true) {
+
+    // Foundation will percent-encode some disallowed characters on its own (`[]`, but not `{}` etc).
+    // If the user explicitly asked to opt-out of encoding, we should fail rather than let it do that.
+    var encodedCopy = webURL
+    switch encodedCopy._spis._addPercentEncodingToAllComponents(RFC2396DisallowedSubdelims()) {
+    case .encodingAdded:
+      guard addPercentEncoding else { return nil }
+    case .exceededMaximumCapacity:
+      return nil
+    case .doesNotNeedEncoding:
+      break
+    }
+
+    self.init(string: encodedCopy.serialized())
+
+    var foundationURLString = self.absoluteString
+    let isEquivalent = foundationURLString.withUTF8 {
+      WebURL._SPIs._checkEquivalence_w2f(encodedCopy, self, foundationString: $0, shortcuts: true)
+    }
+    guard isEquivalent else { return nil }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - URL Equivalence
+// --------------------------------------------
+
+
+extension WebURL._SPIs {
+
+  /// Returns whether the given WebURL and Foundation.URL have an equivalent set of components.
+  ///
+  /// This function assumes that the Foundation.URL has been parsed from a serialized WebURL.
+  /// That means it assumes components in the Foundation URL are already normalized
+  /// (for example, that the scheme has been lowercased, and hostnames that are IP-address are in their canonical form),
+  /// and that it may perform simpler/stricter equivalence checks.
+  ///
+  /// Getting components from Foundation can be very expensive, even if the value is nil.
+  /// If `shortcuts` is `true`, this function takes steps to avoid checking each individual component:
+  /// for example, if Foundation's URL string does not contain a `"@"` character anywhere, it is assumed
+  /// that `foundationURL` will return `nil` for both username or password, and we can check that `webURL` agrees
+  /// rather than actually calling Foundation's getters.
+  ///
+  /// These shortcuts should not reduce the effectiveness of this function (i.e. it should not fail to catch any
+  /// differences in interpretation between Foundation and WebURL), but only if `foundationURL` has been parsed
+  /// from `webURL.serialized()`. The shortcuts are verified by testing, including fuzz-testing.
+  ///
+  /// - parameters:
+  ///   - webURL:           A WebURL value to compare for equivalence.
+  ///   - foundationURL:    A Foundation.URL value to compare for equivalence.
+  ///   - foundationString: A buffer containing the UTF-8 contents of `foundationURL.absoluteString`.
+  ///   - shortcuts:        Whether to allow shortcuts for faster equivalence checks.
+  ///                       Only safe if `foundationURL` has been parsed from `webURL.serialized()`.
+  ///
+  /// - returns: Whether `webURL` and `foundationURL` have an equivalent set of URL components.
+  ///
+  /// > Important:
+  /// > This function is not considered part of WebURL's supported API.
+  /// > Please **do not use** it. It may disappear, or its behavior may change, at any time.
+  ///
+  public static func _checkEquivalence_w2f(
+    _ webURL: WebURL, _ foundationURL: Foundation.URL, foundationString: UnsafeBufferPointer<UInt8>, shortcuts: Bool
+  ) -> Bool {
+
+    // Scheme:
+
+    guard foundationURL.scheme?._withContiguousUTF8({ webURL.utf8.scheme.fastElementsEqual($0) }) == true else {
+      return false
+    }
+
+    // Foundation.URLs with opaque paths (e.g. "mailto:") return nil/empty for all components except the scheme.
+    // That said, they are surprisingly common, so we can't just reject them. Allow them without verification 😐.
+
+    guard !webURL.hasOpaquePath else {
+      if shortcuts {
+        // For some reason, if a URL with opaque path has a fragment, Foundation percent-encodes the '#'.
+        return webURL.utf8.fragment == nil
+      } else {
+        return checkURLWithOpaquePathEquivalenceUsingURLComponents_w2f(webURL, foundationURL)
+      }
+    }
+
+    // [Shortcut] Quick Scan:
+    // Getting components from Foundation is expensive, even if the component is 'nil'. So take a shortcut:
+    // if a component's delimiter is not present anywhere in Foundation's URL string, the component is also not present.
+
+    var assumeNoUserInfo = false
+    var assumeNoQuery = false
+    var assumeNoFragment = false
+
+    if shortcuts {
+      (assumeNoUserInfo, assumeNoQuery, assumeNoFragment) = (
+        !foundationString.fastContains(UInt8(ascii: "@")),
+        !foundationString.fastContains(UInt8(ascii: "?")),
+        !foundationString.fastContains(UInt8(ascii: "#"))
+      )
+    }
+
+    // Username & Password:
+
+    if assumeNoUserInfo {
+      assert(shortcuts)
+      guard webURL.utf8.username == nil, webURL.utf8.password == nil else {
+        return false
+      }
+    } else {
+      guard checkUserInfoEquivalence_w2f(webURL, foundationURL) else {
+        return false
+      }
+    }
+
+    // Host:
+
+    let hostOK = foundationURL.host._withContiguousUTF8 { foundationHost -> Bool in
+      switch (webURL.utf8.hostname, foundationHost) {
+      case (.some(var webURLHost), .some(let foundationHost)):
+        if webURL._spis._isSpecial || webURL._spis._isIPv6 {
+          // Foundation.URL.host doesn't include square brackets in IPv6 addresses.
+          if webURL._spis._isIPv6 {
+            let first = webURLHost.popFirst()
+            let last = webURLHost.popLast()
+            assert(first == UInt8(ascii: "["))
+            assert(last == UInt8(ascii: "]"))
+          }
+          return webURLHost.fastElementsEqual(foundationHost)
+        }
+        return webURLHost.lazy.percentDecoded().fastElementsEqual(foundationHost)
+      case (.none, .none):
+        return true
+      case (.some(let webURLHost), .none):
+        // Foundation.URL.host is nil for empty hostnames.
+        return webURLHost.isEmpty
+      default:
+        return false
+      }
+    }
+    guard hostOK else { return false }
+
+    // Port:
+
+    guard webURL.port == foundationURL.port else {
+      return false
+    }
+
+    // Path:
+    // The only thing we have to verify is whether WebURL and Foundation.URL agree about which
+    // part of the URL string contains the path.
+    //
+    // Unfortunately, that is difficult to check directly, as Foundation.URL only returns percent-decoded paths.
+    // We can sometimes overcome it by using URLComponents, but the conversion is expensive and unreliable.
+
+    // [Shortcut] Skip Path:
+    // Since we have verified all components preceding the path, if we also verify the component following the path
+    // (or reach the end of the string), we may infer that WebURL and Foundation.URL agree about which part
+    // of the URL string was the URL's path component.
+
+    if !shortcuts {
+      guard checkPathEquivalenceUsingURLComponents_w2f(webURL, foundationURL) else {
+        return false
+      }
+    }
+
+    // Query:
+
+    var queryIsPresent = false
+    let webURLQuery = webURL.utf8.query
+
+    if assumeNoQuery {
+      assert(shortcuts)
+      guard webURLQuery == nil else {
+        return false
+      }
+    } else {
+      let queryOK = foundationURL.query._withContiguousUTF8 { foundationQuery -> Bool in
+        switch (webURLQuery, foundationQuery) {
+        case (.some(let webURLQuery), .some(let foundationQuery)):
+          queryIsPresent = true
+          return webURLQuery.fastElementsEqual(foundationQuery)
+        case (.none, .none):
+          return true
+        default:
+          return false
+        }
+      }
+      guard queryOK else { return false }
+    }
+
+    // [Shortcut] Skip Fragment:
+    // If we have seen and verified a query component, that serves to verify the path, and implies that
+    // WebURL and Foundation.URL also agree about which part of the string contains the URL's fragment.
+
+    guard !queryIsPresent || !shortcuts else {
+      return true
+    }
+
+    // Fragment:
+
+    let webURLFragment = webURL.utf8.fragment
+
+    if assumeNoFragment {
+      assert(shortcuts)
+      guard webURLFragment == nil else {
+        return false
+      }
+    } else {
+      let fragmentOK = foundationURL.fragment._withContiguousUTF8 { foundationFragment -> Bool in
+        switch (webURLFragment, foundationFragment) {
+        case (.some(let webURLFragment), .some(let foundationFragment)):
+          return webURLFragment.fastElementsEqual(foundationFragment)
+        case (.none, .none):
+          return true
+        default:
+          return false
+        }
+      }
+      guard fragmentOK else { return false }
+    }
+
+    // All Checks Passed. The URLs appear to contain equivalent components.
+    return true
+  }
+
+  /// Returns whether the given WebURL and Foundation.URL have an equivalent set of user-info components.
+  ///
+  /// This function is deliberately outlined from `_checkEquivalence`.
+  ///
+  @inline(never)
+  private static func checkUserInfoEquivalence_w2f(_ webURL: WebURL, _ foundationURL: URL) -> Bool {
+
+    // If a URL has no username but does have a password (e.g. "http://:password@host/"),
+    // Foundation returns that the username is empty, but WebURL returns nil.
+    // That's a safe difference, but only if both agree that a password is present.
+    var emptyUsernameRequiresPasswordCheck = false
+
+    // Username:
+
+    let userOK = foundationURL.user._withContiguousUTF8 { foundationUser -> Bool in
+      switch (webURL.utf8.username, foundationUser) {
+      case (.some(let webURLUsername), .some(let foundationUser)):
+        return webURLUsername.lazy.percentDecoded().fastElementsEqual(foundationUser)
+      case (.none, .none):
+        return true
+      case (.none, .some(let foundationUser)):
+        emptyUsernameRequiresPasswordCheck = true
+        return foundationUser.isEmpty
+      default:
+        return false
+      }
+    }
+    guard userOK else { return false }
+
+    // Password:
+
+    let passwordOK = foundationURL.password._withContiguousUTF8 { foundationPassword -> Bool in
+      switch (webURL.utf8.password, foundationPassword) {
+      case (.some(let webURLPassword), .some(let foundationPassword)):
+        emptyUsernameRequiresPasswordCheck = false
+        return webURLPassword.fastElementsEqual(foundationPassword)
+      case (.none, .none):
+        return true
+      default:
+        return false
+      }
+    }
+    guard passwordOK, !emptyUsernameRequiresPasswordCheck else { return false }
+
+    return true
+  }
+
+  /// Returns whether the given WebURL and Foundation.URL (as interpreted by URLComponents) have an equivalent path,
+  /// although it is not possible to verify in all circumstances.
+  ///
+  @inline(never)
+  private static func checkPathEquivalenceUsingURLComponents_w2f(
+    _ webURL: WebURL, _ foundationURL: URL
+  ) -> Bool {
+
+    guard let fndRawPath = URLComponents(url: foundationURL, resolvingAgainstBaseURL: true)?.percentEncodedPath else {
+      return true  // Unable to validate.
+    }
+    guard !fndRawPath.isEmpty, !fndRawPath.utf8.lazy.percentDecoded().fastContains(UInt8(ascii: ";")) else {
+      return true  // Unable to validate.
+    }
+    guard !fndRawPath.utf8.fastContains(UInt8(ascii: "\\")) else {
+      return false  // Should not be present.
+    }
+
+    let webURLPath: WebURL.UTF8View.SubSequence
+    // Path sigils are not considered part of the path by WebURL.
+    if webURL._spis._hasPathSigil {
+      webURLPath = webURL.utf8[webURL.utf8.scheme.endIndex..<webURL.utf8.path.endIndex].dropFirst()
+    } else {
+      webURLPath = webURL.utf8.path
+    }
+    return fndRawPath._withContiguousUTF8 { webURLPath.fastElementsEqual($0) }
+  }
+
+  /// Returns whether the given WebURL and Foundation.URL (as interpreted by URLComponents) have an equivalent
+  /// set of components, given that the URL has an opaque path.
+  ///
+  /// It is not possible to verify the components in all circumstances.
+  ///
+  @inline(never)
+  private static func checkURLWithOpaquePathEquivalenceUsingURLComponents_w2f(
+    _ webURL: WebURL, _ foundationURL: URL
+  ) -> Bool {
+
+    assert(webURL.hasOpaquePath)
+
+    guard let foundationComponents = URLComponents(url: foundationURL, resolvingAgainstBaseURL: true) else {
+      return true  // Unable to validate.
+    }
+
+    // Opaque path:
+
+    let foundationPath = foundationComponents.percentEncodedPath
+    guard !foundationPath.utf8.lazy.percentDecoded().fastContains(UInt8(ascii: ";")) else {
+      return true  // Unable to validate.
+    }
+    guard foundationPath._withContiguousUTF8({ webURL.utf8.path.fastElementsEqual($0) }) else {
+      return false
+    }
+
+    // Query:
+
+    let queryOK = foundationComponents.percentEncodedQuery._withContiguousUTF8 { foundationQuery -> Bool in
+      switch (webURL.utf8.query, foundationQuery) {
+      case (.some(let webURLQuery), .some(let foundationQuery)):
+        return webURLQuery.fastElementsEqual(foundationQuery)
+      case (.none, .none):
+        return true
+      default:
+        return false
+      }
+    }
+    guard queryOK else { return false }
+
+    // Fragment:
+
+    let fragmentOK = foundationComponents.percentEncodedFragment._withContiguousUTF8 { foundationFragment -> Bool in
+      switch (webURL.utf8.fragment, foundationFragment) {
+      case (.some(let webURLFragment), .some(let foundationFragment)):
+        return webURLFragment.fastElementsEqual(foundationFragment)
+      case (.none, .none):
+        return true
+      default:
+        return false
+      }
+    }
+
+    return fragmentOK
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - PercentEncodeSets
+// --------------------------------------------
+
+
+/// Code-points banned by RFC-2396 for use as subcomponent delimiters.
+///
+/// RFC-2396 forbids the following code-points from being used unless escaped.
+/// These are the `control`, `space`, and `delims` character sets.
+///
+/// | Characters    | Bytes       |                                                                 |
+/// |---------------|-------------|-----------------------------------------------------------------|
+/// | C0 Controls   |  0x00-0x1F  | Already encoded by WebURL in all components.                    |
+/// | Space         |    0x20     | Already encoded by WebURL in all components.                    |
+/// | "             |    0x22     | Already encoded by WebURL in all components.                    |
+/// | < >           |  0x3C,0x3E  | Already encoded by WebURL in all components.                    |
+/// | U+007F DELETE |    0x7F     | Already encoded by WebURL in all components.                    |
+/// | #             |    0x23     | Allowed by WebURL in the fragment, e.g. `"sc:/foo#abc#def#gh"`. |
+/// | %             |    0x25     | Allowed by WebURL, e.g. `"%ZZ"`.                                |
+///
+/// Additionally, the following code-points comprise the `unwise` character set.
+///
+/// | Characters | Bytes       |                    |
+/// |------------|-------------|--------------------|
+/// |     [ ]    |  0x5B,0x5D  | Allowed by WebURL. |
+/// |      \     |    0x5C     | Allowed by WebURL. |
+/// |      ^     |    0x5E     | Allowed by WebURL. |
+/// |     \`     |    0x60     | Allowed by WebURL. |
+/// |     { }    |  0x7B,0x7D  | Allowed by WebURL. |
+/// |     \|     |    0x7C     | Allowed by WebURL. |
+///
+/// https://www.rfc-editor.org/rfc/rfc2396#section-2.4.3
+///
+internal struct RFC2396DisallowedSubdelims: PercentEncodeSet {
+
+  internal func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
+    //                 FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210_FEDCBA98_76543210
+    let lo: UInt64 = 0b01010000_00000000_00000000_00101101_11111111_11111111_11111111_11111111
+    let hi: UInt64 = 0b00111000_00000000_00000000_00000001_01111000_00000000_00000000_00000000
+    if codePoint < 64 {
+      return lo & (1 &<< codePoint) != 0
+    } else if codePoint < 128 {
+      return hi & (1 &<< (codePoint &- 64)) != 0
+    }
+    return true
+  }
+}

--- a/Tests/WebURLFoundationExtrasTests/WebToFoundationTests.swift
+++ b/Tests/WebURLFoundationExtrasTests/WebToFoundationTests.swift
@@ -1,0 +1,275 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WebURL
+import WebURLTestSupport
+import XCTest
+
+@testable import WebURLFoundationExtras
+
+/// Asserts that the given URLs contain an equivalent set of components,
+/// without taking any shortcuts or making assumptions that they originate from the same string.
+///
+fileprivate func XCTAssertEquivalentURLs(_ webURL: WebURL, _ foundationURL: URL, _ message: String = "") {
+  var message = message
+  if !message.isEmpty {
+    message += " -- "
+  }
+  message += "Foundation: \(foundationURL) -- WebURL: \(webURL)"
+
+  var urlString = foundationURL.absoluteString
+  // Check using the simplified web-to-foundation equivalence checks.
+  var areEquivalent = urlString.withUTF8 {
+    WebURL._SPIs._checkEquivalence_w2f(webURL, foundationURL, foundationString: $0, shortcuts: false)
+  }
+  XCTAssertTrue(areEquivalent, "\(message) [WebToFoundation]")
+  // Also check using the foundation-to-web equivalence checks.
+  areEquivalent = urlString.withUTF8 {
+    WebURL._SPIs._checkEquivalence(webURL, foundationURL, foundationString: $0, shortcuts: false)
+  }
+  XCTAssertTrue(areEquivalent, "\(message) [FoundationToWeb]")
+}
+
+extension WebURL {
+  fileprivate var withEncodedRFC2396DisallowedSubdelims: WebURL {
+    var copy = self
+    let _ = copy._spis._addPercentEncodingToAllComponents(RFC2396DisallowedSubdelims())
+    return copy
+  }
+}
+
+final class WebToFoundationTests: ReportGeneratingTestCase {}
+
+
+// --------------------------------------------
+// MARK: - WPT Constructor Testcases
+// --------------------------------------------
+// These don't run full WPT constructor tests; they use the WPT test files as a database of quirky URLs
+// to test our conversion process on.
+
+
+extension WebToFoundationTests {
+
+  private static let conversionFailures_always: Set<Int> = [
+    // We don't add percent-encoding to a URL's opaque path.
+    9,  // Opaque path with space.
+    11,  // Opaque path with space.
+    354,  // Opaque path with unescaped backslash.
+    356,  // Opaque path with unescaped '%'.
+    357,  // Opaque path with unescaped '%'.
+
+    // If a URL has an opaque path and fragment, Foundation percent-encodes the '#'.
+    105,  // URL with opaque path and fragment.
+    165,  // URL with opaque path and fragment.
+    300,  // URL with opaque path and fragment.
+    301,  // URL with opaque path and fragment.
+    302,  // URL with opaque path and fragment.
+    303,  // URL with opaque path and fragment.
+    304,  // URL with opaque path and fragment.
+    333,  // URL with opaque path and fragment.
+    334,  // URL with opaque path and fragment.
+
+    // We can't add percent-encoding in domains.
+    387,  // Unescaped curly brackets, backtick.
+    623,  // Unescaped curly brackets, backtick.
+  ]
+  private static let conversionFailures_noAddedPercentEncoding: Set<Int> = {
+    var conversionFailures: Set<Int> = conversionFailures_always
+    conversionFailures.formUnion([
+      34,  // Unescaped backslash.
+      60,  // Unescaped hash.
+      63,  // Unescaped square brackets.
+      64,  // Unescaped square brackets.
+      139,  // Unescaped percent-sign.
+      146,  // Unescaped percent-sign.
+      147,  // Unescaped percent-sign.
+      148,  // Unescaped percent-sign.
+      149,  // Unescaped percent-sign.
+      307,  // Unescaped curly brackets, backtick.
+      345,  // Unescaped percent-sign.
+      388,  // Unescaped curly brackets, backtick.
+      480,  // Unescaped vertical bar.
+
+      591,  // Unescaped percent-sign.
+      593,  // Unescaped percent-sign.
+      618,  // Unescaped percent-sign.
+      619,  // Unescaped percent-sign.
+      620,  // Unescaped percent-sign.
+      621,  // Unescaped percent-sign.
+      622,  // Unescaped curly brackets, square brackets, backtick, backslash, vertical bar, etc.
+      624,  // Unescaped percent-sign, square brackets, vertical bar, etc.
+      625,  // Unescaped percent-sign, square brackets, vertical bar, etc.
+      626,  // Unescaped curly brackets, square brackets, backtick, backslash, vertical bar, etc.
+      627,  // Unescaped curly brackets, square brackets, backtick, backslash, vertical bar, etc.
+      628,  // Unescaped curly brackets, square brackets, backtick, backslash, vertical bar, etc.
+      629,  // Unescaped curly brackets, square brackets, backtick, backslash, vertical bar, etc.
+    ])
+    return conversionFailures
+  }()
+
+  func _doTestWPTTestCases(
+    addEncoding: Bool, isExpectedFailure: (Int) -> Bool
+  ) throws -> (report: SimpleTestReport, reportedResultCount: Int) {
+
+    let testFile = try loadTestFile(.WPTURLConstructorTests, as: WPTConstructorTest.TestFile.self)
+
+    var report = SimpleTestReport()
+    var idx = 0
+
+    for fileEntry in testFile {
+      switch fileEntry {
+      case .comment(let comment):
+        report.markSection(comment)
+      case .testcase(let testcase):
+        report.performTest { reporter in
+          defer { idx += 1 }
+          if isExpectedFailure(idx) {
+            reporter.expectedResult = .fail
+          }
+
+          // 1. Parse the (input, base) pair with WebURL.
+          guard let webURL = WebURL.JSModel(testcase.input, base: testcase.base)?.swiftModel else {
+            return
+          }
+          reporter.capture(key: "WebURL", webURL)
+
+          var encodedWebURL = webURL
+          if addEncoding {
+            encodedWebURL = encodedWebURL.withEncodedRFC2396DisallowedSubdelims
+            reporter.capture(key: "Encoded WebURL", encodedWebURL)
+          }
+
+          // 2. Convert to a Foundation URL.
+          guard let foundationURL = URL(webURL, addPercentEncoding: addEncoding) else {
+            reporter.fail("Failed to convert")
+            return
+          }
+          reporter.capture(key: "Foundation", foundationURL)
+
+          // 3. Check equivalence without shortcuts.
+          var foundationString = foundationURL.absoluteString
+          let isEquivalent = foundationString.withUTF8 {
+            WebURL._SPIs._checkEquivalence_w2f(encodedWebURL, foundationURL, foundationString: $0, shortcuts: false)
+          }
+          reporter.expectTrue(isEquivalent, "Equivalence")
+
+          // Finished.
+        }
+      }
+    }
+    return (report, idx)
+  }
+
+  func testWPTTestCases_withEncoding() throws {
+    let (report, resultCount) = try _doTestWPTTestCases(
+      addEncoding: true,
+      isExpectedFailure: { Self.conversionFailures_always.contains($0) }
+    )
+    XCTAssertEqual(resultCount, 666)
+    XCTAssertFalse(report.hasUnexpectedResults, "Test failed")
+
+    let reportURL = fileURLForReport(named: "webtofoundation_wpt_withEncoding.txt")
+    try report.generateReport().write(to: reportURL, atomically: false, encoding: .utf8)
+    print("ℹ️ Report written to \(reportURL)")
+  }
+
+  func testWPTTestCases_noEncoding() throws {
+    let (report, resultCount) = try _doTestWPTTestCases(
+      addEncoding: false,
+      isExpectedFailure: { Self.conversionFailures_noAddedPercentEncoding.contains($0) }
+    )
+    XCTAssertEqual(resultCount, 666)
+    XCTAssertFalse(report.hasUnexpectedResults, "Test failed")
+
+    let reportURL = fileURLForReport(named: "webtofoundation_wpt_noEncoding.txt")
+    try report.generateReport().write(to: reportURL, atomically: false, encoding: .utf8)
+    print("ℹ️ Report written to \(reportURL)")
+  }
+}
+
+
+extension WebToFoundationTests {
+
+  func testURLWithOpaquePath() {
+
+    // Opaque path with allowed characters.
+    test: do {
+      let url = WebURL("sc:foobar")!
+      guard let converted = URL(url) else {
+        XCTFail("Failed to convert URL \(url)")
+        break test
+      }
+      XCTAssertEquivalentURLs(url, converted)
+    }
+
+    // Opaque path with disallowed characters.
+    test: do {
+      let url = WebURL("sc:hello, world!")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+
+    // Opaque path with query.
+    test: do {
+      let url = WebURL("sc:foo?bar")!
+      guard let converted = URL(url) else {
+        XCTFail("Failed to convert URL \(url)")
+        break test
+      }
+      XCTAssertEquivalentURLs(url, converted)
+    }
+    test: do {
+      let url = WebURL("sc:foo?bar[baz]=qux")!
+      guard let converted = URL(url) else {
+        XCTFail("Failed to convert URL \(url)")
+        break test
+      }
+      XCTAssertEquivalentURLs(url.withEncodedRFC2396DisallowedSubdelims, converted)
+    }
+    test: do {
+      let url = WebURL("sc:hello world?bar")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+
+    // Opaque path with fragment.
+    // These should all fail because Foundation.URL encodes the '#'.
+    test: do {
+      let url = WebURL("sc:foo#bar")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+    test: do {
+      let url = WebURL("sc:foo#bar[baz]=qux")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+    test: do {
+      let url = WebURL("sc:hello world#bar")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+
+    // Opaque path with query and fragment.
+    // Should also fail for the same reason as above.
+    test: do {
+      let url = WebURL("sc:foo?bar#baz")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+    test: do {
+      let url = WebURL("sc:foo?bar#baz[qux]=qaz")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+    test: do {
+      let url = WebURL("sc:hello world?foo#bar")!
+      XCTAssertNil(URL(url), "Unexpected conversion: \(url)")
+    }
+  }
+}

--- a/Tests/WebURLFoundationExtrasTests/_ReportGeneratingTestCase.swift
+++ b/Tests/WebURLFoundationExtrasTests/_ReportGeneratingTestCase.swift
@@ -1,0 +1,29 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import XCTest
+
+class ReportGeneratingTestCase: XCTestCase {
+
+  private static let reportDir = ProcessInfo.processInfo.environment["SWIFT_URL_REPORT_PATH"] ?? NSTemporaryDirectory()
+
+  override class func setUp() {
+    try? FileManager.default.createDirectory(atPath: reportDir, withIntermediateDirectories: true, attributes: nil)
+  }
+
+  func fileURLForReport(named reportName: String) -> URL {
+    URL(fileURLWithPath: ReportGeneratingTestCase.reportDir).appendingPathComponent(reportName)
+  }
+}

--- a/Tests/WebURLTests/WebURLPercentEncodingUtilsTests.swift
+++ b/Tests/WebURLTests/WebURLPercentEncodingUtilsTests.swift
@@ -1,0 +1,323 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import WebURLTestSupport
+import XCTest
+
+@testable import WebURL
+
+class WebURLPercentEncodingUtilsTests: XCTestCase {}
+
+extension WebURLPercentEncodingUtilsTests {
+
+  func testDoesNotNeedEncoding() {
+
+    struct EncodeASCIIPeriods: PercentEncodeSet {
+      func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
+        codePoint == UInt8(ascii: ".")
+      }
+    }
+
+    func check<EncodeSet: PercentEncodeSet>(_ original: String, _ encodeSet: EncodeSet) {
+      let originalURL = WebURL(original)!
+      XCTAssertEqual(originalURL.serialized(), original)
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(encodeSet), .doesNotNeedEncoding)
+
+      // Check the serialization and structure are identical to the original.
+      XCTAssertEqual(encodedURL.serialized(), original)
+      XCTAssertTrue(encodedURL.storage.structure.describesSameStructure(as: originalURL.storage.structure))
+      encodedURL.storage.structure.checkInvariants()
+
+      // Check that the "modified" URL reparses to the same result.
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+
+    let componentSetWithoutSubdelims = URLEncodeSet.Component().withoutSubdelims
+
+    // No special characters.
+    check("https://example.com/foo/bar?baz#qux", componentSetWithoutSubdelims)
+    // IPv6 address.
+    check("https://[::ffff:c0a8:1]/foo/bar?baz#qux", componentSetWithoutSubdelims)
+    // Only percent-encoding.
+    check("https://example.com/fo%2Fo/b%5Br?b%7Cz#q%23x", componentSetWithoutSubdelims)
+    // Opaque path.
+    check("foo:abc[flag]`()\\{uuid}", componentSetWithoutSubdelims)
+
+    // Domain.
+    check("https://a.b.c.d/foo/bar?baz#qux", EncodeASCIIPeriods())
+    // IPv4 Address.
+    check("https://127.0.0.1/foo/bar?baz#qux", EncodeASCIIPeriods())
+  }
+
+  func testEmptyComponents() {
+
+    // Since this operation works on the URL's code-units and bypasses the regular setters,
+    // check a variety of edge-cases to make sure the URLStructure is as we expect.
+
+    let encodeSet = URLEncodeSet.Component().withoutSubdelims
+
+    func check(_ original: String, additionalStructureChecks: (URLStructure<URLStorage.SizeType>) -> Void = { _ in }) {
+      let originalURL = WebURL(original)!
+      XCTAssertEqual(originalURL.serialized(), original)
+      additionalStructureChecks(originalURL.storage.structure)
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(encodeSet), .doesNotNeedEncoding)
+
+      // Check the serialization and structure are identical to the original.
+      XCTAssertEqual(encodedURL.serialized(), original)
+      XCTAssertTrue(encodedURL.storage.structure.describesSameStructure(as: originalURL.storage.structure))
+      encodedURL.storage.structure.checkInvariants()
+      additionalStructureChecks(encodedURL.storage.structure)
+
+      // Check that the "modified" URL reparses to the same result.
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+
+    // Empty username.
+    check("https://:pass@test/foo?baz#qux")
+
+    // Nil hostname (path-only).
+    check("foo:/foo?baz#qux")
+    // Empty hostname.
+    check("foo:///foo?baz#qux")
+
+    // Empty path.
+    check("foo://host?baz#qux") { structure in XCTAssertEqual(structure.firstPathComponentLength, 0) }
+    // Root path.
+    check("foo://host/?baz#qux") { structure in XCTAssertEqual(structure.firstPathComponentLength, 1) }
+
+    // Nil query.
+    check("foo://host#qux") { structure in XCTAssertTrue(structure.queryIsKnownFormEncoded) }
+    // Empty query.
+    check("foo://host?#qux") { structure in XCTAssertTrue(structure.queryIsKnownFormEncoded) }
+
+    // Nil fragment.
+    check("foo://host?bar")
+    // Empty fragment.
+    check("foo://host?bar#")
+  }
+
+  func testAddingEncoding_firstPathComponent() {
+
+    // Check that we update the URLStructure's firstPathComponentLength when adding percent-encoding.
+
+    let encodeSet = URLEncodeSet.Component().withoutSubdelims
+
+    do {
+      let originalURL = WebURL("http://test/foo[flag:true]/bar")!
+      XCTAssertEqual(originalURL.storage.structure.firstPathComponentLength, 15)
+      XCTAssertEqual(originalURL.pathComponents.first, "foo[flag:true]")
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(encodeSet), .encodingAdded)
+
+      XCTAssertEqual(encodedURL.serialized(), "http://test/foo%5Bflag%3Atrue%5D/bar")
+      XCTAssertEqual(encodedURL.storage.structure.firstPathComponentLength, 21)
+      XCTAssertEqual(encodedURL.pathComponents.first, "foo[flag:true]")
+      encodedURL.storage.structure.checkInvariants()
+
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+    do {
+      let originalURL = WebURL("scheme:/foo[flag:true]/bar")!
+      XCTAssertEqual(originalURL.storage.structure.firstPathComponentLength, 15)
+      XCTAssertEqual(originalURL.pathComponents.first, "foo[flag:true]")
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(encodeSet), .encodingAdded)
+
+      XCTAssertEqual(encodedURL.serialized(), "scheme:/foo%5Bflag%3Atrue%5D/bar")
+      XCTAssertEqual(encodedURL.storage.structure.firstPathComponentLength, 21)
+      XCTAssertEqual(encodedURL.pathComponents.first, "foo[flag:true]")
+      encodedURL.storage.structure.checkInvariants()
+
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+  }
+
+  func testAddingEncoding_queryIsKnownFormEncoded() {
+
+    // Check that we reset the URLStructure's queryIsKnownFormEncoded when adding percent-encoding.
+
+    struct EncodeUnderscores: PercentEncodeSet {
+      func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
+        codePoint == UInt8(ascii: "_")
+      }
+    }
+
+    // If the encode-set does not include '+', '=', or '&', params will be preserved,
+    // but the 'queryIsKnownFormEncoded' flag will be reset because the query is over-encoded.
+    do {
+      var originalURL = WebURL("https://test/foo")!
+      originalURL.formParams.search = "res_taur_ants in NYC"
+      originalURL.formParams.cli_ent = "mobi_le"
+      XCTAssertEqual(originalURL.serialized(), "https://test/foo?search=res_taur_ants+in+NYC&cli_ent=mobi_le")
+      XCTAssertTrue(originalURL.storage.structure.queryIsKnownFormEncoded)
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(EncodeUnderscores()), .encodingAdded)
+
+      XCTAssertEqual(encodedURL.serialized(), "https://test/foo?search=res%5Ftaur%5Fants+in+NYC&cli%5Fent=mobi%5Fle")
+      XCTAssertFalse(encodedURL.storage.structure.queryIsKnownFormEncoded)
+      XCTAssertEqual(encodedURL.formParams.search, "res_taur_ants in NYC")
+      XCTAssertEqual(encodedURL.formParams.cli_ent, "mobi_le")
+      encodedURL.storage.structure.checkInvariants()
+
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+  }
+
+  func testAddingEncoding_digits() {
+
+    // Even if for some reason we decide to encode ASCII digits, characters which are part of
+    // percent-encoded bytes shouldn't be encoded. Also, the port number should never be encoded.
+
+    struct EncodeDigits: PercentEncodeSet {
+      func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
+        ASCII(codePoint)?.isDigit == true
+      }
+    }
+
+    let encodeSet = EncodeDigits()
+
+    do {
+      var url = WebURL("http://u%25s3r:pa55wo%25rd@h0st:99/p4t%23")!
+      XCTAssertEqual(url.serialized(), "http://u%25s3r:pa55wo%25rd@h0st:99/p4t%23")
+
+      XCTAssertEqual(url._spis._addPercentEncodingToAllComponents(encodeSet), .encodingAdded)
+      XCTAssertEqual(url.serialized(), "http://u%25s%33r:pa%35%35wo%25rd@h0st:99/p%34t%23")
+      XCTAssertEqual(url.port, 99)
+      url.storage.structure.checkInvariants()
+
+      XCTAssertURLIsIdempotent(url)
+    }
+    do {
+      var url = WebURL("scheme://u%25s3r:pa55wo%25rd@h0st:99/p4t%23")!
+      XCTAssertEqual(url.serialized(), "scheme://u%25s3r:pa55wo%25rd@h0st:99/p4t%23")
+
+      XCTAssertEqual(url._spis._addPercentEncodingToAllComponents(encodeSet), .encodingAdded)
+      XCTAssertEqual(url.serialized(), "scheme://u%25s%33r:pa%35%35wo%25rd@h%30st:99/p%34t%23")
+      XCTAssertEqual(url.port, 99)
+      url.storage.structure.checkInvariants()
+
+      XCTAssertURLIsIdempotent(url)
+    }
+  }
+
+  func testAddingEncoding() {
+
+    let encodeSet = URLEncodeSet.Component().withoutSubdelims
+
+    func check(_ original: String, encoded: String, additionalChecks: (WebURL) -> Void) {
+      let originalURL = WebURL(original)!
+      XCTAssertEqual(originalURL.serialized(), original)
+
+      var encodedURL = originalURL
+      XCTAssertEqual(encodedURL._spis._addPercentEncodingToAllComponents(encodeSet), .encodingAdded)
+
+      // Check that COW was triggered.
+      XCTAssertEqual(originalURL.serialized(), original)
+
+      XCTAssertEqual(encodedURL.serialized(), encoded)
+      encodedURL.storage.structure.checkInvariants()
+      additionalChecks(encodedURL)
+
+      XCTAssertURLIsIdempotent(encodedURL)
+    }
+
+    // Username
+    check("http://us%er$foo@test/", encoded: "http://us%25er%24foo@test/") { encodedURL in
+      XCTAssertEqual(encodedURL.username, "us%25er%24foo")
+    }
+
+    // Password
+    check("http://user:pa%s$@test/", encoded: "http://user:pa%25s%24@test/") { encodedURL in
+      XCTAssertEqual(encodedURL.password, "pa%25s%24")
+    }
+
+    // Opaque hostname
+    check("foo://h%o$t/", encoded: "foo://h%25o%24t/") { encodedURL in
+      XCTAssertEqual(encodedURL.hostname, "h%25o%24t")
+    }
+
+    // Path
+    check("foo://host/p[%1]/p^2^", encoded: "foo://host/p%5B%251%5D/p%5E2%5E") { encodedURL in
+      XCTAssertEqual(encodedURL.path, "/p%5B%251%5D/p%5E2%5E")
+      XCTAssertEqualElements(encodedURL.pathComponents, ["p[%1]", "p^2^"])
+    }
+
+    // Query
+    check(
+      "foo://host?color[R]=100&color{%G}=233&color|B|=42",
+      encoded: "foo://host?color%5BR%5D=100&color%7B%25G%7D=233&color%7CB%7C=42"
+    ) { encodedURL in
+      XCTAssertEqual(encodedURL.query, "color%5BR%5D=100&color%7B%25G%7D=233&color%7CB%7C=42")
+      XCTAssertEqual(encodedURL.formParams.get("color[R]"), "100")
+      XCTAssertEqual(encodedURL.formParams.get("color{%G}"), "233")
+      XCTAssertEqual(encodedURL.formParams.get("color|B|"), "42")
+    }
+
+    // Fragment
+    check("foo://test#abc#d%%zef[#]ghi^|", encoded: "foo://test#abc%23d%25%25zef%5B%23%5Dghi%5E%7C") { encodedURL in
+      XCTAssertEqual(encodedURL.fragment, "abc%23d%25%25zef%5B%23%5Dghi%5E%7C")
+    }
+
+    // Many components.
+    check(
+      "https://test/foo[a]/b%ar|a|^1^?ba%z[a]{1}#qux[a]#%1",
+      encoded: "https://test/foo%5Ba%5D/b%25ar%7Ca%7C%5E1%5E?ba%25z%5Ba%5D%7B1%7D#qux%5Ba%5D%23%251"
+    ) { encodedURL in
+      XCTAssertURLComponents(
+        encodedURL, scheme: "https", hostname: "test", path: "/foo%5Ba%5D/b%25ar%7Ca%7C%5E1%5E",
+        query: "ba%25z%5Ba%5D%7B1%7D", fragment: "qux%5Ba%5D%23%251"
+      )
+    }
+    check(
+      "foo://te$%t/foo[a]/b%ar|a|^1^?ba%z[a]{1}#qux[a]#%1",
+      encoded: "foo://te%24%25t/foo%5Ba%5D/b%25ar%7Ca%7C%5E1%5E?ba%25z%5Ba%5D%7B1%7D#qux%5Ba%5D%23%251"
+    ) { encodedURL in
+      XCTAssertURLComponents(
+        encodedURL, scheme: "foo", hostname: "te%24%25t", path: "/foo%5Ba%5D/b%25ar%7Ca%7C%5E1%5E",
+        query: "ba%25z%5Ba%5D%7B1%7D", fragment: "qux%5Ba%5D%23%251"
+      )
+    }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - Utils
+// --------------------------------------------
+
+
+fileprivate struct EncodeSetWithoutSubdelims<Base: PercentEncodeSet>: PercentEncodeSet {
+  var base: Base
+  func shouldPercentEncode(ascii codePoint: UInt8) -> Bool {
+    switch codePoint {
+    case UInt8(ascii: "/"), UInt8(ascii: "&"), UInt8(ascii: "+"), UInt8(ascii: "="):
+      return false
+    default:
+      return base.shouldPercentEncode(ascii: codePoint)
+    }
+  }
+}
+
+extension PercentEncodeSet {
+  fileprivate var withoutSubdelims: EncodeSetWithoutSubdelims<Self> {
+    EncodeSetWithoutSubdelims(base: self)
+  }
+}


### PR DESCRIPTION
Still needs:

- More tests, besides the WPT test cases
- Fuzzing
- Benchmarks (I have benchmarked it and it takes around the same time as Foundation-to-WebURL conversion; in both cases the limiting factor is getting components from Foundation)

When adding percent-encoding for disallowed characters, we can convert 650/666 tests in the WPT test suite (97.6%). Without encoding, that goes down to 624/666 (93.7%).

The URLs that fail when encoding are real outliers - URLs with opaque paths and domains with disallowed characters. Pretty much all WebURLs people might actually use will be convertible.