### PR TITLE
[IDNA] Further implementation improvements

### DIFF
--- a/Sources/IDNA/NFC.swift
+++ b/Sources/IDNA/NFC.swift
@@ -19,13 +19,9 @@
   @usableFromInline
   internal typealias NFCIterator = AnyIterator<Unicode.Scalar>
 
-  @usableFromInline
+  @inlinable
   internal func isNFC<C: Collection>(_ scalars: C) -> Bool where C.Element == Unicode.Scalar {
-    if #available(macOS 9999, *) {
-      return String(scalars)._nfc.elementsEqual(scalars)
-    } else {
-      fatalError()
-    }
+    toNFC(String(scalars)).elementsEqual(scalars)
   }
 
   @usableFromInline
@@ -46,8 +42,7 @@
 
   @inlinable
   internal func isNFC<C: Collection>(_ scalars: C) -> Bool where C.Element == Unicode.Scalar {
-    // These are scalars which have been decoded from Punycode, and are therefore non-ASCII.
-    String(scalars).precomposedStringWithCanonicalMapping.unicodeScalars.elementsEqual(scalars)
+    IteratorSequence(toNFC(String(scalars))).elementsEqual(scalars)
   }
 
   @inlinable

--- a/Sources/UnicodeDataStructures/Shared/IDNA/IDNAValidationDataSchema.swift
+++ b/Sources/UnicodeDataStructures/Shared/IDNA/IDNAValidationDataSchema.swift
@@ -99,6 +99,11 @@ extension IDNAValidationData.ValidationFlags {
     init(value: UInt8) {
       self.value = value
     }
+
+    @inlinable
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.value == rhs.value
+    }
   }
 
   // swift-format-ignore
@@ -116,6 +121,11 @@ extension IDNAValidationData.ValidationFlags {
     @inlinable
     init(value: UInt8) {
       self.value = value
+    }
+
+    @inlinable
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.value == rhs.value
     }
   }
 }


### PR DESCRIPTION
- Move STD3 checking to somewhere it won't get in the way as much (URLs don't even use it)
- Allows us to simplify some of the mapping code, which is nice
- Various small performance tweaks related to minimising ARC and table lookups.

With Foundation we can get down to about 106:

```
name                                  time          std        iterations warmup           
-------------------------------------------------------------------------------------------
Constructor.HTTP.AverageURLs           24025.000 ns ±  29.18 %      59108  239648800.000 ns
Constructor.HTTP.AverageURLs.filtered  39117.000 ns ±  25.47 %      32125  432200337.000 ns
Constructor.HTTP.IDNA                 106099.000 ns ±  24.23 %      11844 1186124639.000 ns
```

The standard library is still much better, of course:

```

name                                  time         std        iterations warmup          
-----------------------------------------------------------------------------------------
Constructor.HTTP.AverageURLs          23934.000 ns ±  13.89 %      57003 257716257.000 ns
Constructor.HTTP.AverageURLs.filtered 37280.000 ns ±  11.64 %      36620 387509660.000 ns
Constructor.HTTP.IDNA                 67125.000 ns ±  13.16 %      20093 710228960.000 ns
```

So very small gains over what is already there, but it's good to reduce some of this ARC traffic anyway and it's generally just an improved implementation.