### PR TITLE
[WebURLFoundationExtras] URLRequest/URLResponse/URLSession extensions

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,6 +1,4 @@
 // swift-tools-version:5.5
-// >> This should be identical to Package.swift,
-// >> except that targets may include ".docc" bundles.
 
 // Copyright The swift-url Contributors.
 //
@@ -41,7 +39,10 @@ let package = Package(
     // swift-system for WebURLSystemExtras.
     .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.0.0")),
 
-    // swift-checkit for testing protocol conformances. Test-only dependency.
+    // [Test Only] No-dependency HTTP server for testing Foundation extensions.
+    .package(name: "Swifter", url: "https://github.com/httpswift/swifter.git", .upToNextMajor(from: "1.5.0")),
+
+    // [Test Only] Checkit for testing protocol conformances.
     .package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", from: "0.0.2"),
   ],
   targets: [
@@ -79,6 +80,13 @@ let package = Package(
       name: "WebURLFoundationExtrasTests",
       dependencies: ["WebURLFoundationExtras", "WebURLTestSupport", "WebURL"],
       resources: [.copy("Resources")]
+    ),
+    .testTarget(
+      name: "WebURLFoundationExtensionsTests",
+      dependencies: [
+        "WebURLFoundationExtras", "WebURL",
+        .product(name: "Swifter", package: "Swifter", condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux]))
+      ]
     ),
   ]
 )

