### PR TITLE
[NFC] Reduce the diff between Package.swift variants

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@
 
 import PackageDescription
 
-var package = Package(
+let package = Package(
   name: "swift-url",
   products: [
 
@@ -126,6 +126,6 @@ var package = Package(
     .testTarget(
       name: "WebURLFoundationEndToEndTests",
       dependencies: ["WebURLFoundationExtras", "WebURL"]
-    )
+    ),
   ]
 )


### PR DESCRIPTION
It's just for DocC; pre-5.5 compilers need to exclude the WebURL.docc folder.

Previously there were some other minor differences, but after this patch it's just:

```
karl@Karls-MBP swift-url % diff Package.swift Package@swift-5.5.swift                                          
1c1
< // swift-tools-version:5.3
---
> // swift-tools-version:5.5
85,86c85
<       dependencies: ["IDNA"],
<       exclude: ["WebURL.docc"]
---
>       dependencies: ["IDNA"]
```