### PR TITLE
SegmentedLine improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
     ),
     .testTarget(
       name: "UnicodeDataStructuresTests",
-      dependencies: ["UnicodeDataStructures"],
+      dependencies: ["UnicodeDataStructures", "Checkit"],
       resources: [.copy("GenerateData/TableDefinitions")]
     ),
 

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -64,7 +64,7 @@ let package = Package(
     ),
     .testTarget(
       name: "UnicodeDataStructuresTests",
-      dependencies: ["UnicodeDataStructures"],
+      dependencies: ["UnicodeDataStructures", "Checkit"],
       resources: [.copy("GenerateData/TableDefinitions")]
     ),
 


### PR DESCRIPTION
- Split `(Bound, Value)` array in to separate `Bound` and `Value` arrays, to reduce padding and improve binary search performance
- Added `subscript(Bound) -> Value`, to get the value at a given location
- Added `.segments.index(of: Bound)`, to get the segment containing a given location
- Better description, with a vertical (multiline) layout

`SegmentedLine` is only used offline for Unicode table generation, but these are still nice improvements.