### PR TITLE
More robust tuple pointers

### DIFF
--- a/Sources/WebURL/Util/StringAdditions.swift
+++ b/Sources/WebURL/Util/StringAdditions.swift
@@ -81,9 +81,9 @@ extension String {
       )
     let _ = sixtyFourBytes.63  // Check that there are 64 elements. This wouldn't compile otherwise.
     self = withUnsafeMutableBytes(of: &sixtyFourBytes) { rawBuffer in
-      let buffer = rawBuffer._assumingMemoryBound(to: UInt8.self)
-      let initializedCount = initializer(buffer)
-      return String(decoding: UnsafeBufferPointer(rebasing: buffer.prefix(initializedCount)), as: UTF8.self)
+      let ptr = UnsafeMutableBufferPointer(start: rawBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self), count: 64)
+      let initializedCount = initializer(ptr)
+      return String(decoding: UnsafeBufferPointer(rebasing: ptr.prefix(initializedCount)), as: UTF8.self)
     }
   }
 }


### PR DESCRIPTION
Calculating the number of elements in a tuple using `byteCount / MemoryLayout<T>.stride` may return _less_ than the expected number of elements, because tuples do not include tail padding.

See: https://forums.swift.org/t/zero-sized-types-vs-tuple-memory-layout/58768

Instead, we should explicitly say how many elements are in the tuple.

---

The current implementation is not invoking UB in practice, because:

- It only returns fewer elements. It would never cause an over-read or over-write.
- We only use this function with plain integers that don't have padding.

But it's better to have a more robust implementation. Fixed-size arrays can't come soon enough; I'd really much rather not have this code at all, but we do need it.