--- a/Sources/WebURLFoundationExtras/Extensions/URLRequestResponse.swift
+++ b/Sources/WebURLFoundationExtras/Extensions/URLRequestResponse.swift
@@ -1,0 +1,182 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: Some documentation comments are copied/adapted from Foundation,
+// and are (c) Apple Inc and the Swift project authors.
+
+import Foundation
+import WebURL
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// --------------------------------
+// MARK: - URLRequest
+// --------------------------------
+
+
+// On non-Apple platforms, executing a URLRequest whose url is nil will 'fatalError'.
+// Since that is how we prefer to signal conversion failures, we don't offer extensions to create
+// a URLRequest from a WebURL on those platforms. Fixed by https://github.com/apple/swift-corelibs-foundation/pull/3154
+#if canImport(Darwin)
+
+  extension URLRequest {
+
+    /// A URLRequest to be executed when a WebURL could not be converted to a Foundation.URL.
+    ///
+    /// Firstly, it is important to note that WebURL -> Foundation.URL conversion failures are very, very rare.
+    /// They occur for some URLs with opaque paths, and domains containing disallowed characters (e.g. curly braces),
+    /// but otherwise all WebURLs can be converted. Most users will never see a conversion failure in this direction.
+    ///
+    /// Typically, errors which occur while executing a `URLSessionTask` are communicated via the task's error property,
+    /// and the error parameter passed to delegate calls or the completion handler block. For example, making a request
+    /// to <foo>, or <foo://bar>, or executing a request whose `url` is `nil` all return errors in this way.
+    ///
+    /// However, subclasses such as `URLSessionDataTask` cannot be instantiated except though methods such as
+    /// `URLSession.dataTask(with: URLRequest)`, and there is no method to create a data task which always
+    /// immediately completes with an error.
+    ///
+    /// So our options are to either:
+    ///
+    /// 1. Have all of these extensions return optional tasks. The returned tasks would be `nil` for one _particular_
+    ///    and very rare kind of invalid URL, and all other invalid URLs would be notified via `URLSessionTask` errors
+    ///    as usual. Or...
+    ///
+    /// 2. Create a dummy `URLRequest` which we can execute, but is malformed in some way that guarantees
+    ///    it completes with an error, allowing users to handle all invalid URLs in the same way.
+    ///
+    /// We choose the latter approach. This request has a `nil` URL, resulting in a `.unsupportedURL` error.
+    ///
+    /// Technically, it is not entirely _guaranteed_ to return an error, because for some reason Foundation lets
+    /// you register `URLProtocol`s which process requests with a `nil` URL. It may be worth registering our own
+    /// `URLProtocol` as an additional safeguard, but that's a bit tricky because it depends on the
+    /// session configuration.
+    ///
+    /// Hopefully, one day we will get an API which allows us to return an error and bypasses `URLProtocol` entirely.
+    /// In the mean time, this is a reasonable compromise.
+    ///
+    internal static func requestForConversionFailure(
+      _ url: WebURL, cachePolicy: CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 60.0
+    ) -> URLRequest {
+      var req = URLRequest(url: URL(string: "invalid")!, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+      req.url = nil
+      assert(req.url == nil)
+      return req
+    }
+
+    /// Creates and initializes a URL request with the given URL, cache policy, and timeout interval.
+    ///
+    /// The given `url` will be converted to a `Foundation.URL` value and verified for equivalence.
+    /// Percent-encoding will only be added as part of that conversion if the `addPercentEncoding` parameter is `true`
+    /// (which is the default).
+    ///
+    /// It is very, very rare that a `WebURL` cannot be converted to a `Foundation.URL` despite adding percent-encoding.
+    /// If it does occur, the created request's `url` will be `nil`, and attempts to execute it will, by default,
+    /// fail with an `.unsupportedURL` error.
+    ///
+    /// - parameters:
+    ///   - url:                 The URL for the request.
+    ///   - addPercentEncoding:  Whether or not percent-encoding may be added to `url` in order to convert it
+    ///                          to a `Foundation.URL` value. The default is `true`.
+    ///   - cachePolicy:         The cache policy for the request. The default is `useProtocolCachePolicy`.
+    ///   - timeoutInterval:     The timeout interval for the request. The default is `60.0`.
+    ///                          See the commentary for the `timeoutInterval` for more information on timeout intervals.
+    ///
+    public init(
+      url: WebURL, addPercentEncoding: Bool = true,
+      cachePolicy: CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 60.0
+    ) {
+
+      // This is not failable, because WebURL -> Foundation.URL conversion failures are exceptionally rare.
+      // They can still happen, of course, but they are so uncommon that users should not have to consider
+      // that possibility every time they make a URLRequest using a WebURL.
+      //
+      // The only WebURLs which cannot be converted are:
+      //
+      // - URLs with opaque paths, if the path contains a forbidden character or fragment component.
+      //   This does not matter to http/s, ws/s, ftp or file URLs, as they cannot have opaque paths.
+      //
+      //   - The WHATWG URL standard allows these URLs to even contain non-percent-encoded spaces (!!!),
+      //     e.g. <javascript:alert("hello, world!")>, and encoding them is considered not web-compatible.
+      //
+      //   - Foundation.URL encodes fragments in these URLs by itself, e.g. <sc:#foo> becomes <sc:%23foo>,
+      //     but that seems like a bug. Hopefully it will be fixed one day. https://bugs.swift.org/browse/SR-15381
+      //
+      // - URLs with domains (i.e. special schemes like http/s), if the domain contains an invalid character.
+      //
+      //   For example, Foundation does not accept <http://loc{al}host/foo>. Percent-encoding the invalid characters
+      //   is awkward because the WHATWG URL Standard technically does not allow it, but we **could** do it
+      //   at the string level. If we decided that it preserved equivalence, of course -- who even knows
+      //   what "loc{al}host" is supposed to connect to, or what "loc%7Bal%7Dhost" actually connects to?
+
+      if let convertedURL = URL(url, addPercentEncoding: addPercentEncoding) {
+        self.init(url: convertedURL, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+      } else {
+        self = .requestForConversionFailure(url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+      }
+    }
+  }
+
+#endif  // canImport(Darwin)
+
+extension URLRequest {
+
+  /// The URL of the request.
+  ///
+  /// This property returns the request's `url`, converted to its equivalent `WebURL` value.
+  /// If the request was not created from a `WebURL` value (for example, if it was created by Foundation
+  /// as part of an HTTP redirect), it may be normalized in ways that the URL sent over the wire is not.
+  ///
+  /// When assigning to this property, the request's `url` is assigned to the equivalent `Foundation.URL`
+  /// of the new value.
+  ///
+  public var webURL: WebURL? {
+    get { url.flatMap { WebURL($0) } }
+    set { url = newValue.flatMap { URL($0) } }
+  }
+
+  /// The main document URL associated with this request.
+  ///
+  /// This property returns the request's `mainDocumentURL`, converted to its equivalent `WebURL` value.
+  /// If the request was not created from a `WebURL` value (for example, if it was created by Foundation
+  /// as part of an HTTP redirect), it may be normalized in ways that the URL sent over the wire is not.
+  ///
+  /// When assigning to this property, the request's `mainDocumentURL` is assigned to the equivalent `Foundation.URL`
+  /// of the new value.
+  ///
+  public var mainDocumentWebURL: WebURL? {
+    get { mainDocumentURL.flatMap { WebURL($0) } }
+    set { mainDocumentURL = newValue.flatMap { URL($0) } }
+  }
+}
+
+
+// --------------------------------
+// MARK: - URLResponse
+// --------------------------------
+
+
+extension URLResponse {
+
+  /// The URL for the response.
+  ///
+  /// This property returns the response's `url`, converted to its equivalent `WebURL` value.
+  /// If the request was not created from a `WebURL` value (for example, if it was created by Foundation
+  /// as part of an HTTP redirect), it may be normalized in ways that the URL sent over the wire is not.
+  ///
+  public var webURL: WebURL? {
+    url.flatMap { WebURL($0) }
+  }
+}

--- a/Sources/WebURLFoundationExtras/Extensions/URLSession.swift
+++ b/Sources/WebURLFoundationExtras/Extensions/URLSession.swift
@@ -1,0 +1,312 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: Some documentation comments are copied/adapted from Foundation,
+// and are (c) Apple Inc and the Swift project authors.
+
+import Foundation
+import WebURL
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// --------------------------------
+// MARK: - URLSessionDataTask
+// --------------------------------
+
+
+// On non-Apple platforms, executing a URLRequest whose url is nil will 'fatalError'.
+// Since that is how we prefer to signal conversion failures, we don't offer extensions to create
+// a URLRequest from a WebURL on those platforms. Fixed by https://github.com/apple/swift-corelibs-foundation/pull/3154
+#if canImport(Darwin)
+
+  extension URLSession {
+
+    /// Creates a task that retrieves the contents of the specified URL.
+    ///
+    /// After you create the task, you must start it by calling its `resume()` method.
+    /// The task calls methods on the session’s delegate to provide you with the response metadata,
+    /// response data, and so on.
+    ///
+    /// - parameters:
+    ///   - url:               The URL to be retrieved.
+    ///
+    /// - returns: The new session data task.
+    ///
+    public func dataTask(
+      with url: WebURL
+    ) -> URLSessionDataTask {
+      URL(url).map { dataTask(with: $0) }
+        ?? dataTask(with: .requestForConversionFailure(url))
+    }
+
+    /// Creates a task that retrieves the contents of the specified URL, then calls a handler upon completion.
+    ///
+    /// After you create the task, you must start it by calling its `resume()` method.
+    ///
+    /// By using the completion handler, the task bypasses calls to delegate methods for response and data delivery,
+    /// and instead provides any resulting `Data`, `URLResponse`, and `Error` objects inside the completion handler.
+    /// Delegate methods for handling authentication challenges, however, are still called.
+    /// The completion handler is executed on the delegate queue.
+    ///
+    /// - If the request completes successfully, the data parameter of the completion handler block contains
+    ///   the resource data, and the error parameter is `nil`.
+    /// - If the request fails, the data parameter is `nil` and the error parameter contains
+    ///   information about the failure.
+    /// - If a response from the server is received, regardless of whether the request completes successfully or fails,
+    ///   the response parameter contains that information. If you are making an HTTP or HTTPS request,
+    ///   the returned object is actually an `HTTPURLResponse` object.
+    ///
+    /// - parameters:
+    ///   - url:               The URL to be retrieved.
+    ///   - completionHandler: The completion handler to call when the load request is complete.
+    ///
+    /// - returns: The new session data task.
+    ///
+    public func dataTask(
+      with url: WebURL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
+      URL(url).map { dataTask(with: $0, completionHandler: completionHandler) }
+        ?? dataTask(with: .requestForConversionFailure(url), completionHandler: completionHandler)
+    }
+  }
+
+  #if canImport(Combine)
+
+    import Combine
+
+    extension URLSession {
+
+      /// Returns a publisher that wraps a URL session data task for a given URL.
+      ///
+      /// The publisher publishes data when the task completes, or terminates if the task fails with an error.
+      ///
+      /// - parameters:
+      ///   - url: The URL for which to create a data task.
+      ///
+      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+      public func dataTaskPublisher(
+        for url: WebURL
+      ) -> URLSession.DataTaskPublisher {
+        URL(url).map { dataTaskPublisher(for: $0) }
+          ?? dataTaskPublisher(for: .requestForConversionFailure(url))
+      }
+    }
+
+  #endif  // canImport(Combine)
+
+// swift 5.3 can't deal with an '#if swift' nested inside another conditional compilation clause,
+// so we have to interrupt this conditional around the async functions.
+#endif  // canImport(Darwin)
+
+#if swift(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
+
+  extension URLSession {
+
+    /// Retrieves the contents of a URL and delivers the data asynchronously.
+    ///
+    /// Use this method to wait until the session finishes transferring data and receive it in a single `Data` instance.
+    /// To process the bytes as the session receives them, use `bytes(from:delegate:)`.
+    ///
+    /// - parameters:
+    ///   - url:      The URL to retrieve.
+    ///   - delegate: A delegate that receives life cycle and authentication challenge callbacks
+    ///               as the transfer progresses.
+    ///
+    /// - returns: An asynchronously-delivered tuple that contains the URL contents as a `Data` instance,
+    ///            and a `URLResponse`.
+    ///
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func data(
+      from url: WebURL, delegate: URLSessionTaskDelegate? = nil
+    ) async throws -> (Data, URLResponse) {
+      guard let convertedURL = URL(url) else {
+        return try await data(for: .requestForConversionFailure(url), delegate: delegate)
+      }
+      return try await data(from: convertedURL, delegate: delegate)
+    }
+
+    /// Retrieves the contents of a given URL and delivers an asynchronous sequence of bytes.
+    ///
+    /// Use this method when you want to process the bytes while the transfer is underway.
+    /// You can use a `for-await-in` loop to handle each byte. For textual data, use the `URLSession.AsyncBytes`
+    /// properties `characters`, `unicodeScalars`, or `lines` to receive the content as asynchronous sequences
+    /// of those types. To wait until the session finishes transferring data and receive it in a single `Data` instance,
+    /// use `data(from:delegate:)`.
+    ///
+    /// - parameters:
+    ///   - url:      The URL to retrieve.
+    ///   - delegate: A delegate that receives life cycle and authentication challenge callbacks
+    ///               as the transfer progresses.
+    ///
+    /// - returns: An asynchronously-delivered tuple that contains a `URLSession.AsyncBytes` sequence to iterate over,
+    ///            and a `URLResponse`.
+    ///
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    public func bytes(
+      from url: WebURL, delegate: URLSessionTaskDelegate? = nil
+    ) async throws -> (URLSession.AsyncBytes, URLResponse) {
+      guard let convertedURL = URL(url) else {
+        return try await bytes(for: .requestForConversionFailure(url), delegate: delegate)
+      }
+      return try await bytes(from: convertedURL, delegate: delegate)
+    }
+  }
+
+#endif  // swift(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
+
+
+// --------------------------------
+// MARK: - URLSessionUploadTask
+// --------------------------------
+
+
+// TODO: How can we handle conversion failures for the body file URL?
+// - uploadTask(with: URLRequest, fromFile: URL)
+// - uploadTask(with: URLRequest, fromFile: URL, completionHandler: (Data?, URLResponse?, Error?) -> Void)
+
+
+// --------------------------------
+// MARK: - URLSessionDownloadTask
+// --------------------------------
+
+
+// See above - continues canImport(Darwin) that was interrupted for the async functions.
+#if canImport(Darwin)
+
+  extension URLSession {
+
+    /// Creates a download task that retrieves the contents of the specified URL and saves the results to a file.
+    ///
+    /// After you create the task, you must start it by calling its `resume()` method.
+    ///
+    /// - parameters:
+    ///   - url: The URL to download.
+    ///
+    /// - returns: The new session download task.
+    ///
+    public func downloadTask(with url: WebURL) -> URLSessionDownloadTask {
+      URL(url).map { downloadTask(with: $0) }
+        ?? downloadTask(with: .requestForConversionFailure(url))
+    }
+
+    /// Creates a download task that retrieves the contents of the specified URL, saves the results to a file,
+    /// and calls a handler upon completion.
+    ///
+    /// By using the completion handler, the task bypasses calls to delegate methods for response and data delivery,
+    /// and instead provides any resulting `WebURL`, `URLResponse`, and `Error` objects inside the completion handler.
+    /// Delegate methods for handling authentication challenges, however, are still called.
+    /// The completion handler is executed on the delegate queue.
+    ///
+    /// After you create the task, you must start it by calling its resume() method.
+    ///
+    /// - If the request completes successfully, the location parameter of the completion handler block
+    ///   contains the location of a temporary file where the server’s response is stored, and the error parameter
+    ///   is `nil`. You must move this file or open it for reading before your completion handler returns.
+    ///   Otherwise, the file is deleted, and the data is lost.
+    ///
+    /// - If the request fails, the location parameter is `nil` and the error parameter contains information
+    ///   about the failure.
+    ///
+    /// - If a response from the server is received, regardless of whether the request completes successfully or fails,
+    ///   the response parameter contains that information. If you are making an HTTP or HTTPS request,
+    ///   the returned object is actually an `HTTPURLResponse` object.
+    ///
+    /// - It is possible for both location and error to be `nil`. The best way to process the result is:
+    ///   if the temporary file location is not `nil`, use it, otherwise fail (if the error parameter is not `nil`,
+    ///   you can show that, otherwise fall-back to a generic failure message).
+    ///
+    /// - parameters:
+    ///   - url: The URL to download.
+    ///   - completionHandler: The completion handler to call when the load request is complete.
+    ///
+    /// - returns: The new session download task.
+    ///
+    public func downloadTask(
+      with url: WebURL, completionHandler: @escaping (WebURL?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDownloadTask {
+
+      let wrappedCompletionHandler = { (location: URL?, response: URLResponse?, error: Error?) -> Void in
+        // - If the temporary file location cannot be represented as a web-compatible URL,
+        //   we have no choice but to pass `nil` here, meaning both error and location parameters may be nil.
+        // - We could fix that by passing a non-nil error in, but that means the 'error' parameter may differ
+        //   from the task's 'error' property - which seems more subtle and probably a worse decision overall.
+        //   Also, the user couldn't really handle the error without dropping down to Foundation.URL.
+        // - This shouldn't be a problem for "file:" URLs, but Foundation has a lot of quirky stuff
+        //   (sandbox URLs, etc), so who knows? Foundation URLs really are nothing like actual URLs
+        //   so it's _not impossible_ that some of them cannot even be represented textually.
+        guard let fileURL = location, let convertedFileURL = WebURL(fileURL) else {
+          if let fileURL = location {
+            print("⚠️ Download task temporary file URL could not be converted to WebURL: \(fileURL)")
+          }
+          completionHandler(nil, response, error)
+          return
+        }
+        completionHandler(convertedFileURL, response, error)
+      }
+
+      return URL(url).map { downloadTask(with: $0, completionHandler: wrappedCompletionHandler) }
+        ?? downloadTask(with: .requestForConversionFailure(url), completionHandler: wrappedCompletionHandler)
+    }
+  }
+
+
+  // --------------------------------
+  // MARK: - URLSessionWebSocketTask
+  // --------------------------------
+
+
+  #if canImport(Darwin)  // URLSessionWebSocketTask is not implemented in swift-corelibs-foundation.
+
+    extension URLSession {
+
+      /// Creates a WebSocket task for the provided URL.
+      ///
+      /// The provided URL must have a ws or wss scheme.
+      ///
+      /// - parameters:
+      ///   - url:       The WebSocket URL with which to connect.
+      ///
+      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+      public func webSocketTask(with url: WebURL) -> URLSessionWebSocketTask {
+        URL(url).map { webSocketTask(with: $0) }
+          ?? webSocketTask(with: .requestForConversionFailure(url))
+      }
+
+      /// Creates a WebSocket task given a URL and an array of protocols.
+      ///
+      /// During the WebSocket handshake, the task uses the provided protocols to negotiate
+      /// a preferred protocol with the server.
+      ///
+      /// > Note:
+      /// > The protocol doesn’t affect the WebSocket framing.
+      /// > More details on the protocol are available in [RFC 6455, The WebSocket Protocol][rfc-6455].
+      ///
+      /// [rfc-6455]: https://datatracker.ietf.org/doc/html/rfc6455
+      ///
+      /// - parameters:
+      ///   - url:       The WebSocket URL with which to connect.
+      ///   - protocols: An array of protocols to negotiate with the server.
+      ///
+      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+      public func webSocketTask(with url: WebURL, protocols: [String]) -> URLSessionWebSocketTask {
+        URL(url).map { webSocketTask(with: $0, protocols: protocols) }
+          ?? webSocketTask(with: .requestForConversionFailure(url))
+      }
+    }
+
+  #endif  // canImport(Darwin)
+
+#endif  // canImport(Darwin)

--- a/Tests/WebURLFoundationExtensionsTests/URLRequestResponseTests.swift
+++ b/Tests/WebURLFoundationExtensionsTests/URLRequestResponseTests.swift
@@ -1,0 +1,225 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WebURL
+import WebURLFoundationExtras
+import XCTest
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+final class URLRequestTests: XCTestCase {}
+
+
+// --------------------------------
+// MARK: - Constructing a URLRequest
+// --------------------------------
+
+
+// On non-Apple platforms, executing a URLRequest whose url is nil will 'fatalError'.
+// Since that is how we prefer to signal conversion failures, we don't offer extensions to create
+// a URLRequest from a WebURL on those platforms. Fixed by https://github.com/apple/swift-corelibs-foundation/pull/3154
+#if canImport(Darwin)
+
+  extension URLRequestTests {
+
+    func testCreateRequest_simpleConversion() {
+      let webURL = WebURL("http://example.com/foo/bar?baz=qux")!
+      XCTAssertEqual(webURL.serialized(), "http://example.com/foo/bar?baz=qux")
+
+      let urlRequest = URLRequest(url: webURL)
+      XCTAssertEqual(urlRequest.url?.absoluteString, "http://example.com/foo/bar?baz=qux")
+      XCTAssertEqual(urlRequest.webURL, webURL)
+      XCTAssertEqual(urlRequest.webURL, webURL.encodedForFoundation)
+
+      XCTAssertEqual(urlRequest.mainDocumentURL, nil)
+      XCTAssertEqual(urlRequest.mainDocumentWebURL, nil)
+    }
+
+    func testCreateRequest_addPercentEncoding() {
+      let webURL = WebURL("http://example.com/foo/bar?baz=[qux]")!
+      XCTAssertEqual(webURL.serialized(), "http://example.com/foo/bar?baz=[qux]")
+
+      // The default behavior is to add percent-encoding.
+      do {
+        let urlRequest = URLRequest(url: webURL)
+        XCTAssertEqual(urlRequest.url?.absoluteString, "http://example.com/foo/bar?baz=%5Bqux%5D")
+        XCTAssertEqual(urlRequest.webURL?.serialized(), "http://example.com/foo/bar?baz=%5Bqux%5D")
+        XCTAssertEqual(urlRequest.webURL, webURL.encodedForFoundation)
+
+        XCTAssertEqual(urlRequest.mainDocumentURL, nil)
+        XCTAssertEqual(urlRequest.mainDocumentWebURL, nil)
+      }
+      // If we explicitly set 'addPercentEncoding' to false, the conversion will fail.
+      do {
+        let urlRequest = URLRequest(url: webURL, addPercentEncoding: false)
+        XCTAssertEqual(urlRequest.url, nil)
+        XCTAssertEqual(urlRequest.webURL, nil)
+
+        XCTAssertEqual(urlRequest.mainDocumentURL, nil)
+        XCTAssertEqual(urlRequest.mainDocumentWebURL, nil)
+      }
+    }
+
+    func testCreateRequest_conversionFailure() {
+      let webURL = WebURL("http://ex{am}ple.com/")!
+      XCTAssertEqual(webURL.serialized(), "http://ex{am}ple.com/")
+
+      let urlRequest = URLRequest(url: webURL)
+      XCTAssertEqual(urlRequest.url, nil)
+      XCTAssertEqual(urlRequest.webURL, nil)
+
+      XCTAssertEqual(urlRequest.mainDocumentURL, nil)
+      XCTAssertEqual(urlRequest.mainDocumentWebURL, nil)
+    }
+  }
+
+#endif
+
+
+// --------------------------------
+// MARK: - URLRequest Getters/Setters
+// --------------------------------
+
+
+extension URLRequestTests {
+
+  func testWebURLProperty_simpleConversion() {
+    // Construct a URLRequest with a Foundation.URL.
+    var request = URLRequest(url: URL(string: "http://example.com/foo/bar?baz=qux")!)
+
+    // Get the converted URL via the .webURL property.
+    XCTAssertEqual(request.url?.absoluteString, "http://example.com/foo/bar?baz=qux")
+    XCTAssertEqual(request.webURL?.serialized(), "http://example.com/foo/bar?baz=qux")
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+
+    // Set the URL via the .webURL property. Percent-encoding should be added as needed.
+    let webURL = WebURL("https://localhost/qux/baz?bar=[foo]")!
+    XCTAssertEqual(webURL.serialized(), "https://localhost/qux/baz?bar=[foo]")
+
+    request.webURL = webURL
+    XCTAssertEqual(request.url?.absoluteString, "https://localhost/qux/baz?bar=%5Bfoo%5D")
+    XCTAssertEqual(request.webURL, webURL.encodedForFoundation)
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+  }
+
+  func testWebURLProperty_getterConversionFailure() {
+    // Construct a URLRequest with a Foundation.URL.
+    var request = URLRequest(url: URL(string: "foo")!)
+
+    // The URL is relative and cannot be converted to a WebURL.
+    XCTAssertEqual(request.url?.absoluteString, "foo")
+    XCTAssertEqual(request.webURL, nil)
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+
+    // Set the URL to a convertible WebURL via the .webURL property.
+    let webURL = WebURL("https://localhost/qux/baz?bar=foo")!
+    XCTAssertEqual(webURL.serialized(), "https://localhost/qux/baz?bar=foo")
+
+    request.webURL = webURL
+    XCTAssertEqual(request.url?.absoluteString, "https://localhost/qux/baz?bar=foo")
+    XCTAssertEqual(request.webURL, webURL.encodedForFoundation)
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+  }
+
+  func testWebURLProperty_setterConversionFailure() {
+    // Construct a URLRequest with a Foundation.URL.
+    var request = URLRequest(url: URL(string: "http://example.com/foo/bar?baz=qux")!)
+
+    // Get the converted URL via the .webURL property.
+    XCTAssertEqual(request.url?.absoluteString, "http://example.com/foo/bar?baz=qux")
+    XCTAssertEqual(request.webURL?.serialized(), "http://example.com/foo/bar?baz=qux")
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+
+    // Set the URL via the .webURL property. The URL cannot be converted to a Foundation.URL.
+    let webURL = WebURL("https://loc{alh}ost/qux/baz?bar=foo")!
+    XCTAssertEqual(webURL.serialized(), "https://loc{alh}ost/qux/baz?bar=foo")
+
+    request.webURL = webURL
+    XCTAssertEqual(request.url, nil)
+    XCTAssertEqual(request.webURL, nil)
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+  }
+
+  func testMainDocumentWebURLProperty() {
+    // Construct a URLRequest with a Foundation.URL. The value doesn't matter.
+    var request = URLRequest(url: URL(string: "foo")!)
+    XCTAssertEqual(request.url?.absoluteString, "foo")
+    XCTAssertEqual(request.webURL, nil)
+
+    XCTAssertEqual(request.mainDocumentURL, nil)
+    XCTAssertEqual(request.mainDocumentWebURL, nil)
+
+    // Set the mainDocumentWebURL to a convertible WebURL value. Percent-encoding should be added as needed.
+    do {
+      let webURL = WebURL("http://example.com/foo/bar?baz=[qux]")!
+      XCTAssertEqual(webURL.serialized(), "http://example.com/foo/bar?baz=[qux]")
+
+      request.mainDocumentWebURL = webURL
+      XCTAssertEqual(request.url?.absoluteString, "foo")
+      XCTAssertEqual(request.webURL, nil)
+      XCTAssertEqual(request.mainDocumentURL?.absoluteString, "http://example.com/foo/bar?baz=%5Bqux%5D")
+      XCTAssertEqual(request.mainDocumentWebURL, webURL.encodedForFoundation)
+    }
+
+    // Set the mainDocumentWebURL to a non-convertible WebURL value. Should set the value to nil.
+    do {
+      let webURL = WebURL("https://loc{alh}ost/qux/baz?bar=foo")!
+      XCTAssertEqual(webURL.serialized(), "https://loc{alh}ost/qux/baz?bar=foo")
+
+      request.mainDocumentWebURL = webURL
+      XCTAssertEqual(request.url?.absoluteString, "foo")
+      XCTAssertEqual(request.webURL, nil)
+      XCTAssertEqual(request.mainDocumentURL?.absoluteString, nil)
+      XCTAssertEqual(request.mainDocumentWebURL, nil)
+    }
+  }
+}
+
+
+// --------------------------------
+// MARK: - URLResponse Getters
+// --------------------------------
+
+
+final class URLResponseTests: XCTestCase {}
+
+extension URLResponseTests {
+
+  func testWebURLProperty_simpleConversion() {
+    let response = URLResponse(
+      url: URL(string: "http://example.com/foo/bar?baz=qux")!,
+      mimeType: nil, expectedContentLength: 42, textEncodingName: nil
+    )
+    XCTAssertEqual(response.url?.absoluteString, "http://example.com/foo/bar?baz=qux")
+    XCTAssertEqual(response.webURL?.serialized(), "http://example.com/foo/bar?baz=qux")
+  }
+
+  func testWebURLProperty_getterConversionFailure() {
+    let response = URLResponse(
+      url: URL(string: "foo")!,
+      mimeType: nil, expectedContentLength: 42, textEncodingName: nil
+    )
+    XCTAssertEqual(response.url?.absoluteString, "foo")
+    XCTAssertEqual(response.webURL, nil)
+  }
+}

--- a/Tests/WebURLFoundationExtensionsTests/URLSessionTests.swift
+++ b/Tests/WebURLFoundationExtensionsTests/URLSessionTests.swift
@@ -1,0 +1,1242 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WebURL
+import WebURLFoundationExtras
+import XCTest
+
+#if canImport(Swifter)
+  import Swifter
+#endif
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+final class URLSessionTests: XCTestCase {}
+
+
+// --------------------------------
+// MARK: - URLSessionDataTask
+// --------------------------------
+// It isn't really our business to check that URLSession works, but it is still nice to have these tests
+// so we know exactly what developers are going to see when they make requests via the wrapper APIs we expose -
+// including situations where percent-encoding needs to be added or when the WebURL cannot be converted to
+// a Foundation.URL.
+
+
+// On non-Apple platforms, executing a URLRequest whose url is nil will 'fatalError'.
+// Since that is how we prefer to signal conversion failures, we don't offer extensions to create
+// a URLRequest from a WebURL on those platforms. Fixed by https://github.com/apple/swift-corelibs-foundation/pull/3154
+#if canImport(Darwin)
+
+  fileprivate class Box<T> {
+    internal var value: T
+
+    internal init(_ value: T) {
+      self.value = value
+    }
+  }
+
+  fileprivate func XCTAssertEquivalentNSErrors(_ left: Error?, _ right: Error?) {
+    // The errors must have the same domain and code, but the 'userInfo' may differ.
+    if let left = (left as NSError?), let right = (right as NSError?) {
+      XCTAssertEqual(left.domain, right.domain)
+      XCTAssertEqual(left.code, right.code)
+    } else {
+      XCTAssertNil(left)
+      XCTAssertNil(right)
+    }
+  }
+
+  extension URLSessionTests {
+
+    fileprivate enum ExpectedURLConversion {
+      case encodingAdded
+      case noEncodingAdded
+      case failure
+    }
+
+    /// Makes a request via a `URLSessionDataTask`, checks the URLs exposed via the task's original/current
+    /// `URLRequest`s, and invokes the given closure to check the resulting `URLResponse`/data/error.
+    ///
+    fileprivate func makeDataTaskRequest(
+      to urlString: String,
+      expectedURLConversion: ExpectedURLConversion = .noEncodingAdded,
+      function: StaticString = #function, line: Int = #line,
+      checkResponse: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) {
+      let webURL = WebURL(urlString)!
+      XCTAssertEqual(webURL.serialized(), urlString, "Given string must be a normalized WebURL")
+
+      let ex = expectation(description: "\(function):\(line)")
+      let task: Box<URLSessionDataTask?> = .init(nil)
+      task.value = URLSession.shared.dataTask(with: webURL) { data, response, error in
+        defer {
+          task.value = nil
+          ex.fulfill()
+        }
+        // Verify the URLSessionDataTask.
+        // There should not be any redirects, so `originalRequest.url` should be the same as `currentRequest.url`.
+        switch expectedURLConversion {
+        case .encodingAdded:
+          XCTAssertNotEqual(task.value?.originalRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertNotEqual(task.value?.currentRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertNotEqual(task.value?.originalRequest?.webURL, webURL)
+          XCTAssertNotEqual(task.value?.currentRequest?.webURL, webURL)
+          let encodedWebURL = webURL.encodedForFoundation
+          XCTAssertEqual(task.value?.originalRequest?.url?.absoluteString, encodedWebURL.serialized())
+          XCTAssertEqual(task.value?.currentRequest?.url?.absoluteString, encodedWebURL.serialized())
+          XCTAssertEqual(task.value?.originalRequest?.webURL, encodedWebURL)
+          XCTAssertEqual(task.value?.currentRequest?.webURL, encodedWebURL)
+        case .noEncodingAdded:
+          XCTAssertEqual(task.value?.originalRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertEqual(task.value?.currentRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertEqual(task.value?.originalRequest?.webURL, webURL)
+          XCTAssertEqual(task.value?.currentRequest?.webURL, webURL)
+        case .failure:
+          XCTAssertNil(task.value?.originalRequest?.url)
+          XCTAssertNil(task.value?.currentRequest?.url)
+          XCTAssertNil(task.value?.originalRequest?.webURL)
+          XCTAssertNil(task.value?.currentRequest?.webURL)
+        }
+        // The wrapper API should not return an error which differs from the task error.
+        XCTAssertEquivalentNSErrors(task.value?.error, error)
+        // The closure verifies the URLResponse, data, and error.
+        checkResponse(data, response, error)
+      }
+      task.value!.resume()
+    }
+
+    fileprivate enum ExpectedURLOfRedirect {
+      case exactly(String)
+      case normalized(foundation: String, webURL: String)
+    }
+
+    fileprivate func makeDataTaskRequest(
+      to urlString: String,
+      expectedURLConversion: ExpectedURLConversion = .noEncodingAdded,
+      expectedURLOfRedirect: ExpectedURLOfRedirect,
+      function: StaticString = #function, line: Int = #line,
+      checkResponse: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) {
+      let webURL = WebURL(urlString)!
+      XCTAssertEqual(webURL.serialized(), urlString, "Given string must be a normalized WebURL")
+
+      let ex = expectation(description: "\(function):\(line)")
+      let task: Box<URLSessionDataTask?> = .init(nil)
+      task.value = URLSession.shared.dataTask(with: webURL) { data, response, error in
+        defer {
+          task.value = nil
+          ex.fulfill()
+        }
+        // Verify the URLSessionDataTask.
+        // `originalRequest` is the result of a WebURL -> Foundation conversion,
+        // so it is already normalized (although percent-encoding may have been added).
+        switch expectedURLConversion {
+        case .encodingAdded:
+          XCTAssertNotEqual(task.value?.originalRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertNotEqual(task.value?.originalRequest?.webURL, webURL)
+          let encodedURL = webURL.encodedForFoundation
+          XCTAssertEqual(task.value?.originalRequest?.url?.absoluteString, encodedURL.serialized())
+          XCTAssertEqual(task.value?.originalRequest?.webURL, encodedURL)
+        case .noEncodingAdded:
+          XCTAssertEqual(task.value?.originalRequest?.url?.absoluteString, webURL.serialized())
+          XCTAssertEqual(task.value?.originalRequest?.webURL, webURL)
+        case .failure:
+          XCTAssertNil(task.value?.originalRequest?.url)
+          XCTAssertNil(task.value?.originalRequest?.webURL)
+        }
+        // `currentRequest` may be the result of a Foundation -> WebURL conversion,
+        // so it may go through more extensive normalization (e.g. simplifying the path).
+        switch expectedURLOfRedirect {
+        case .exactly(let string):
+          XCTAssertEqual(task.value?.currentRequest?.url?.absoluteString, string)
+          XCTAssertEqual(task.value?.currentRequest?.webURL?.serialized(), string)
+        case .normalized(let foundation, let webURL):
+          XCTAssertEqual(task.value?.currentRequest?.url?.absoluteString, foundation)
+          XCTAssertEqual(task.value?.currentRequest?.webURL?.serialized(), webURL)
+        }
+        // The wrapper API should not return an error which differs from the task error.
+        XCTAssertEquivalentNSErrors(task.value?.error, error)
+        // The closure verifies the URLResponse, data, and error.
+        checkResponse(data, response, error)
+      }
+      task.value!.resume()
+    }
+  }
+
+  extension URLSessionTests {
+
+    func testDataTask_http() throws {
+
+      let localServer = HttpServer()
+      try localServer.start(0)
+      defer { localServer.stop() }
+      let port = try localServer.port()
+      print("ℹ️ Server started on port: \(port)")
+
+      var rng = SystemRandomNumberGenerator()
+
+      // Root path.
+      let referenceData_root = Data((0...1024).lazy.map { _ in rng.next() })
+      localServer["/"] = { _ in .ok(.data(referenceData_root, contentType: nil)) }
+      makeDataTaskRequest(to: "http://localhost:\(port)/") {
+        data, response, error in
+        XCTAssertEqual(data, referenceData_root)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/")
+      }
+
+      // Non-root path.
+      let referenceData_nonRoot = Data((0...1024).lazy.map { _ in rng.next() })
+      localServer["/foo/bar"] = { _ in .ok(.data(referenceData_nonRoot, contentType: nil)) }
+      makeDataTaskRequest(to: "http://localhost:\(port)/foo/bar") {
+        data, response, error in
+        XCTAssertEqual(data, referenceData_nonRoot)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+      }
+
+      // Path requires percent-encoding.
+      // The encoding is added when the URLSessionTask is created.
+      localServer["/encode/[baz]/"] = { _ in .ok(.text("You made it!")) }
+      makeDataTaskRequest(to: "http://localhost:\(port)/encode/[baz]", expectedURLConversion: .encodingAdded) {
+        data, response, error in
+        XCTAssertEqual(data, Data("You made it!".utf8))
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/encode/%5Bbaz%5D")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/encode/%5Bbaz%5D")
+      }
+
+      // Query requires percent-encoding.
+      // The encoding is added when the URLSessionTask is created.
+      localServer["/encode/q"] = { req in .ok(.text("You made it again! - \(req.queryParams.first?.1 ?? "")")) }
+      makeDataTaskRequest(to: "http://localhost:\(port)/encode/q?product={xx}", expectedURLConversion: .encodingAdded) {
+        data, response, error in
+        XCTAssertEqual(data, Data("You made it again! - %7Bxx%7D".utf8))
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/encode/q?product=%7Bxx%7D")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/encode/q?product=%7Bxx%7D")
+      }
+
+      // URLs which cannot be converted.
+      // For HTTP, this means domains with disallowed characters.
+      makeDataTaskRequest(to: "http://local{host}:\(port)/", expectedURLConversion: .failure) {
+        data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+      }
+
+      // Wait for all requests.
+      waitForExpectations(timeout: 5)
+    }
+
+    func testDataTask_customProtocol() throws {
+
+      #if os(watchOS)
+        throw XCTSkip("Custom URL protocol handling is not available on watchOS")
+      #endif
+
+      class FooSchemeHandler: URLProtocol {
+        override class func canInit(with request: URLRequest) -> Bool {
+          request.webURL?.scheme == "foo"
+        }
+        override class func canInit(with task: URLSessionTask) -> Bool {
+          task.currentRequest?.webURL?.scheme == "foo"
+        }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+          // Note: this is never called in swift-corelibs-foundation.
+          // https://bugs.swift.org/browse/SR-15987
+          request
+        }
+        override func startLoading() {
+          let response = URLResponse(url: request.url!, mimeType: "", expectedContentLength: 0, textEncodingName: nil)
+          client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+          if let payload = request.webURL?.path {
+            let reversedPayload = String(payload.reversed())
+            client?.urlProtocol(self, didLoad: Data(reversedPayload.utf8))
+          }
+          client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {
+        }
+      }
+
+      XCTAssertTrue(URLProtocol.registerClass(FooSchemeHandler.self))
+      defer { URLProtocol.unregisterClass(FooSchemeHandler.self) }
+
+      // Opaque path.
+      makeDataTaskRequest(to: "foo:barbazqux") { data, response, error in
+        XCTAssertEqual(data, Data("xuqzabrab".utf8))
+        XCTAssertNotNil(response)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "foo:barbazqux")
+        XCTAssertEqual(response?.url?.absoluteString, "foo:barbazqux")
+      }
+
+      // List-style path.
+      makeDataTaskRequest(to: "foo:/bar/baz/qux") { data, response, error in
+        XCTAssertEqual(data, Data("xuq/zab/rab/".utf8))
+        XCTAssertNotNil(response)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "foo:/bar/baz/qux")
+        XCTAssertEqual(response?.url?.absoluteString, "foo:/bar/baz/qux")
+      }
+
+      // URLs which cannot be converted.
+      // Disallowed characters in opaque paths won't be encoded.
+      makeDataTaskRequest(to: "foo:path has a space", expectedURLConversion: .failure) {
+        data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+      }
+      makeDataTaskRequest(to: "foo:path[br{ack}ets]!", expectedURLConversion: .failure) {
+        data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+      }
+
+      // Wait for all requests.
+      waitForExpectations(timeout: 5)
+    }
+
+    func testDataTask_redirects() throws {
+
+      let localServer = HttpServer()
+      try localServer.start(0)
+      defer { localServer.stop() }
+      let port = try localServer.port()
+      print("ℹ️ Server started on port: \(port)")
+
+      localServer["/foo/bar"] = { _ in .ok(.text("Hello, world!")) }
+
+      // Standard redirect to absolute URL. No encoding needed.
+      localServer["/redirect/normal-abs"] = { _ in .movedPermanently("http://localhost:\(port)/foo/bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/normal-abs",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/foo/bar")
+      ) { data, response, error in
+        XCTAssertTrue(data?.elementsEqual("Hello, world!".utf8) == true)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+      }
+
+      // Standard redirect to absolute path. No encoding needed.
+      localServer["/redirect/normal-path"] = { _ in .movedPermanently("/foo/bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/normal-path",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/foo/bar")
+      ) { data, response, error in
+        XCTAssertTrue(data?.elementsEqual("Hello, world!".utf8) == true)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+      }
+
+      // Redirect to a protocol-relative URL. No encoding needed.
+      localServer["/redirect/protorel"] = { _ in .movedPermanently("//foo/bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/protorel",
+        expectedURLOfRedirect: .exactly("https://foo/bar")
+      ) { data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .cannotFindHost)
+      }
+
+      // Redirect to the same absolute URL in a loop. Fails due to redirect limit.
+      localServer["/redirect/self"] = { _ in .movedPermanently("http://localhost:\(port)/redirect/self") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/self",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/redirect/self")
+      ) { data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .httpTooManyRedirects)
+      }
+
+      // Redirect to a dot, such that it resolves to the same URL in a loop. Fails due to redirect limit.
+      localServer["/redirect/dot/"] = { _ in .movedPermanently(".") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/dot/",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/redirect/dot/")
+      ) { data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .httpTooManyRedirects)
+      }
+
+      // Redirect to a space. Ends up not redirecting, but also not failing.
+      localServer["/redirect/space"] = { _ in .movedPermanently(" ") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/space",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/redirect/space")
+      ) { data, response, error in
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 301)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/redirect/space")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/redirect/space")
+      }
+
+      // Redirect to absolute path including tabs.
+      // 404 due to not filtering internal tabs, as WebURL would do. Works in Chrome.
+      // Foundation percent-encodes internal tabs, so they are preserved in the converted URL.
+      localServer["/redirect/tab"] = { _ in .movedPermanently("\t/fo\to/bar\t") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/tab",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/fo%09o/bar")
+      ) { data, response, error in
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/fo%09o/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/fo%09o/bar")
+      }
+
+      // Redirect to absolute path including a dot.
+      // 404 due to not simplifying path, as WebURL would do. Works in Safari and Chrome.
+      // The dot cannot be preserved in the converted URL, so it may not be clear as to why this request failed.
+      localServer["/redirect/includes-dot"] = { _ in .movedPermanently("/foo/./bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/includes-dot",
+        expectedURLOfRedirect: .normalized(
+          foundation: "http://localhost:\(port)/foo/./bar",
+          webURL: "http://localhost:\(port)/foo/bar"
+        )
+      ) { data, response, error in
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/./bar")
+      }
+
+      // Redirect to absolute path including a dot-dot.
+      // 404 due to not simplifying path, as WebURL would do. Works in Safari and Chrome.
+      // The dot-dot cannot be preserved in the converted URL, so it may not be clear as to why this request failed.
+      localServer["/redirect/includes-dotdot"] = { _ in .movedPermanently("/foo/tmp/../bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/includes-dotdot",
+        expectedURLOfRedirect: .normalized(
+          foundation: "http://localhost:\(port)/foo/tmp/../bar",
+          webURL: "http://localhost:\(port)/foo/bar"
+        )
+      ) { data, response, error in
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/tmp/../bar")
+      }
+
+      // Redirect to absolute path containing backslash.
+      // 404 since back-slashes are not normalized to forward-slashes, as WebURL would do. Works in Chrome.
+      // Foundation percent-encodes backslashes, so they are preserved in the converted URL.
+      localServer["/redirect/backslash"] = { _ in .movedPermanently("\\foo\\bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/backslash",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/redirect/%5Cfoo%5Cbar")
+      ) { data, response, error in
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/redirect/%5Cfoo%5Cbar")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/redirect/%5Cfoo%5Cbar")
+      }
+
+      // Redirect to absolute path containing forbidden characters (square brackets).
+      // Foundation percent-encodes these, so they are preserved in the converted URL.
+      localServer["/foo/[bar]"] = { _ in .ok(.text("You found me!")) }
+      localServer["/redirect/encode"] = { _ in .movedPermanently("/foo/[bar]") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/encode",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/foo/%5Bbar%5D")
+      ) {
+        data, response, error in
+        XCTAssertEqual(data, Data("You found me!".utf8))
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/%5Bbar%5D")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbar%5D")
+      }
+
+      // Redirect to absolute path containing forbidden characters (curly braces).
+      // Foundation percent-encodes these, so they are preserved in the converted URL.
+      localServer["/foo/{bar}"] = { _ in .ok(.text("You found me, too!")) }
+      localServer["/redirect/encode2"] = { _ in .movedPermanently("/foo/{bar}") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/encode2",
+        expectedURLOfRedirect: .exactly("http://localhost:\(port)/foo/%7Bbar%7D")
+      ) {
+        data, response, error in
+        XCTAssertEqual(data, Data("You found me, too!".utf8))
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(error)
+
+        XCTAssertEqual(response?.webURL?.serialized(), "http://localhost:\(port)/foo/%7Bbar%7D")
+        XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/foo/%7Bbar%7D")
+      }
+
+      // Redirect to absolute URL with too many slashes between scheme/host.
+      // 404 due to not treating as equivalent to a double-slash, as WebURL would. Works in Chrome.
+      // Foundation does something really weird here.
+      localServer["/redirect/toomanyslashes"] = { _ in .movedPermanently("http:///localhost:\(port)/foo/bar") }
+      makeDataTaskRequest(
+        to: "http://localhost:\(port)/redirect/toomanyslashes",
+        expectedURLOfRedirect: .exactly("http://localhost/localhost:\(port)/foo/bar")
+      ) { data, response, error in
+        XCTAssertNil(data)
+        XCTAssertNil(response)
+        XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost)
+      }
+
+      // Wait for all requests.
+      waitForExpectations(timeout: 5)
+    }
+
+    func testDataTask_sessionDelegate() throws {
+
+      let localServer = HttpServer()
+      try localServer.start(0)
+      defer { localServer.stop() }
+      let port = try localServer.port()
+      print("ℹ️ Server started on port: \(port)")
+
+      class Delegate: NSObject, URLSessionTaskDelegate {
+        var onComplete: Optional<(URLSessionTask, Error?) -> Void> = nil
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+          onComplete?(task, error)
+        }
+      }
+
+      let delegate = Delegate()
+      defer { delegate.onComplete = nil }
+      let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+      do {
+        localServer["/foo/bar"] = { _ in .ok(.text("hello!")) }
+
+        let ex = expectation(description: "Successful Request (Simple)")
+        let url = WebURL("http://localhost:\(port)/foo/bar")!
+        let _task = session.dataTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/foo/bar")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+          XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+          XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+          XCTAssertEqual(task.originalRequest?.webURL, url)
+          XCTAssertEqual(task.currentRequest?.webURL, url)
+          XCTAssertEqual(task.response?.webURL, url)
+          XCTAssertNil(error)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+
+      do {
+        localServer["/foo/[baz]"] = { _ in .ok(.text("world!")) }
+
+        let ex = expectation(description: "Successful Request (Adding Percent-Encoding)")
+        let url = WebURL("http://localhost:\(port)/foo/[baz]")!
+        let _task = session.dataTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/foo/[baz]")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+          XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+          XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+          XCTAssertEqual(task.originalRequest?.webURL, url.encodedForFoundation)
+          XCTAssertEqual(task.currentRequest?.webURL, url.encodedForFoundation)
+          XCTAssertEqual(task.response?.webURL, url.encodedForFoundation)
+          XCTAssertNil(error)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+
+      do {
+        let ex = expectation(description: "Conversion Failure")
+        let url = WebURL("http://loc{alh}ost:\(port)/foo/bar")!
+        let _task = session.dataTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost:\(port)/foo/bar")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.webURL, nil)
+          XCTAssertEqual(task.currentRequest?.webURL, nil)
+          XCTAssertEqual(task.response?.webURL, nil)
+          XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+    }
+
+    func testDataTask_customNilURLHandler() throws {
+
+      // This tests a special edge-case where the URL cannot be converted, but a custom URLProtocol handler
+      // processes it anyway. This is a rather contrived example: for instance, the URLProtocol handler
+      // must create a URL out of thin air for the URLResponse object.
+
+      #if os(watchOS)
+        throw XCTSkip("Custom URL protocol handling is not available on watchOS")
+      #endif
+
+      class NilURLHandler: URLProtocol {
+        static var DataToLoad: Data? = nil
+
+        override class func canInit(with request: URLRequest) -> Bool {
+          request.url == nil
+        }
+        override class func canInit(with task: URLSessionTask) -> Bool {
+          task.currentRequest?.url == nil
+        }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+          // Note: this is never called in swift-corelibs-foundation.
+          // https://bugs.swift.org/browse/SR-15987
+          request
+        }
+        override func startLoading() {
+          let url = URL(string: "made-up")!
+          let response = URLResponse(url: url, mimeType: "", expectedContentLength: 0, textEncodingName: nil)
+          client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+          if let data = Self.DataToLoad {
+            client?.urlProtocol(self, didLoad: data)
+          }
+          client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {
+        }
+      }
+
+      XCTAssertTrue(URLProtocol.registerClass(NilURLHandler.self))
+      defer { URLProtocol.unregisterClass(NilURLHandler.self) }
+
+      do {
+        let ex = expectation(description: "No data loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+          XCTAssertNotNil(data)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(data, Data())
+          XCTAssertEqual(data?.count, 0)
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        let ex = expectation(description: "Zero bytes loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        NilURLHandler.DataToLoad = Data()
+
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+          XCTAssertNotNil(data)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(data, Data())
+          XCTAssertEqual(data?.count, 0)
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        let ex = expectation(description: "Some bytes loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<10).map { _ in rng.next() as UInt8 }
+        NilURLHandler.DataToLoad = Data(bytes)
+
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+          XCTAssertNotNil(data)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(data?.elementsEqual(bytes), true)
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+    }
+  }
+
+  #if canImport(Combine)
+
+    import Combine
+
+    extension URLSessionTests {
+
+      func testDataTask_combine() throws {
+
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
+          throw XCTSkip("Combine requires macOS 10.15/iOS 13.0/watchOS 6.0 or newer")
+        }
+
+        let localServer = HttpServer()
+        try localServer.start(0)
+        defer { localServer.stop() }
+        let port = try localServer.port()
+        print("ℹ️ Server started on port: \(port)")
+
+        var rng = SystemRandomNumberGenerator()
+
+        var tokens = [AnyCancellable]()
+        do {
+          let referenceData = Data((0..<1024).lazy.map { _ in rng.next() })
+          localServer["/"] = { _ in .ok(.data(referenceData, contentType: nil)) }
+
+          let ex = expectation(description: "Root")
+          let publisher = URLSession.shared.dataTaskPublisher(for: WebURL("http://localhost:\(port)/")!)
+          XCTAssertEqual(publisher.request.webURL?.serialized(), "http://localhost:\(port)/")
+          XCTAssertEqual(publisher.request.url?.absoluteString, "http://localhost:\(port)/")
+
+          publisher.sink { completion in
+            switch completion {
+            case .failure(let error):
+              XCTFail("Unexpected error: \(error)")
+            case .finished:
+              break
+            }
+            ex.fulfill()
+          } receiveValue: { (data, response) in
+            XCTAssertEqual(data, referenceData)
+            XCTAssertEqual(response.webURL?.serialized(), "http://localhost:\(port)/")
+            XCTAssertEqual(response.url?.absoluteString, "http://localhost:\(port)/")
+          }.store(in: &tokens)
+        }
+
+        do {
+          let referenceData = Data((0..<1024).lazy.map { _ in rng.next() })
+          localServer["/foo/bar"] = { _ in .ok(.data(referenceData, contentType: nil)) }
+
+          let ex = expectation(description: "/Foo/Bar")
+          let publisher = URLSession.shared.dataTaskPublisher(for: WebURL("http://localhost:\(port)/foo/bar")!)
+          XCTAssertEqual(publisher.request.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+          XCTAssertEqual(publisher.request.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+
+          publisher.sink { completion in
+            switch completion {
+            case .failure(let error):
+              XCTFail("Unexpected error: \(error)")
+            case .finished:
+              break
+            }
+            ex.fulfill()
+          } receiveValue: { (data, response) in
+            XCTAssertEqual(data, referenceData)
+            XCTAssertEqual(response.webURL?.serialized(), "http://localhost:\(port)/foo/bar")
+            XCTAssertEqual(response.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+          }.store(in: &tokens)
+        }
+
+        do {
+          let ex = expectation(description: "Conversion failure")
+          let publisher = URLSession.shared.dataTaskPublisher(for: WebURL("http://loc{alh}ost:\(port)/foo/bar")!)
+          XCTAssertEqual(publisher.request.webURL, nil)
+          XCTAssertEqual(publisher.request.url, nil)
+
+          publisher.sink { completion in
+            switch completion {
+            case .failure(let error):
+              XCTAssertEqual(error.code, .unsupportedURL)
+            default:
+              XCTFail("Unexpected non-error result: \(completion)")
+            }
+            ex.fulfill()
+          } receiveValue: { (data, response) in
+            XCTFail("Unexpected response: \(data) \(response)")
+          }.store(in: &tokens)
+        }
+
+        waitForExpectations(timeout: 5)
+        withExtendedLifetime(tokens) {}
+      }
+    }
+
+  #endif  // canImport(Combine)
+
+  #if swift(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
+
+    extension URLSessionTests {
+      // TODO: URLSessionDataTask Async Tests (macOS 12+)
+    }
+
+  #endif  // swift(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
+
+
+  // --------------------------------
+  // MARK: - URLSessionDownloadTask
+  // --------------------------------
+
+
+  extension URLSessionTests {
+
+    func testDownloadTask() throws {
+
+      let localServer = HttpServer()
+      try localServer.start(0)
+      defer { localServer.stop() }
+      let port = try localServer.port()
+      print("ℹ️ Server started on port: \(port)")
+
+      do {
+        localServer["/files/test"] = { _ in .ok(.data(Data("hello, world!".utf8), contentType: nil)) }
+
+        let ex = expectation(description: "Successful Request (Simple)")
+        let url = WebURL("http://localhost:\(port)/files/test")!
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/files/test")
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNotNil(fileURL)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/files/test")
+          XCTAssertEqual(response?.webURL, url)
+
+          if let fileURL = fileURL.flatMap({ URL($0) }) {
+            XCTAssertEqual(try? Data(contentsOf: fileURL).elementsEqual("hello, world!".utf8), true)
+          }
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        localServer["/files/[abc]"] = { _ in .ok(.data(Data("def".utf8), contentType: nil)) }
+
+        let ex = expectation(description: "Successful Request (Adding Percent-Encoding)")
+        let url = WebURL("http://localhost:\(port)/files/[abc]")!
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/files/[abc]")
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNotNil(fileURL)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(response?.url?.absoluteString, "http://localhost:\(port)/files/%5Babc%5D")
+          XCTAssertEqual(response?.webURL, url.encodedForFoundation)
+
+          if let fileURL = fileURL.flatMap({ URL($0) }) {
+            XCTAssertEqual(try? Data(contentsOf: fileURL).elementsEqual("def".utf8), true)
+          }
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        let ex = expectation(description: "Conversion Failure")
+        let url = WebURL("http://loc{alh}ost:\(port)/files/test")!
+
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost:\(port)/files/test")
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNil(fileURL)
+          XCTAssertNil(response)
+          XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual((task.error as? URLError)?.code, .unsupportedURL)
+      }
+    }
+
+    func testDownloadTask_sessionDelegate() throws {
+
+      let localServer = HttpServer()
+      try localServer.start(0)
+      defer { localServer.stop() }
+      let port = try localServer.port()
+      print("ℹ️ Server started on port: \(port)")
+
+      // Note: We don't really care about URLSessionDownloadDelegate because it uses Foundation.URL anyway.
+      class Delegate: NSObject, URLSessionTaskDelegate {
+        var onComplete: Optional<(URLSessionTask, Error?) -> Void> = nil
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+          onComplete?(task, error)
+        }
+      }
+
+      let delegate = Delegate()
+      defer { delegate.onComplete = nil }
+      let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+      do {
+        localServer["/files/test"] = { _ in .ok(.data(Data("hello, world!".utf8), contentType: nil)) }
+
+        let ex = expectation(description: "Successful Request (Simple)")
+        let url = WebURL("http://localhost:\(port)/files/test")!
+        let _task = session.downloadTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/files/test")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/files/test")
+          XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/files/test")
+          XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/files/test")
+          XCTAssertEqual(task.originalRequest?.webURL, url)
+          XCTAssertEqual(task.currentRequest?.webURL, url)
+          XCTAssertEqual(task.response?.webURL, url)
+          XCTAssertNil(error)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+
+      do {
+        localServer["/files/[abc]"] = { _ in .ok(.data(Data("def".utf8), contentType: nil)) }
+
+        let ex = expectation(description: "Successful Request (Adding Percent-Encoding)")
+        let url = WebURL("http://localhost:\(port)/files/[abc]")!
+        let _task = session.downloadTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://localhost:\(port)/files/[abc]")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/files/%5Babc%5D")
+          XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/files/%5Babc%5D")
+          XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/files/%5Babc%5D")
+          XCTAssertEqual(task.originalRequest?.webURL, url.encodedForFoundation)
+          XCTAssertEqual(task.currentRequest?.webURL, url.encodedForFoundation)
+          XCTAssertEqual(task.response?.webURL, url.encodedForFoundation)
+          XCTAssertNil(error)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+
+      do {
+        let ex = expectation(description: "Conversion Failure")
+        let url = WebURL("http://loc{alh}ost:\(port)/files/test")!
+        let _task = session.downloadTask(with: url)
+
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost:\(port)/files/test")
+        delegate.onComplete = { task, error in
+          XCTAssertEqual(task.taskIdentifier, _task.taskIdentifier)
+          XCTAssertEqual(task.originalRequest?.webURL, nil)
+          XCTAssertEqual(task.currentRequest?.webURL, nil)
+          XCTAssertEqual(task.response?.webURL, nil)
+          XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+          XCTAssertEquivalentNSErrors(task.error, error)
+          ex.fulfill()
+        }
+        _task.resume()
+        waitForExpectations(timeout: 2)
+      }
+    }
+
+    func testDownloadTask_customNilURLHandler() throws {
+
+      // This tests a special edge-case where the URL cannot be converted, but a custom URLProtocol handler
+      // processes it anyway. This is a rather contrived example: for instance, the URLProtocol handler
+      // must create a URL out of thin air for the URLResponse object.
+
+      #if os(watchOS)
+        throw XCTSkip("Custom URL protocol handling is not available on watchOS")
+      #endif
+
+      class NilURLHandler: URLProtocol {
+        static var DataToLoad: Data? = nil
+
+        override class func canInit(with request: URLRequest) -> Bool {
+          request.url == nil
+        }
+        override class func canInit(with task: URLSessionTask) -> Bool {
+          task.currentRequest?.url == nil
+        }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+          // Note: this is never called in swift-corelibs-foundation.
+          // https://bugs.swift.org/browse/SR-15987
+          request
+        }
+        override func startLoading() {
+          let url = URL(string: "made-up")!
+          let response = URLResponse(url: url, mimeType: "", expectedContentLength: 0, textEncodingName: nil)
+          client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+          if let data = Self.DataToLoad {
+            client?.urlProtocol(self, didLoad: data)
+          }
+          client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {
+        }
+      }
+
+      XCTAssertTrue(URLProtocol.registerClass(NilURLHandler.self))
+      defer { URLProtocol.unregisterClass(NilURLHandler.self) }
+
+      do {
+        let ex = expectation(description: "No data loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNotNil(fileURL)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          if let fileURL = fileURL.flatMap({ URL($0) }) {
+            let data = try? Data(contentsOf: fileURL)
+            XCTAssertEqual(data, Data())
+            XCTAssertEqual(data?.count, 0)
+          }
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        let ex = expectation(description: "Zero bytes loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        NilURLHandler.DataToLoad = Data()
+
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNotNil(fileURL)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          if let fileURL = fileURL.flatMap({ URL($0) }) {
+            let data = try? Data(contentsOf: fileURL)
+            XCTAssertEqual(data, Data())
+            XCTAssertEqual(data?.count, 0)
+          }
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+
+      do {
+        let ex = expectation(description: "Some bytes loaded")
+        let url = WebURL("http://loc{alh}ost/files/test")!
+        XCTAssertEqual(url.serialized(), "http://loc{alh}ost/files/test")
+
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<10).map { _ in rng.next() as UInt8 }
+        NilURLHandler.DataToLoad = Data(bytes)
+
+        let task = URLSession.shared.downloadTask(with: url) { fileURL, response, error in
+          XCTAssertNotNil(fileURL)
+          XCTAssertNotNil(response)
+          XCTAssertNil(error)
+
+          XCTAssertEqual(response?.url?.absoluteString, "made-up")
+          if let fileURL = fileURL.flatMap({ URL($0) }) {
+            let data = try? Data(contentsOf: fileURL)
+            XCTAssertEqual(data?.elementsEqual(bytes), true)
+          }
+          ex.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(task.error)
+      }
+    }
+  }
+
+
+  // --------------------------------
+  // MARK: - URLSessionWebSocketTask (Darwin-only)
+  // --------------------------------
+
+
+  #if canImport(Darwin)
+
+    extension URLSessionTests {
+
+      func testWebsocketTask() throws {
+
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
+          throw XCTSkip("URLSessionWebSocketTask requires macOS 10.15/iOS 13.0/watchOS 6.0 or newer")
+        }
+
+        let localServer = HttpServer()
+        try localServer.start(0)
+        defer { localServer.stop() }
+        let port = try localServer.port()
+        print("ℹ️ Server started on port: \(port)")
+
+        do {
+          localServer["/foo/bar"] = websocket(
+            text: { session, text in session.writeText(String(text.reversed())) },
+            binary: { session, data in fatalError("Only sending text in this test") }
+          )
+
+          let ex = expectation(description: "Successful Connection (Simple)")
+          let url = WebURL("ws://localhost:\(port)/foo/bar")!
+          let task = URLSession.shared.webSocketTask(with: url)
+          task.resume()
+
+          XCTAssertEqual(url.serialized(), "ws://localhost:\(port)/foo/bar")
+          task.send(.string("hello, world!")) { error in
+            XCTAssertNil(error)
+            // For some reason, Foundation makes all of these URLs http 🤷‍♂️
+            XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+            XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+            XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/foo/bar")
+            var httpURL = url
+            httpURL.scheme = "http"
+            XCTAssertEqual(task.originalRequest?.webURL, httpURL)
+            XCTAssertEqual(task.currentRequest?.webURL, httpURL)
+            XCTAssertEqual(task.response?.webURL, httpURL)
+
+            task.receive { result in
+              guard case .success(.string(let msg)) = result else {
+                XCTFail("Unexpected error - \(result)")
+                ex.fulfill()
+                return
+              }
+              XCTAssertEqual(msg, "!dlrow ,olleh")
+              ex.fulfill()
+            }
+          }
+          waitForExpectations(timeout: 2)
+          XCTAssertNil(task.error)
+        }
+
+        do {
+          localServer["/foo/[baz]"] = websocket(
+            text: { session, text in session.writeText(String((text + text).reversed()).uppercased()) },
+            binary: { session, data in fatalError("Only sending text in this test") }
+          )
+
+          let ex = expectation(description: "Successful Connection (Adding Percent-Encoding)")
+          let url = WebURL("ws://localhost:\(port)/foo/[baz]")!
+          let task = URLSession.shared.webSocketTask(with: url)
+          task.resume()
+
+          task.send(.string("hello, world!")) { error in
+            XCTAssertNil(error)
+            // For some reason, Foundation makes all of these URLs http 🤷‍♂️
+            XCTAssertEqual(task.originalRequest?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+            XCTAssertEqual(task.currentRequest?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+            XCTAssertEqual(task.response?.url?.absoluteString, "http://localhost:\(port)/foo/%5Bbaz%5D")
+            var httpURL = url
+            httpURL.scheme = "http"
+            XCTAssertEqual(task.originalRequest?.webURL, httpURL.encodedForFoundation)
+            XCTAssertEqual(task.currentRequest?.webURL, httpURL.encodedForFoundation)
+            XCTAssertEqual(task.response?.webURL, httpURL.encodedForFoundation)
+
+            task.receive { result in
+              guard case .success(.string(let msg)) = result else {
+                XCTFail("Unexpected error - \(result)")
+                ex.fulfill()
+                return
+              }
+              XCTAssertEqual(msg, "!DLROW ,OLLEH!DLROW ,OLLEH")
+              ex.fulfill()
+            }
+          }
+          waitForExpectations(timeout: 2)
+          XCTAssertNil(task.error)
+        }
+
+        do {
+          let ex = expectation(description: "Conversion Failure")
+          let url = WebURL("ws://loc{alh}ost:\(port)/foo/bar")!
+          let task = URLSession.shared.webSocketTask(with: url)
+          task.resume()
+
+          task.send(.string("hello, world!")) { error in
+            XCTAssertEqual((error as? URLError)?.code, .unsupportedURL)
+            XCTAssertEquivalentNSErrors(task.error, error)
+            XCTAssertNil(task.originalRequest?.url)
+            XCTAssertNil(task.currentRequest?.url)
+            XCTAssertNil(task.response?.url)
+            XCTAssertNil(task.originalRequest?.webURL)
+            XCTAssertNil(task.currentRequest?.webURL)
+            XCTAssertNil(task.response?.webURL)
+            ex.fulfill()
+          }
+          waitForExpectations(timeout: 2)
+        }
+      }
+    }
+
+  #endif  // canImport(Darwin)
+
+#endif  // canImport(Darwin)


### PR DESCRIPTION
Leaving this here while I work on some other things.

Adds overloads to `URLSession` APIs which accept/return WebURLs. I'm still a little unsure as to whether it's a good idea.

For making simple requests, it's fine because we do WebURL -> Foundation.URL conversion, which may add percent-encoding in relatively rare cases but performs no other normalization, and is guaranteed to round-trip back to an identical WebURL (to the version with encoding). Since that is done as the first step, all URLs on the `URLRequest` and `URLResponse` objects include that percent-encoding, and everything seems consistent from the developer's perspective.

If redirects occur, things get a little more complicated. Foundation resolves the redirect on its own, and converting those URLs to WebURL may require normalization.

For example, if a redirect occurs to `/foo/./bar`, Foundation will literally make a GET request with that target (including the dot component), and as a result, the request may fail. WebURL would simplify that URL to `/foo/bar`, and the developer would be left wondering why the request to a proper URL suddenly failed, because they can't see the dot component.

FWIW, Chrome agrees with the WebURL result, and generally Safari does as well. Ugh. It would be much better if we could just have WebURL handle all of the redirect resolution logic.