### PR TITLE
[ManagedArrayBuffer] Use static exclusivity enforcement rather than no enforcement

### DIFF
--- a/Sources/WebURL/Util/UnsafeBuffer+ReplaceSubrange.swift
+++ b/Sources/WebURL/Util/UnsafeBuffer+ReplaceSubrange.swift
@@ -33,7 +33,7 @@
 @usableFromInline
 internal protocol BufferContainer {
   associatedtype Element
-  func withUnsafeMutablePointerToElements<R>(_ body: (UnsafeMutablePointer<Element>) throws -> R) rethrows -> R
+  mutating func withUnsafeMutablePointerToElements<R>(_ body: (UnsafeMutablePointer<Element>) throws -> R) rethrows -> R
 }
 
 /// Given a `buffer`, representing an entire allocation in which `0..<initializedCount` are initialized elements
@@ -134,7 +134,7 @@ internal func replaceElements<T: BufferContainer>(
     }
     return (bufferCount: newCount, insertedCount: insertCount, newStorage: nil, newStorageCount: 0)
   }
-  let newStorage = storageConstructor(finalCount)
+  var newStorage = storageConstructor(finalCount)
   let srcBuffer = UnsafeMutableBufferPointer(rebasing: buffer.prefix(initializedCount))
   let newCount = newStorage.withUnsafeMutablePointerToElements { newBufferPtr -> Int in
     let newBuffer = UnsafeMutableBufferPointer(start: newBufferPtr, count: finalCount)


### PR DESCRIPTION
By making methods on AltManagedBufferReference mutating (even though they have reference semantics),
we can have the compiler enforce no local overlapping accesses to the header. Together with COW
ensuring that no non-local mutations will occur, we get full exclusivity enforcement without the runtime cost.

(I've checked that code such as example [here](https://forums.swift.org/t/managedbuffer-header-and-exclusivity/55013/5) gets caught at compile time. Can't add a test, because it wouldn't compile 😉 )

Also, while I'm here, improve the documentation comments.