### PR TITLE
Add APIs for parsing hostnames and a HostKind for domains with Punycode labels

### DIFF
--- a/Sources/WebURL/SPIs.swift
+++ b/Sources/WebURL/SPIs.swift
@@ -210,7 +210,7 @@ extension WebURL._SPIs {
       return .ipv4Address(IPv4Address(dottedDecimalUTF8: hostnameUTF8)!)
     case .ipv6Address:
       return .ipv6Address(IPv6Address(utf8: hostnameUTF8.dropFirst().dropLast())!)
-    case .domain:
+    case .domain, .domainWithIDN:
       return .domain(hostnameUTF8)
     case .opaque:
       return .opaque(hostnameUTF8)
@@ -360,8 +360,8 @@ extension WebURL._SPIs {
 
     // Hostname.
     switch _url.storage.structure.hostKind {
-    case .some(.domain):
-      guard _url.utf8.hostname?.contains(where: { encodeSet.shouldPercentEncode(ascii: $0) }) != true else {
+    case .some(.domain), .some(.domainWithIDN):
+      guard _url.utf8.hostname?.contains(where: { encodeSet.shouldPercentEncode(ascii: $0) }) == false else {
         // Domains are not allowed to contain percent-encoding.
         return .unableToEncode
       }

--- a/Sources/WebURL/URLStorage.swift
+++ b/Sources/WebURL/URLStorage.swift
@@ -574,9 +574,12 @@ extension URLStructure {
       }
 
       switch hostKind {
-      case .ipv4Address, .domain:
+      case .ipv4Address, .domain, .domainWithIDN:
         assert(schemeKind.isSpecial, "Only URLs with special schemes can have IPv4 or domain hosts")
         assert(hostnameLength > 0, "IPv4/domain hostKinds cannot have empty hostnames")
+        if case .domainWithIDN = hostKind {
+          assert(hostnameLength >= 5, "A domain with IDN label cannot have fewer than 5 characters ('xn--' + 1)")
+        }
       case .empty:
         if schemeKind.isSpecial {
           assert(schemeKind == .file, "The only special URL which allows empty hostnames is file")

--- a/Sources/WebURL/WebURL+Host.swift
+++ b/Sources/WebURL/WebURL+Host.swift
@@ -14,117 +14,6 @@
 
 extension WebURL {
 
-  /// The kind of host contained in a URL.
-  ///
-  @usableFromInline
-  internal enum HostKind {
-    case ipv4Address
-    case ipv6Address
-    case domain
-    case domainWithIDN
-    case opaque
-    case empty
-  }
-
-  /// The host of this URL.
-  ///
-  /// A host is a network address or opaque identifier. This property exposes the URL's precise interpretation
-  /// of its host, allowing a network connection to be established directly rather than manually parsing the URL's
-  /// ``hostname``.
-  ///
-  /// ```swift
-  /// let url = WebURL("http://127.0.0.1:8888/my_site")!
-  ///
-  /// guard url.scheme == "http" || url.scheme == "https" else {
-  ///   throw UnknownSchemeError()
-  /// }
-  /// switch url.host {
-  ///   case .domain(let name): ... // DNS lookup.
-  ///   case .ipv4Address(let address): ... // Connect to known address.
-  ///   case .ipv6Address(let address): ... // Connect to known address.
-  ///   case .opaque, .empty, .none: fatalError("Not possible for http")
-  /// }
-  /// ```
-  ///
-  /// See the ``IPv6Address`` and ``IPv4Address`` documentation for more information
-  /// about how to use them to establish a network connection.
-  ///
-  /// ### Allowed Hosts
-  ///
-  /// The kinds of hosts supported by a URL depends on its ``scheme``, and is defined
-  /// by the [URL Standard][URL-hostcombinations].
-  ///
-  /// | Schemes             | Domain | IPv4 | IPv6 | Opaque | Empty | Nil (not present) |
-  /// |:-------------------:|:------:|:----:|:----:|:------:|:-----:|:-----------------:|
-  /// | http(s), ws(s), ftp |   ✅   |  ✅  |  ✅  |    -   |   -   |         -         |
-  /// |                file |   ✅   |  ✅  |  ✅  |    -   |   ✅  |         -         |
-  /// |     everything else |    -   |   -  |  ✅  |   ✅   |   ✅  |         ✅        |
-  ///
-  /// What this means, in summary:
-  ///
-  /// - For **custom schemes** (`"my.app://..."`, etc), the URL Standard does not make any assumptions
-  ///   about what a hostname means, except that hostnames in square brackets are IPv6 addresses
-  ///   (for example, `"[::1]"`).
-  ///
-  ///   The hosts of these URLs may indeed be IPv4 addresses or domains, but as far as the standard is concerned,
-  ///   they are opaque strings. They are not parsed or canonicalized, and invalid IPv4 addresses or domains
-  ///   are not necessarily invalid hosts.
-  ///
-  /// - For **special schemes**, the standard knows which kinds of hosts are supported,
-  ///   and will parse and canonicalize them.
-  ///
-  ///   For example, domains are expected to be resolved using the Domain Name System (DNS), which is case-insensitive
-  ///   and has a unique way of encoding Unicode hostnames, so these hosts are normalized to lowercase and encoded
-  ///   as Internationalized Domain Names if necessary.
-  ///
-  /// - **`http` and `https` URLs** always have a host, and it is never opaque or empty.
-  ///
-  /// > Note:
-  /// > WebURL does not currently support Internationalized Domain Names (IDN), although we hope to support them
-  /// > soon.
-  ///
-  /// [URL-hostcombinations]: https://url.spec.whatwg.org/#url-representation
-  ///
-  /// ## Topics
-  ///
-  /// ### Kinds of Host
-  ///
-  /// - ``WebURL/WebURL/Host-swift.enum/domain(_:)``
-  /// - ``WebURL/WebURL/Host-swift.enum/ipv4Address(_:)``
-  /// - ``WebURL/WebURL/Host-swift.enum/ipv6Address(_:)``
-  /// - ``WebURL/WebURL/Host-swift.enum/opaque(_:)``
-  /// - ``WebURL/WebURL/Host-swift.enum/empty``
-  ///
-  /// ### Obtaining a Host's String Representation
-  ///
-  /// - ``WebURL/WebURL/Host-swift.enum/serialized``
-  ///
-  /// ### Host Type
-  ///
-  /// - ``WebURL/WebURL/Host-swift.enum``
-  ///
-  /// ## See Also
-  ///
-  /// - ``WebURL/hostname``
-  /// - ``IPv4Address``
-  /// - ``IPv6Address``
-  ///
-  public var host: Host? {
-    guard let hostKind = hostKind, let hostnameCodeUnits = utf8.hostname else { return nil }
-    switch hostKind {
-    case .ipv4Address:
-      return .ipv4Address(IPv4Address(dottedDecimalUTF8: hostnameCodeUnits)!)
-    case .ipv6Address:
-      return .ipv6Address(IPv6Address(utf8: hostnameCodeUnits.dropFirst().dropLast())!)
-    case .domain, .domainWithIDN:
-      return .domain(String(decoding: hostnameCodeUnits, as: UTF8.self))
-    case .opaque:
-      return .opaque(String(decoding: hostnameCodeUnits, as: UTF8.self))
-    case .empty:
-      return .empty
-    }
-  }
-
   /// The specific kind of host found in a URL.
   ///
   /// A URL's Host is a network address or opaque identifier. The URL Standard defines several specific kinds
@@ -192,6 +81,7 @@ extension WebURL.Host: Equatable, Hashable {}
 
 extension WebURL.Host: CustomStringConvertible {
 
+  @inlinable
   public var description: String {
     serialized
   }
@@ -201,6 +91,287 @@ extension WebURL.Host: CustomStringConvertible {
   extension WebURL.Host: Sendable {}
   extension WebURL.HostKind: Sendable {}
 #endif
+
+extension WebURL.Host: Codable {
+
+  public enum CodingKeys: CodingKey {
+    case hostname
+    case kind
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(serialized, forKey: .hostname)
+    let kind: String
+    switch self {
+    case .opaque, .empty: return
+    case .domain: kind = "domain"
+    case .ipv4Address: kind = "ipv4"
+    case .ipv6Address: kind = "ipv6"
+    }
+    try container.encode(kind, forKey: .kind)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let hostname = try container.decode(String.self, forKey: .hostname)
+
+    // All empty hostnames become '.empty', regardless of kind.
+    guard !hostname.isEmpty else {
+      self = .empty
+      return
+    }
+
+    let kind = try container.decodeIfPresent(String.self, forKey: .kind)
+    switch kind {
+    // Domains and IPv4 require a special context.
+    case "domain", "ipv4":
+      switch (kind, WebURL.Host(hostname, scheme: "http")) {
+      case ("domain", .some(.domain(let domain))):
+        self = .domain(domain)
+      case ("ipv4", .some(.ipv4Address(let address))):
+        self = .ipv4Address(address)
+      default:
+        throw DecodingError.dataCorruptedError(forKey: .hostname, in: container, debugDescription: "invalid hostname")
+      }
+    // IPv6 and Opaque hosts can be parsed in a non-special context.
+    case "ipv6", .none:
+      switch (kind, WebURL.Host(hostname, scheme: "foo")) {
+      case ("ipv6", .some(.ipv6Address(let address))):
+        self = .ipv6Address(address)
+      case (.none, .some(.opaque(let opaque))):
+        self = .opaque(opaque)
+      default:
+        throw DecodingError.dataCorruptedError(forKey: .hostname, in: container, debugDescription: "invalid hostname")
+      }
+    default:
+      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "invalid kind")
+    }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - Hosts in WebURL values
+// --------------------------------------------
+
+
+extension WebURL {
+
+  /// The kind of host contained in a URL.
+  ///
+  @usableFromInline
+  internal enum HostKind {
+    case ipv4Address
+    case ipv6Address
+    case domain
+    case domainWithIDN
+    case opaque
+    case empty
+  }
+
+  /// The host of this URL.
+  ///
+  /// A host is a network address or opaque identifier, whose serialization is the URL's ``hostname``.
+  /// Hosts are interpreted from string values using context such as a URL's ``scheme``.
+  ///
+  /// For example, we know that the host of `"http://example.com/"` refers to a kind of network address because HTTP
+  /// is a well-known network protocol, but in a custom URL scheme - say `"app.settings://example.com"`,
+  /// the same hostname might not refer to a network address at all.
+  ///
+  /// The `Host` enumeration tells you precisely how the URL Standard interprets a host in a given context,
+  /// as well as utilities to interpret hostnames as various other URLs do.
+  ///
+  /// ```swift
+  /// let url = WebURL("http://127.0.0.1:8888/my_site")!
+  ///
+  /// // 🤓 Get precise information about the URL's host.
+  /// switch url.host {
+  ///   case .domain(let domain): ... // Perform DNS lookup.
+  ///   case .ipv4Address(let address): ... // Connect to known address.
+  ///   case .ipv6Address(let address): ... // Connect to known address.
+  ///   case .opaque, .empty, .none: fatalError("Not possible for http")
+  /// }
+  /// ```
+  ///
+  /// See the ``WebURL/WebURL/Domain``, ``IPv6Address``, and ``IPv4Address`` documentation
+  /// for more information about how to use them to establish a network connection or perform other processing.
+  /// They are the recommended way to process hostnames in URLs, as they capture more information and provide
+  /// stronger guarantees than is possible with hostname strings.
+  ///
+  /// ### Allowed Hosts
+  ///
+  /// The kinds of hosts supported by a URL are defined by the [URL Standard][URL-hostcombinations].
+  ///
+  /// | Schemes             | Domain | IPv4 | IPv6 | Opaque | Empty | Nil (not present) |
+  /// |:-------------------:|:------:|:----:|:----:|:------:|:-----:|:-----------------:|
+  /// | http(s), ws(s), ftp |   ✅   |  ✅  |  ✅  |    -   |   -   |         -         |
+  /// |                file |   ✅   |  ✅  |  ✅  |    -   |   ✅  |         -         |
+  /// |     everything else |    -   |   -  |  ✅  |   ✅   |   ✅  |         ✅        |
+  ///
+  /// In other words:
+  ///
+  /// - For **special schemes** (`"http://..."`, etc), the standard knows the hostname is supposed to be
+  ///   some kind of network address, so it parses and normalizes them, and rejects hostnames it doesn't understand
+  ///   or which result in invalid addresses.
+  ///
+  ///   Note that "domain" does not mean that the host is a valid DNS name.
+  ///   Valid DNS names have requirements which are not enforced at the URL level.
+  ///
+  /// - For **custom schemes** (`"my.app://..."`, etc), the URL Standard cannot know what the hostname means,
+  ///   so it considers it an opaque string. The only exception is that square brackets are reserved for
+  ///   IPv6 addresses (`"[::1]"`). IPv6 addresses are syntactically supported in every URL.
+  ///
+  ///   Often, it is helpful to interpret and normalize the opaque string as though it were a domain -
+  ///   for example, to detect IPv4 addresses or to apply IDNA compatibility processing. The URL Standard
+  ///   cannot do this by default, but you can with **FIXME**
+  ///
+  /// - **`http` and `https` URLs** always have a host, and it is never opaque or empty.
+  ///
+  /// [URL-hostcombinations]: https://url.spec.whatwg.org/#url-representation
+  ///
+  /// ## Topics
+  ///
+  /// ### Kinds of Host
+  ///
+  /// - ``WebURL/WebURL/Host-swift.enum/domain(_:)``
+  /// - ``WebURL/WebURL/Host-swift.enum/ipv4Address(_:)``
+  /// - ``WebURL/WebURL/Host-swift.enum/ipv6Address(_:)``
+  /// - ``WebURL/WebURL/Host-swift.enum/opaque(_:)``
+  /// - ``WebURL/WebURL/Host-swift.enum/empty``
+  ///
+  /// ### Obtaining a Host's String Representation
+  ///
+  /// - ``WebURL/WebURL/Host-swift.enum/serialized``
+  ///
+  /// ### Host Type
+  ///
+  /// - ``WebURL/WebURL/Host-swift.enum``
+  ///
+  /// ## See Also
+  ///
+  /// - ``WebURL/hostname``
+  /// - ``IPv4Address``
+  /// - ``IPv6Address``
+  ///
+  public var host: Host? {
+    guard let kind = hostKind, let name = utf8.hostname else { return nil }
+    switch kind {
+    case .ipv4Address:
+      return .ipv4Address(IPv4Address(dottedDecimalUTF8: name)!)
+    case .ipv6Address:
+      return .ipv6Address(IPv6Address(utf8: name.dropFirst().dropLast())!)
+    case .domain, .domainWithIDN:
+      return .domain(String(decoding: name, as: UTF8.self))
+    case .opaque:
+      return .opaque(String(decoding: name, as: UTF8.self))
+    case .empty:
+      return .empty
+    }
+  }
+}
+
+
+// --------------------------------------------
+// MARK: - Parsing
+// --------------------------------------------
+
+
+extension WebURL.Host {
+
+  /// Interprets a hostname in a given URL context.
+  ///
+  /// This initializer allows you to understand and normalize hostnames as the URL parser does,
+  /// using the [host parser][url-hostparser] from the URL Standard.
+  ///
+  /// For example, if you are reading a hostname from a command-line argument or configuration file,
+  /// it may be desirable to parse it in the context of an HTTP URL. Doing so would provide reasonable validation
+  /// of the input, automatic support for IPv4/v6 addresses and Unicode domains via IDNA compatibility processing,
+  /// and other useful normalization such as percent-decoding and lowercasing - all of which are standard in HTTP URLs.
+  ///
+  /// ```swift
+  /// // For custom URL schemes (e.g. redis:/mongodb:/etc URLs), the URL Standard generally
+  /// // considers hostnames to be opaque and doesn't interpret them.
+  /// // Request engines end up parsing the hostname themselves to figure out what it means.
+  ///
+  /// WebURL.Host("EXAMPLE.com", scheme: "foo")   // 😐 .opaque, "EXAMPLE.com"
+  /// WebURL.Host("abc.أهلا.com", scheme: "foo")   // 😕 .opaque, "abc.%D8%A3%D9%87%D9%84%D8%A7.com"
+  /// WebURL.Host("192.168.0.1", scheme: "foo")   // 🤨 .opaque, "192.168.0.1"
+  ///
+  /// // Matching the behavior of HTTP URLs can be a useful strategy -
+  /// // especially as it comes with Unicode domain names (IDNA) and IPv4 support.
+  ///
+  /// WebURL.Host("EXAMPLE.com", scheme: "http")  // 😍 .domain, "example.com"
+  /// WebURL.Host("abc.أهلا.com", scheme: "http")  // 🤩 .domain, "abc.xn--igbi0gl.com"
+  /// WebURL.Host("192.168.0.1", scheme: "http")  // 🥳 .ipv4Address, IPv4Address { 192.168.0.1 }
+  ///
+  /// // IPv6 addresses are supported by all schemes.
+  ///
+  /// WebURL.Host("[::ca08:99]", scheme: "http")  // ✅ .ipv6Address, IPv6Address { ... }
+  /// WebURL.Host("[::ca08:99]", scheme: "foo")   // ✅ .ipv6Address, IPv6Address { ... }
+  /// ```
+  ///
+  /// [url-hostparser]: https://url.spec.whatwg.org/#concept-host-parser
+  ///
+  /// - parameters:
+  ///   - string: The string to parse.
+  ///   - scheme: The
+  ///
+  @inlinable
+  public init?<StringType>(_ string: StringType, scheme: String) where StringType: StringProtocol {
+    guard let contig = string._withContiguousUTF8({ WebURL.Host(utf8: $0, scheme: scheme) }) else {
+      return nil
+    }
+    self = contig
+  }
+
+  @inlinable
+  public init?<UTF8Bytes>(
+    utf8: UTF8Bytes, scheme: String
+  ) where UTF8Bytes: BidirectionalCollection, UTF8Bytes.Element == UInt8 {
+
+    // Parse the scheme.
+    let schemeKind: WebURL.SchemeKind
+    if scheme == "http" || scheme == "https" {
+      schemeKind = .http
+    } else {
+      schemeKind = scheme._withContiguousUTF8 { WebURL.SchemeKind(parsing: $0) }
+    }
+
+    // Check empty hostnames.
+    guard !utf8.isEmpty else {
+      if schemeKind.isSpecial, schemeKind != .file {
+        return nil  // .schemeDoesNotSupportNilOrEmptyHostnames
+      }
+      // The operation is valid. Calculate the new structure and replace the code-units.
+      self = .empty
+      return
+    }
+
+    // Parse the hostname in the context of the given scheme.
+    var callback = IgnoreValidationErrors()
+    guard let newHost = ParsedHost(utf8, schemeKind: schemeKind, callback: &callback) else {
+      return nil
+    }
+    switch newHost {
+    case .ipv4Address(let address):
+      self = .ipv4Address(address)
+    case .ipv6Address(let address):
+      self = .ipv6Address(address)
+    case .empty:
+      self = .empty
+    case .toASCIINormalizedDomain, .simpleDomain, .opaque:
+      var writer = _DomainOrOpaqueStringWriter()
+      newHost.write(bytes: utf8, using: &writer)
+      let result = writer.result!
+      if case .opaque = result.kind {
+        self = .opaque(result.string)
+      } else {
+        self = .domain(result.string)
+      }
+    }
+  }
+}
 
 
 // --------------------------------------------

--- a/Sources/WebURL/WebURL.docc/WebURLStruct.md
+++ b/Sources/WebURL/WebURL.docc/WebURLStruct.md
@@ -195,6 +195,7 @@ The WebURL package includes a number of integration libraries for popular first-
 
 ### Network Hosts and Origins
 
+- ``Host-swift.enum``
 - ``host-swift.property``
 - ``origin-swift.property``
 

--- a/Sources/WebURLTestSupport/TestFilesData/additional_constructor_tests.json
+++ b/Sources/WebURLTestSupport/TestFilesData/additional_constructor_tests.json
@@ -861,5 +861,20 @@
     "pathname": "/",
     "search": "",
     "hash": ""
+  },
+  "[IDNA] Unicode hostnames which get mapped to 'localhost'",
+  {
+    "input": "file://loC𝐀𝐋𝐇𝐨𝐬𝐭/usr/bin",
+    "base": "about:blank",
+    "href": "file:///usr/bin",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/usr/bin",
+    "search": "",
+    "hash": ""
   }
 ]

--- a/Tests/WebURLTests/HostTests.swift
+++ b/Tests/WebURLTests/HostTests.swift
@@ -1,0 +1,620 @@
+// Copyright The swift-url Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import WebURLTestSupport
+import XCTest
+
+@testable import WebURL
+
+final class HostTests: XCTestCase {}
+
+
+// --------------------------------------------
+// MARK: - Protocol conformances
+// --------------------------------------------
+
+
+extension HostTests {
+
+  func testCustomStringConvertible() {
+
+    let ipv4 = IPv4Address(octets: (192, 168, 0, 1))
+    XCTAssertEqual(WebURL.Host.ipv4Address(ipv4).description, "192.168.0.1")
+    XCTAssertEqual(ipv4.description, ipv4.serialized)
+
+    // IPv6 description includes square brackets, so it can be re-parsed as a hostname
+    // (although the brackets will need removing for `IPv6Address.init`).
+
+    let ipv6 = IPv6Address(pieces: (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334), .numeric)
+    XCTAssertEqual(WebURL.Host.ipv6Address(ipv6).description, "[2001:db8:85a3::8a2e:370:7334]")
+    XCTAssertEqual(ipv6.description, ipv6.serialized)
+
+    // These are just strings; we can't prevent users creating them from invalid values.
+    // We just return the string they gave us.
+
+    let asciiDomain = WebURL.Host.domain("example.com")
+    XCTAssertEqual(asciiDomain.description, "example.com")
+    XCTAssertEqual(asciiDomain.description, asciiDomain.serialized)
+
+    let idnDomain = WebURL.Host.domain("a.xn--igbi0gl.com")
+    XCTAssertEqual(idnDomain.description, "a.xn--igbi0gl.com")
+    XCTAssertEqual(idnDomain.description, idnDomain.serialized)
+
+    let opaque = WebURL.Host.opaque("some string")
+    XCTAssertEqual(opaque.description, "some string")
+    XCTAssertEqual(opaque.description, opaque.serialized)
+
+    let empty = WebURL.Host.empty
+    XCTAssertEqual(empty.description, "")
+    XCTAssertEqual(empty.description, empty.serialized)
+  }
+
+  func testCodable() throws {
+
+    guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
+      throw XCTSkip("JSONEncoder.OutputFormatting.withoutEscapingSlashes requires tvOS 13 or newer")
+    }
+
+    func roundTripJSON<Value: Codable & Equatable>(
+      _ original: Value, expectedJSON: String, expectedDecoded: Value? = nil
+    ) throws {
+      // Encode to JSON, check that we get the expected string.
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+      let jsonString = String(decoding: try encoder.encode(original), as: UTF8.self)
+      XCTAssertEqual(jsonString, expectedJSON)
+      // Decode the JSON output, check we get the expected result.
+      let decodedValue = try JSONDecoder().decode(Value.self, from: Data(jsonString.utf8))
+      XCTAssertEqual(decodedValue, expectedDecoded ?? original)
+    }
+
+    func fromJSON(_ json: String) throws -> WebURL.Host {
+      try JSONDecoder().decode(WebURL.Host.self, from: Data(json.utf8))
+    }
+
+    ipv4: do {
+      // Host values can round-trip through JSON.
+      let address = IPv4Address(octets: (192, 168, 0, 1))
+      try roundTripJSON(
+        WebURL.Host.ipv4Address(address),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "192.168.0.1",
+            "kind" : "ipv4"
+          }
+          """#
+      )
+      // When decoding, invalid values are rejected.
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "not-an-address",
+            "kind" : "ipv4"
+          }
+          """#
+        )
+      )
+      // When decoding, we use the full host parser, which handles things like IDNA domains which map to IPv4 addresses.
+      let exoticIpv4_1 = try fromJSON(
+        #"""
+        {
+          "hostname" : "0x7F.1",
+          "kind" : "ipv4"
+        }
+        """#
+      )
+      XCTAssertEqual(exoticIpv4_1, .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))))
+      let exoticIpv4_2 = try fromJSON(
+        #"""
+        {
+          "hostname" : "0x𝟕f.1",
+          "kind" : "ipv4"
+        }
+        """#
+      )
+      XCTAssertEqual(exoticIpv4_2, .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))))
+    }
+
+    ipv6: do {
+      // Host values can round-trip through JSON.
+      let address = IPv6Address(pieces: (0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334), .numeric)
+      try roundTripJSON(
+        WebURL.Host.ipv6Address(address),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "[2001:db8:85a3::8a2e:370:7334]",
+            "kind" : "ipv6"
+          }
+          """#
+      )
+      // When decoding, invalid values are rejected.
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "not-an-address",
+            "kind" : "ipv6"
+          }
+          """#
+        )
+      )
+      // When decoding, addresses are parsed by the regular IPv6 parser,
+      // which supports uncompressed pieces and mixed-case hex characters.
+      let decoded = try fromJSON(
+        #"""
+        {
+          "hostname" : "[2001:0DB8:85A3:0:0:8a2E:0370:7334]",
+          "kind" : "ipv6"
+        }
+        """#
+      )
+      XCTAssertEqual(decoded, .ipv6Address(address))
+      // When decoding, the hostname must be enclosed in square brackets.
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "2001:db8:85a3::8a2e:370:7334",
+            "kind" : "ipv6"
+          }
+          """#
+        )
+      )
+    }
+
+    domain: do {
+      // Because ".domain" is just a string and "Host" is just an enum, users can construct non-normalized values.
+
+      // Normalized values round-trip exactly, including IDNA.
+      try roundTripJSON(
+        WebURL.Host.domain("example.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "example.com",
+            "kind" : "domain"
+          }
+          """#
+      )
+      try roundTripJSON(
+        WebURL.Host.domain("a.xn--igbi0gl.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "a.xn--igbi0gl.com",
+            "kind" : "domain"
+          }
+          """#
+      )
+      // When decoding, invalid domains are rejected.
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "hello world",
+            "kind" : "domain"
+          }
+          """#
+        )
+      )
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "xn--cafe-dma.fr",
+            "kind" : "domain"
+          }
+          """#
+        )
+      )
+      // When decoding, values are normalized as domains.
+      try roundTripJSON(
+        WebURL.Host.domain("EX%61MPLE.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "EX%61MPLE.com",
+            "kind" : "domain"
+          }
+          """#,
+        expectedDecoded: .domain("example.com")
+      )
+      try roundTripJSON(
+        WebURL.Host.domain("a.أهلا.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "a.أهلا.com",
+            "kind" : "domain"
+          }
+          """#,
+        expectedDecoded: .domain("a.xn--igbi0gl.com")
+      )
+    }
+
+    opaque: do {
+      // Because ".opaque" is just a string and "Host" is just an enum, users can construct invalid values.
+
+      // Valid values round-trip exactly. All non-empty names with no 'kind' are considered opaque.
+      try roundTripJSON(
+        WebURL.Host.opaque("EX%61MPLE.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "EX%61MPLE.com"
+          }
+          """#
+      )
+      try roundTripJSON(
+        WebURL.Host.opaque("abc.%D8%A3%D9%87%D9%84%D8%A7.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "abc.%D8%A3%D9%87%D9%84%D8%A7.com"
+          }
+          """#
+      )
+      // When decoding, invalid hostnames are rejected.
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "EX%61 MPLE.com"
+          }
+          """#
+        )
+      )
+      // When decoding, values are normalized as opaque hostnames.
+      try roundTripJSON(
+        WebURL.Host.opaque("a.أهلا.com"),
+        expectedJSON:
+          #"""
+          {
+            "hostname" : "a.أهلا.com"
+          }
+          """#,
+        expectedDecoded: .opaque("a.%D8%A3%D9%87%D9%84%D8%A7.com")
+      )
+    }
+
+    empty: do {
+      // Empty hosts can round-trip through JSON. They do not have a 'kind'.
+      try roundTripJSON(
+        WebURL.Host.empty,
+        expectedJSON:
+          #"""
+          {
+            "hostname" : ""
+          }
+          """#
+      )
+      // When decoding, all empty hostnames become '.empty', regardless of the 'kind'.
+      var wrongKind = try fromJSON(
+        #"""
+        {
+          "hostname" : "",
+          "kind" : "ipv4"
+        }
+        """#
+      )
+      XCTAssertEqual(wrongKind, .empty)
+      wrongKind = try fromJSON(
+        #"""
+        {
+          "hostname" : "",
+          "kind" : "ipv6"
+        }
+        """#
+      )
+      XCTAssertEqual(wrongKind, .empty)
+      wrongKind = try fromJSON(
+        #"""
+        {
+          "hostname" : "",
+          "kind" : "domain"
+        }
+        """#
+      )
+      XCTAssertEqual(wrongKind, .empty)
+      wrongKind = try fromJSON(
+        #"""
+        {
+          "hostname" : "",
+          "kind" : "xxx"
+        }
+        """#
+      )
+      XCTAssertEqual(wrongKind, .empty)
+    }
+
+    invalidKind: do {
+      XCTAssertThrowsError(
+        try fromJSON(
+          #"""
+          {
+            "hostname" : "somehost",
+            "kind" : "xxx"
+          }
+          """#
+        )
+      )
+    }
+  }
+}
+
+#if swift(>=5.5) && canImport(_Concurrency)
+
+  extension HostTests {
+
+    func testSendable() {
+      // Since Sendable only exists at compile-time, it's enough to just ensure that this type-checks.
+      func _requiresSendable<T: Sendable>(_: T) {}
+
+      let host = WebURL.Host("example.com", scheme: "http")!
+      _requiresSendable(host)
+    }
+  }
+
+#endif
+
+
+// --------------------------------------------
+// MARK: - Parsing
+// --------------------------------------------
+
+
+extension HostTests {
+
+  func testParsing() {
+
+    // In special URL contexts, all non-IP hostnames are domains.
+    test: do {
+      let host = WebURL.Host("example.com", scheme: "http")
+      guard case .domain("example.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // In special URL contexts, Unicode hostnames are validated and normalized using IDNA.
+    test: do {
+      var host = WebURL.Host("💩.com", scheme: "http")
+      guard case .domain("xn--ls8h.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("www.foo。bar.com", scheme: "http")
+      guard case .domain("www.foo.bar.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("xn--cafe-dma.com", scheme: "http")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("has a space.com", scheme: "http")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Special URL contexts detect IPv4 addresses, including after IDNA.
+    test: do {
+      var host = WebURL.Host("11.173.240.13", scheme: "http")
+      guard case .ipv4Address(IPv4Address(octets: (11, 173, 240, 13))) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("0xbadf00d", scheme: "http")
+      guard case .ipv4Address(IPv4Address(octets: (11, 173, 240, 13))) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("0x𝟕f.1", scheme: "http")
+      guard case .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("11.173.240.13.4", scheme: "http")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // In non-special URL contexts, all non-IP hostnames are opaque strings.
+    test: do {
+      let host = WebURL.Host("example.com", scheme: "non-special")
+      guard case .opaque("example.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // In non-special URL contexts, Unicode hostnames are percent-encoded.
+    // Other invalid characters are rejected.
+    test: do {
+      var host = WebURL.Host("💩.com", scheme: "foo")
+      guard case .opaque("%F0%9F%92%A9.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("www.foo。bar.com", scheme: "foo")
+      guard case .opaque("www.foo%E3%80%82bar.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("xn--cafe-dma.com", scheme: "foo")
+      guard case .opaque("xn--cafe-dma.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("has a space.com", scheme: "foo")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Non-special URL contexts do not detect IPv4 addresses.
+    test: do {
+      var host = WebURL.Host("11.173.240.13", scheme: "foo")
+      guard case .opaque("11.173.240.13") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("0xbadf00d", scheme: "foo")
+      guard case .opaque("0xbadf00d") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("0x𝟕f.1", scheme: "foo")
+      guard case .opaque("0x%F0%9D%9F%95f.1") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Both special and non-special URL contexts detect IPv6 addresses.
+    test: do {
+      var host = WebURL.Host("[::127.0.0.1]", scheme: "http")
+      guard case .ipv6Address(IPv6Address(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("[::127.0.0.1]", scheme: "foo")
+      guard case .ipv6Address(IPv6Address(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("[blahblahblah]", scheme: "http")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("[blahblahblah]", scheme: "foo")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Special URL contexts interpret domains and IPv4 addresses through percent-encoding.
+    test: do {
+      var host = WebURL.Host("www.foo%E3%80%82bar.com", scheme: "http")
+      guard case .domain("www.foo.bar.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("%F0%9F%92%A9.com", scheme: "http")
+      guard case .domain("xn--ls8h.com") = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("0x%F0%9D%9F%95f.1", scheme: "http")
+      guard case .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))) = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Only File and non-special URLs may have empty hostnames.
+    test: do {
+      var host = WebURL.Host("", scheme: "http")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("", scheme: "ftp")
+      guard case .none = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("", scheme: "file")
+      guard case .empty = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+
+      host = WebURL.Host("", scheme: "foo")
+      guard case .empty = host else {
+        XCTFail("Unexpected host: \(String(describing: host))")
+        break test
+      }
+    }
+
+    // Localhost is normalized to empty in file URLs, to lowercase in other special URLs,
+    // and not at all in non-special URLs.
+    do {
+      XCTAssertEqual(WebURL.Host("localhost", scheme: "file"), .empty)
+      XCTAssertEqual(WebURL.Host("loCAlhost", scheme: "file"), .empty)
+      XCTAssertEqual(WebURL.Host("loc%61lhost", scheme: "file"), .empty)
+      XCTAssertEqual(WebURL.Host("loC𝐀𝐋𝐇𝐨𝐬𝐭", scheme: "file"), .empty)
+
+      XCTAssertEqual(WebURL.Host("localhost", scheme: "http")?.serialized, "localhost")
+      XCTAssertEqual(WebURL.Host("loCAlhost", scheme: "http")?.serialized, "localhost")
+      XCTAssertEqual(WebURL.Host("loc%61lhost", scheme: "http")?.serialized, "localhost")
+      XCTAssertEqual(WebURL.Host("loC𝐀𝐋𝐇𝐨𝐬𝐭", scheme: "http")?.serialized, "localhost")
+
+      XCTAssertEqual(WebURL.Host("localhost", scheme: "foo"), .opaque("localhost"))
+      XCTAssertEqual(WebURL.Host("loCAlhost", scheme: "foo"), .opaque("loCAlhost"))
+      XCTAssertEqual(WebURL.Host("loc%61lhost", scheme: "foo"), .opaque("loc%61lhost"))
+      XCTAssertEqual(
+        WebURL.Host("loC𝐀𝐋𝐇𝐨𝐬𝐭", scheme: "foo"),
+        .opaque("loC%F0%9D%90%80%F0%9D%90%8B%F0%9D%90%87%F0%9D%90%A8%F0%9D%90%AC%F0%9D%90%AD")
+      )
+    }
+
+    // Windows drive letters are not valid hosts in any special URLs, and must be escaped in non-special URLs.
+    do {
+      XCTAssertNil(WebURL.Host("C:", scheme: "file"))
+      XCTAssertNil(WebURL.Host("C|", scheme: "file"))
+      XCTAssertNil(WebURL.Host("C%3A", scheme: "file"))
+      XCTAssertNil(WebURL.Host("C%7C", scheme: "file"))
+
+      XCTAssertNil(WebURL.Host("C:", scheme: "http"))
+      XCTAssertNil(WebURL.Host("C|", scheme: "http"))
+      XCTAssertNil(WebURL.Host("C%3A", scheme: "http"))
+      XCTAssertNil(WebURL.Host("C%7C", scheme: "http"))
+
+      XCTAssertNil(WebURL.Host("C:", scheme: "foo"))
+      XCTAssertNil(WebURL.Host("C|", scheme: "foo"))
+      XCTAssertEqual(WebURL.Host("C%3A", scheme: "foo"), .opaque("C%3A"))
+      XCTAssertEqual(WebURL.Host("C%7C", scheme: "foo"), .opaque("C%7C"))
+    }
+  }
+}

--- a/Tests/WebURLTests/HostTests.swift
+++ b/Tests/WebURLTests/HostTests.swift
@@ -577,6 +577,13 @@ extension HostTests {
       }
     }
 
+    // Hosts which get IDNA-mapped to the empty string. Not allowed even in file URLs.
+    do {
+      XCTAssertEqual(WebURL.Host("%AD", scheme: "foo"), .opaque("%AD"))
+      XCTAssertNil(WebURL.Host("%AD", scheme: "file"))
+      XCTAssertNil(WebURL.Host("%AD", scheme: "http"))
+    }
+
     // Localhost is normalized to empty in file URLs, to lowercase in other special URLs,
     // and not at all in non-special URLs.
     do {

--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -1266,123 +1266,248 @@ extension WebURLTests {
 
   func testHost() {
 
-    // Non-IP hostnames in special URLs are always domains.
-    do {
-      let url = WebURL("http://example.com/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .domain)
-      if case .domain("example.com") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // In special URLs, all non-IP hostnames are domains.
+    test: do {
+      let url = WebURL("http://example.com/aPath?aQuery#andFragment, too")
+      guard case .domain("example.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
     }
 
-    // Non-IP hostnames in non-special URLs are always opaque hostnames.
-    do {
-      let url = WebURL("foo://example.com/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .opaque)
-      if case .opaque("example.com") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // In special URLs, Unicode hostnames are validated and normalized using IDNA.
+    test: do {
+      var url = WebURL("http://💩.com/foo")
+      guard case .domain("xn--ls8h.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://www.foo。bar.com/foo")
+      guard case .domain("www.foo.bar.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://xn--cafe-dma.com/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("xn--cafe-dma.com", scheme: "http"))
+
+      url = WebURL("http://has a space.com/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("has a space.com", scheme: "http"))
     }
 
-    // Unicode domains in special URLs are encoded using IDNA.
-    do {
-      let url = WebURL("http://💩.com/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .domainWithIDN)
-      if case .domain("xn--ls8h.com") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // Special URLs detect IPv4 addresses, including after IDNA.
+    test: do {
+      var url = WebURL("http://11.173.240.13/foo")
+      guard case .ipv4Address(IPv4Address(octets: (11, 173, 240, 13))) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://0xbadf00d/foo")
+      guard case .ipv4Address(IPv4Address(octets: (11, 173, 240, 13))) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://0x𝟕f.1/foo")
+      guard case .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://11.173.240.13.4/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("11.173.240.13.4", scheme: "http"))
     }
 
-    // HostKind.domain vs .domainWithIDN is determined by the presence of Punycode labels,
-    // not the processing path which was taken. Unicode domains which map to ASCII are just HostKind.domain.
-    do {
-      let url = WebURL("http://www.foo。bar.com")!
-      XCTAssertEqual(url.hostKind, .domain)
-      if case .domain("www.foo.bar.com") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // In non-special URLs, all non-IP hostnames are opaque strings.
+    test: do {
+      let url = WebURL("non-special://example.com/foo")
+      guard case .opaque("example.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
     }
 
-    // In non-special URLs, they are percent-encoded.
-    do {
-      let url = WebURL("foo://💩.com/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .opaque)
-      if case .opaque("%F0%9F%92%A9.com") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // In non-special URLs, Unicode hostnames are percent-encoded.
+    // Other invalid characters are rejected.
+    test: do {
+      var url = WebURL("foo://💩.com/foo")
+      guard case .opaque("%F0%9F%92%A9.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://www.foo。bar.com/foo")
+      guard case .opaque("www.foo%E3%80%82bar.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://xn--cafe-dma.com/foo")
+      guard case .opaque("xn--cafe-dma.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://has a space.com/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("has a space.com", scheme: "foo"))
     }
 
-    // Special URLs detect IPv4 addresses.
-    do {
-      let url = WebURL("http://0xbadf00d/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .ipv4Address)
-      if case .ipv4Address(.init(octets: (11, 173, 240, 13))) = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // Non-special URLs do not detect IPv4 addresses.
+    test: do {
+      var url = WebURL("foo://11.173.240.13/foo")
+      guard case .opaque("11.173.240.13") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
-    }
-    // Non-special URLs do not.
-    do {
-      let url = WebURL("foo://11.173.240.13/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .opaque)
-      if case .opaque("11.173.240.13") = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://0xbadf00d/foo")
+      guard case .opaque("0xbadf00d") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://0x𝟕f.1/foo")
+      guard case .opaque("0x%F0%9D%9F%95f.1") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
     }
 
     // Both special and non-special URLs detect IPv6 addresses.
-    do {
-      let url = WebURL("http://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .ipv6Address)
-      if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    test: do {
+      var url = WebURL("http://[::127.0.0.1]/foo")
+      guard case .ipv6Address(IPv6Address(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("foo://[::127.0.0.1]/foo")
+      guard case .ipv6Address(IPv6Address(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("http://[blahblahblah]/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("[blahblahblah]", scheme: "http"))
+
+      url = WebURL("foo://[blahblahblah]/foo")
+      guard case .none = url else {
+        XCTFail("Unexpected URL: \(String(describing: url))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("[blahblahblah]", scheme: "foo"))
     }
-    do {
-      let url = WebURL("foo://[::127.0.0.1]/aPath?aQuery#andFragment, too")!
-      XCTAssertEqual(url.hostKind, .ipv6Address)
-      if case .ipv6Address(.init(pieces: (0, 0, 0, 0, 0, 0, 0x7f00, 0x0001), .numeric)) = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+
+    // Special URLs interpret domains and IPv4 addresses through percent-encoding.
+    test: do {
+      var url = WebURL("http://www.foo%E3%80%82bar.com/foo")
+      guard case .domain("www.foo.bar.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+
+      url = WebURL("http://%F0%9F%92%A9.com/foo")
+      guard case .domain("xn--ls8h.com") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+
+      url = WebURL("http://0x%F0%9D%9F%95f.1/foo")
+      guard case .ipv4Address(IPv4Address(octets: (127, 0, 0, 1))) = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
     }
 
-    // File and non-special URLs may have empty hostnames.
-    do {
-      let url = WebURL("file:///usr/bin/swift")!
-      XCTAssertEqual(url.hostKind, .empty)
-      if case .empty = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-        XCTAssertEqual(url.host?.serialized, "")
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
+    // Only File and non-special URLs may have empty hostnames.
+    test: do {
+      var url = WebURL("http:///foo")
+      guard case .domain("foo") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
       }
+      XCTAssertNil(WebURL.Host("", scheme: "http"))
+
+      url = WebURL("ftp:///foo")
+      guard case .domain("foo") = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertNil(WebURL.Host("", scheme: "ftp"))
+
+      url = WebURL("file:///foo")
+      guard case .empty = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
+
+      url = WebURL("non-special:///foo")
+      guard case .empty = url?.host else {
+        XCTFail("Unexpected host: \(String(describing: url?.host))")
+        break test
+      }
+      XCTAssertEqual(url!.host, WebURL.Host(url!.hostname!, scheme: url!.scheme))
     }
+
+    // Localhost is normalized to empty in file URLs, to a lowercase domain in other special URLs,
+    // and not at all in non-special URLs.
+    // WebURL.Host.init?(String) equivalence is tested in `HostTests.testParsing`.
     do {
-      let url = WebURL("foo:///some/path")!
-      XCTAssertEqual(url.hostKind, .empty)
-      if case .empty = url.host {
-        XCTAssertEqual(url.host?.serialized, url.hostname)
-        XCTAssertEqual(url.host?.serialized, "")
-      } else {
-        XCTFail("Unexpected host: \(String(describing: url.host))")
-      }
+      XCTAssertEqual(WebURL("file://localhost/foo")?.host, .empty)
+      XCTAssertEqual(WebURL("file://loCAlhost/foo")?.host, .empty)
+      XCTAssertEqual(WebURL("file://loc%61lhost/foo")?.host, .empty)
+      XCTAssertEqual(WebURL("file://loC𝐀𝐋𝐇𝐨𝐬𝐭/foo")?.host, .empty)
+
+      XCTAssertEqual(WebURL("http://localhost/foo")?.host, .domain("localhost"))
+      XCTAssertEqual(WebURL("http://loCAlhost/foo")?.host, .domain("localhost"))
+      XCTAssertEqual(WebURL("http://loc%61lhost/foo")?.host, .domain("localhost"))
+      XCTAssertEqual(WebURL("http://loC𝐀𝐋𝐇𝐨𝐬𝐭/foo")?.host, .domain("localhost"))
+
+      XCTAssertEqual(WebURL("foo://localhost/foo")?.host, .opaque("localhost"))
+      XCTAssertEqual(WebURL("foo://loCAlhost/foo")?.host, .opaque("loCAlhost"))
+      XCTAssertEqual(WebURL("foo://loc%61lhost/foo")?.host, .opaque("loc%61lhost"))
+      XCTAssertEqual(
+        WebURL("foo://loC𝐀𝐋𝐇𝐨𝐬𝐭/foo")?.host,
+        .opaque("loC%F0%9D%90%80%F0%9D%90%8B%F0%9D%90%87%F0%9D%90%A8%F0%9D%90%AC%F0%9D%90%AD")
+      )
     }
 
     // Path-only and URLs with opaque paths do not have hosts.


### PR DESCRIPTION
The new APIs allow libraries which process custom URL schemes to also support IDNA.
The new HostKind will be used by a new `Domain` type.

This is all prep for the `Domain` type, whose introduction will, unfortunately, be source-breaking. That's the only thing holding up the next release (likely 0.4.0)