### PR TITLE
Port setter should not throw if setting a nil port to a URL which doesn't support a port

### DIFF
--- a/Tests/WebURLTests/WebURLTests.swift
+++ b/Tests/WebURLTests/WebURLTests.swift
@@ -910,6 +910,12 @@ extension WebURLTests {
     XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
     XCTAssertURLIsIdempotent(url)
 
+    // However, setting a value of 'nil' doesn't throw.
+    url = WebURL("file://somehost/p1/p2")!
+    XCTAssertNoThrow { try url.setPort(nil) }
+    XCTAssertEqual(url.serialized(), "file://somehost/p1/p2")
+    XCTAssertURLIsIdempotent(url)
+
     // [Throw] Setting a port to a non-valid UInt16 value.
     url = WebURL("http://example.com/p1/p2")!
     XCTAssertThrowsSpecific(URLSetterError.portValueOutOfBounds) { try url.setPort(-99) }


### PR DESCRIPTION
Don't use `setSimpleComponent` for the port. That function is going to be made in to a query/fragment-specific thing.

Also, port setter should not throw if setting a nil port to a URL which doesn't support a port.