### PR TITLE
[IDNA] Documentation improvements, performance improvements

### DIFF
--- a/Benchmarks/Sources/WebURLBenchmark/Constructor+HTTP.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/Constructor+HTTP.swift
@@ -42,6 +42,14 @@ extension Constructor {
         }
       }
 
+      // IDNA.
+
+      suite.benchmark("IDNA") {
+        for string in SampleURLs.IDNAURLs {
+          blackHole(WebURL(string))
+        }
+      }
+
       // IPv4.
 
       suite.benchmark("IPv4") {

--- a/Benchmarks/Sources/WebURLBenchmark/SampleURLs.swift
+++ b/Benchmarks/Sources/WebURLBenchmark/SampleURLs.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// A collection of sample URLs shared by several benchmark suites.
-/// 
+///
 enum SampleURLs {}
 
 
@@ -213,5 +213,32 @@ extension SampleURLs {
     "http:/\t/\t[:\n:53.\n197.134.182]",
     "http:/\t/\t[6\n880:\n1845:26e0:6df1:f7e6:9e4b:7b7:7bc4]",
     "http:/\t/\t[1\nf09:\nbebc:131f:3de7:8bfb:3192:9f6a:fc64]",
+  ]
+}
+
+
+// --------------------------------------------
+// MARK: - IDNA
+// --------------------------------------------
+
+
+extension SampleURLs {
+
+  /// 10 HTTP(S) URLs with IDNs.
+  ///
+  /// These are basically like the AverageURLs, with IDNs.
+  ///
+  internal static let IDNAURLs: [String] = [
+    #"http://ₓn--fa-hia.example/foo/bar/baz?a=b&c=d&e=f"#,
+    #"http://caf\u{00E9}.fr/bar?baz=qux&search=nothing#top"#,
+    #"http://xn--caf-dma.fr/one/two?coffee"#,
+    #"https://a.xn--igbi0gl.com/wiki/Swift_(programming_language)"#,
+    #"https://a.xn--mgbet1febhkb.com/w/index.php?title=Swift_(programming_language)&action=edit"#,
+
+    #"https://xn--b1abfaaepdrnnbgefbadotcwatmq2g4l/w/index.php?title=Swift_programming_language&redirect=no"#,
+    #"https://xn--1ch.com/wiki/Swift_(parallel_scripting_language)"#,
+    #"https://국립중앙도서관.한국/foo/bar?baz"#,
+    #"https://日本語.jp/foo/bar?baz"#,
+    #"http://中国移动.中国/foo/bar?baz"#,
   ]
 }


### PR DESCRIPTION
Before
```
name                                  time          std        iterations warmup           
-------------------------------------------------------------------------------------------
Constructor.HTTP.AverageURLs           24707.000 ns ±  17.66 %      53628  266289080.000 ns
Constructor.HTTP.AverageURLs.filtered  37439.000 ns ±  27.44 %      33427  416324500.000 ns
Constructor.HTTP.IDNA                 141071.000 ns ±  23.49 %       9138 1548975540.000 ns
```
After
```
name                                  time          std        iterations warmup           
-------------------------------------------------------------------------------------------
Constructor.HTTP.AverageURLs           23391.000 ns ±  24.68 %      61023  238289616.000 ns
Constructor.HTTP.AverageURLs.filtered  38563.000 ns ±  26.68 %      32004  431694166.000 ns
Constructor.HTTP.IDNA                 110999.500 ns ±  23.30 %      11272 1268018770.000 ns
```

The biggest issue is still the NFC normalization, which comes from Foundation and requires bridging, etc. Using the standard library NFC instead is way faster:

```
xcrun -toolchain swift swift build -c release -Xswiftc -DWEBURL_IDNA_USE_STDLIB_NFC                                                                                              
<plus some rpath fiddling with install_name_tool so it actually uses the toolchain stdlib>
```
```
name                                  time         std        iterations warmup          
-----------------------------------------------------------------------------------------
Constructor.HTTP.AverageURLs          24325.000 ns ±  27.30 %      54222 237479378.000 ns
Constructor.HTTP.AverageURLs.filtered 39292.000 ns ±  25.89 %      32053 439869002.000 ns
Constructor.HTTP.IDNA                 71475.000 ns ±  23.93 %      18097 788458819.000 ns
```

But even that could be much better. We're still buffering everything in a string, and profiling shows that is by far the biggest performance hit. That's just because of how the stdlib SPI happens to be exposed; it could offer something far more efficient and help us cut that out (also, `isNFC` could be way faster than we're doing it here).

So yeah - better NFC normalization APIs are what we need to really make a significant dent.