### PR TITLE
🎉 WebURL fully conforms to the WHATWG URL Standard 🎉

### DIFF
--- a/Tests/WebURLTests/WebPlatformTests.swift
+++ b/Tests/WebURLTests/WebPlatformTests.swift
@@ -36,21 +36,7 @@ extension WebPlatformTests {
       "Incorrect number of test cases. If you updated the test list, be sure to update the expected failure indexes"
     )
 
-    var harness = WPTConstructorTest.WebURLReportHarness(expectedFailures: [
-      // These test failures are due to us not having implemented the `domain2ascii` transform,
-      // often in combination with other features (e.g. with percent encoding).
-      //
-      263,  // domain2ascii: (no-break, zero-width, zero-width-no-break) are name-prepped away to nothing.
-      265,  // domain2ascii: U+3002 is mapped to U+002E (dot).
-      277,  // domain2ascii: fullwidth input should be converted to ASCII and NOT IDN-ized.
-      282,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
-      283,  // domain2ascii: Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN.
-      294,  // domain2ascii: Fullwidth and escaped UTF-8 fullwidth should still be treated as IP.
-      464,  // domain2ascii: Hosts and percent-encoding.
-      465,  // domain2ascii: Hosts and percent-encoding.
-      680,  // domain2ascii: IDNA ignored code points in file URLs hosts.
-      681,  // domain2ascii: IDNA ignored code points in file URLs hosts.
-    ])
+    var harness = WPTConstructorTest.WebURLReportHarness()
     harness.runTests(testFile)
     XCTAssertEqual(harness.reportedResultCount, 737, "Unexpected number of tests executed.")
     XCTAssertFalse(harness.report.hasUnexpectedResults, "Test failed")


### PR DESCRIPTION
IDNA was the last functional gap before we could truly claim to implement the URL standard. 

I never knew just how involved it would be to write a new URL type - not just the parser, but all of _other parsers_ and details like IP addresses, file path conversions (which was a complete nightmare and it took months and months to examine the various implementations, understand the legacy implications and build a comprehensive test suite), designing interop with previous standards to allow use with `URLSession` while protecting users from a class of bugs that are increasingly being used in real exploits, not to mention offering a rich, generic API to all of this that is easy to use and expressive, while scaling to any performance requirement, and even though we're doing a huge amount more work than `URL`, I wanted regular URL string parsing to be _even faster_ than it is today.

I've had to learn a lot about all of these topics - about all of the legacy compatibility issues with URLs, about how they have lead to security vulnerabilities in the past and how they are continuing to do so today. I've had to think long and hard about why URLs are such a persistent security problem - about how the expectations of developers don't always match what URLs do, and how that can lead to many of those problems. I've had to get involved with the standards - querying things that I didn't understand, discovering issues, contributing tests, writing clarifications and fixes, and coordinating with other implementors to get them adopted (or even just implementing them in other projects myself). I've had to examine the current Swift URL API closely, including all of its subtle interactions and secondary behaviours, to design a library that I think showcases how the Swift language can be used to solve many of those issues.

And now we add Unicode. As the cherry on top 🍰.

Yeah, it's just a URL library. On the other hand, there's a lot that goes in to a URL library, and it has been a really rewarding journey. It has actually taken years.

And it still isn't done - after IDNA support in the parser, the next logical step is offering APIs to _render_ IDNA domains as Unicode. But there are a [whole host](https://www.unicode.org/reports/tr36/#international_domain_names) of other details about that, so next I'm going to have to learn more about Unicode, about scripts I don't even know how to write, and how to detect and guard against confusable Unicode strings. The only way to learn this kind of stuff is to do it. And so this project has given me the opportunity to learn so much.

If you've used WebURL, thank you. Even just using the library supports the project in a small way.
If you haven't used WebURL yet, and you're reading this, give it a try and let me know what you think.